### PR TITLE
fix: Fixes broken MCP external link (was pointing to the draft)

### DIFF
--- a/agents/mcp.mdx
+++ b/agents/mcp.mdx
@@ -28,7 +28,7 @@ Glean's Model Context Protocol (MCP) server enables AI models to securely access
 You'll need Glean API credentials, and specifically a [user-scoped API token](client/authentication#user). You should speak to your Glean administrator to provision these tokens.
 
 <Warning>
-Currently, our MCP implementation uses API tokens for authentication. While the MCP specification includes [optional authorization mechanisms](https://spec.modelcontextprotocol.io/specification/draft/basic/authorization/) and there is [an active RFC to add OAuth 2.0 support](https://github.com/modelcontextprotocol/specification/pull/133), we're using a simple token-based approach for now. Once the OAuth specification is finalized and widely adopted in the MCP ecosystem, we plan to implement OAuth-based authentication for enhanced security and user management.
+Currently, our MCP implementation uses API tokens for authentication. While the MCP specification includes [optional authorization mechanisms](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) and there is [an active RFC to add OAuth 2.0 support](https://github.com/modelcontextprotocol/specification/pull/133), we're using a simple token-based approach for now. Once the OAuth specification is finalized and widely adopted in the MCP ecosystem, we plan to implement OAuth-based authentication for enhanced security and user management.
 </Warning>
 
 ## IDE Integrations


### PR DESCRIPTION
## Summary

The "optional authorization mechanisms" link was broken on the MCP page (was pointing to a draft URL that's been removed now). This PR updates to use the current spec URL.

### Code changes:
* Updated the URL in the MCP authentication warning from an outdated draft link to the current specification link, ensuring accurate documentation regarding authorization mechanisms for enhanced clarity and correctness.
