### PR TITLE
docs: Adds information on which scopes to use for API tokens for MCP/Langchain

### DIFF
--- a/agents/langchain.mdx
+++ b/agents/langchain.mdx
@@ -36,7 +36,13 @@ Glean's official LangChain integration enables you to build powerful AI agents t
 
 ## Configuration
 
-Configure your Glean credentials by setting the following environment variables. You can obtain these credentials from the [authentication documentation](/client/authentication#glean-issued-tokens):
+#### API Tokens
+
+You'll need Glean [API credentials](/client/authentication#glean-issued-tokens), and specifically a [user-scoped API token](client/authentication#user). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
+
+#### Configure Environment Variables
+
+Configure your Glean credentials by setting the following environment variables:
 
 ```bash
 export GLEAN_SUBDOMAIN="your-glean-subdomain"

--- a/agents/mcp.mdx
+++ b/agents/mcp.mdx
@@ -25,7 +25,9 @@ Glean's Model Context Protocol (MCP) server enables AI models to securely access
 
 ### Configuration
 
-You'll need Glean API credentials, and specifically a [user-scoped API token](client/authentication#user). You should speak to your Glean administrator to provision these tokens.
+#### API Tokens
+
+You'll need Glean [API credentials](/client/authentication#glean-issued-tokens), and specifically a [user-scoped API token](client/authentication#user). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
 
 <Warning>
 Currently, our MCP implementation uses API tokens for authentication. While the MCP specification includes [optional authorization mechanisms](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) and there is [an active RFC to add OAuth 2.0 support](https://github.com/modelcontextprotocol/specification/pull/133), we're using a simple token-based approach for now. Once the OAuth specification is finalized and widely adopted in the MCP ecosystem, we plan to implement OAuth-based authentication for enhanced security and user management.


### PR DESCRIPTION
## Summary

Adds information on which API scopes are required for both the MCP and Langchain integrations. 

### Code changes:
* Added sections detailing API tokens required for Glean integration, highlighting the need for user-scoped tokens with specific scopes: `chat` and `search`. Sections for configuring environment variables were also expanded.
