### PR TITLE
docs: Updates MCP configuration to include CLI `configure` command to setup the server

### DIFF
--- a/agents/mcp.mdx
+++ b/agents/mcp.mdx
@@ -16,195 +16,11 @@ Glean's Model Context Protocol (MCP) server enables AI models to securely access
   Official MCP server implementation for Glean's search and chat capabilities
 </Card>
 
-### Features
+## Features
 
-- 🔍 **Enterprise Search**: Access Glean's powerful content search capabilities
-- 💬 **Chat Interface**: Interact with Glean's AI assistant
-- 🔒 **Secure Access**: Maintain enterprise security and permissions
-- 🔄 **MCP Compliant**: Implements the Model Context Protocol specification
-
-### Configuration
-
-#### API Tokens
-
-You'll need Glean [API credentials](/client/authentication#glean-issued-tokens), and specifically a [user-scoped API token](client/authentication#user). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
-
-<Warning>
-Currently, our MCP implementation uses API tokens for authentication. While the MCP specification includes [optional authorization mechanisms](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) and there is [an active RFC to add OAuth 2.0 support](https://github.com/modelcontextprotocol/specification/pull/133), we're using a simple token-based approach for now. Once the OAuth specification is finalized and widely adopted in the MCP ecosystem, we plan to implement OAuth-based authentication for enhanced security and user management.
-</Warning>
-
-## IDE Integrations
-
-<Accordion title="Cursor">
-### Configure Cursor
-
-<Steps>
-  <Step title="Get Credentials">
-    Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
-    - Your Glean subdomain
-    - A [user-scoped API token](/client/authentication#user)
-  </Step>
-
-  <Step title="Configure Cursor">
-    1. Click "Cursor" in the menu bar
-    2. Select "Settings"
-    3. Click "Cursor Settings"
-    4. Navigate to the "MCP" section
-    5. Click "Add new global MCP server"
-    6. Add the following configuration to the opened `mcp.json` file:
-
-    ```json
-    {
-      "mcpServers": {
-        "glean": {
-          "command": "npx",
-          "args": ["-y", "@gleanwork/mcp-server"],
-          "env": {
-            "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
-            "GLEAN_API_TOKEN": "<your-glean-api-token>"
-          }
-        }
-      }
-    }
-    ```
-    7. Close the file to save the configuration
-    
-    Your MCP server should now be listed and Enabled, as shown below.
-
-    <Frame>
-      <img src="./images/cursor-mcp-settings.png" alt="Cursor MCP Settings" />
-    </Frame>
-  </Step>
-
-
-  <Step title="Test the Integration">
-    <Note>
-      Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cursor's AI to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help the AI understand which tool to use.
-    </Note>
-
-    1. Open a new chat in Cursor
-    2. Try a query like "Using Glean, what's our company's policy on remote work?"
-    3. Verify that Cursor can access and search your Glean content
-  </Step>
-</Steps>
-</Accordion>
-
-<Accordion title="Windsurf">
-### Configure Windsurf
-
-<Steps>
-  <Step title="Get Credentials">
-    Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
-    - Your Glean subdomain
-    - A [user-scoped API token](/client/authentication#user)
-  </Step>
-
-  <Step title="Configure Windsurf">
-    1. Click "Windsurf" in the menu bar
-    2. Select "Settings"
-    3. Click "Windsurf Settings"
-    4. Under "Cascade / Model Context Protocol (MCP) Servers"
-    5. Click "Add Server"
-    6. Click "Add Custom Server"
-    7. Add the following configuration to the opened `mcp_config.json` file:
-
-    ```json
-    {
-      "mcpServers": {
-        "glean": {
-          "command": "npx",
-          "args": ["-y", "@gleanwork/mcp-server"],
-          "env": {
-            "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
-            "GLEAN_API_TOKEN": "<your-glean-api-token>"
-          }
-        }
-      }
-    }
-    ```
-    8. Close the file to save the configuration
-    
-    Your MCP server should now be listed in the servers section, as shown below.
-
-    <Frame>
-      <img src="./images/windsurf-mcp-settings.png" alt="Windsurf MCP Settings" />
-    </Frame>
-  </Step>
-
-
-  <Step title="Test the Integration">
-    <Note>
-      Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cascade to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Cascade understand which tool to use.
-    </Note>
-    
-    1. Open a new chat in Windsurf
-    2. Try a query like "Using Glean, what's our company's policy on remote work?"
-    3. Verify that Windsurf can access and search your Glean content
-  </Step>
-</Steps>
-</Accordion>
-
-## Application Integrations
-
-<Accordion title="Claude Desktop">
-### Claude Desktop
-
-<Steps>
-  <Step title="Get Credentials">
-    Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
-    - Your Glean subdomain
-    - A [user-scoped API token](/client/authentication#user)
-  </Step>
-
-  <Step title="Configure Claude Desktop">
-    1. Click "Claude" in the menu bar
-    2. Select "Settings..."
-    3. Click on "Developer"
-    4. Click "Edit Config" to open your `claude_desktop_config.json` file
-    5. Add the following configuration:
-
-    ```json
-    {
-      "mcpServers": {
-        "glean": {
-          "command": "npx",
-          "args": ["-y", "@gleanwork/mcp-server"],
-          "env": {
-            "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
-            "GLEAN_API_TOKEN": "<your-glean-api-token>"
-          }
-        }
-      }
-    }
-    ```
-    6. Save and close the file
-    7. Restart Claude Desktop
-
-    <Note>
-    The config file is typically located at:
-    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-    - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
-    </Note>
-
-    Your MCP server should now be listed, as shown below.
-
-    <Frame>
-      <img src="./images/claude-mcp-settings.png" alt="Claude Desktop MCP Settings" />
-    </Frame>
-  </Step>
-
-
-  <Step title="Test the Integration">
-    <Note>
-      Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Claude to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Claude understand which tool to use.
-    </Note>
-
-    1. Start a new conversation in Claude Desktop
-    2. Try a query like "Using Glean, what's our company's policy on remote work?"
-    3. Verify that Claude can access and search your Glean content
-  </Step>
-</Steps>
-</Accordion>
+- **Enterprise Search**: Access Glean's powerful content search capabilities
+- **Chat Interface**: Interact with Glean's AI assistant
+- **MCP Compliant**: Implements the Model Context Protocol specification
 
 ## Available Tools
 
@@ -221,3 +37,296 @@ For complete parameter details, see [Search API Documentation](https://developer
 Interact with Glean's AI assistant using the Glean Chat API. This tool allows you to have conversational interactions with Glean's AI, including support for message history, citations, and various configuration options.
 
 For complete parameter details, see [Chat API Documentation](https://developers.glean.com/client/operation/chat/)
+
+## Configuration
+
+### API Tokens
+
+You'll need Glean [API credentials](/client/authentication#glean-issued-tokens), and specifically a [user-scoped API token](client/authentication#user). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
+
+<Warning>
+Currently, our MCP implementation uses API tokens for authentication. While the MCP specification includes [optional authorization mechanisms](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/) and there is [an active RFC to add OAuth 2.0 support](https://github.com/modelcontextprotocol/specification/pull/133), we're using a simple token-based approach for now. Once the OAuth specification is finalized and widely adopted in the MCP ecosystem, we plan to implement OAuth-based authentication for enhanced security and user management.
+</Warning>
+
+### IDE Integrations
+
+<Accordion title="Cursor">
+### Configure Cursor
+
+<Tabs>
+  <Tab title="Configure using the CLI">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+
+      <Step title="Configure Cursor">
+        Run the following command to configure Cursor to use Glean's MCP server. This will add a new MCP server to Cursor's settings.
+
+        Using explicit `domain` and `token` flags:
+        ```bash
+        npx @gleanwork/mcp-server --client cursor --domain <your-glean-subdomain> --token <your-glean-api-token>
+        ```
+
+        Using a `.env` file:
+        ```bash
+        npx @gleanwork/mcp-server --client cursor --env <path-to-env-file>
+        ```
+      </Step>
+
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cursor's AI to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help the AI understand which tool to use.
+        </Note>
+
+        1. Open a new chat in Cursor
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Cursor can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="Configure manually">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+
+      <Step title="Configure Cursor">
+        1. Click "Cursor" in the menu bar
+        2. Select "Settings"
+        3. Click "Cursor Settings"
+        4. Navigate to the "MCP" section
+        5. Click "Add new global MCP server"
+        6. Add the following configuration to the opened `mcp.json` file:
+
+        ```json
+        {
+          "mcpServers": {
+            "glean": {
+              "command": "npx",
+              "args": ["-y", "@gleanwork/mcp-server"],
+              "env": {
+                "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
+                "GLEAN_API_TOKEN": "<your-glean-api-token>"
+              }
+            }
+          }
+        }
+        ```
+        7. Close the file to save the configuration
+        
+        Your MCP server should now be listed and Enabled, as shown below.
+
+        <Frame>
+          <img src="./images/cursor-mcp-settings.png" alt="Cursor MCP Settings" />
+        </Frame>
+      </Step>
+
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cursor's AI to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help the AI understand which tool to use.
+        </Note>
+
+        1. Open a new chat in Cursor
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Cursor can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+</Accordion>
+
+<Accordion title="Windsurf">
+### Configure Windsurf
+
+<Tabs>
+  <Tab title="Configure using the CLI">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+      <Step title="Configure Windsurf">
+        Run the following command to configure Windsurf to use Glean's MCP server. This will add a new MCP server to Windsurf's settings.
+
+        Using explicit `domain` and `token` flags:
+        ```bash
+        npx @gleanwork/mcp-server --client windsurf --domain <your-glean-subdomain> --token <your-glean-api-token>
+        ```
+
+        Using a `.env` file:
+        ```bash
+        npx @gleanwork/mcp-server --client windsurf --env <path-to-env-file>
+        ```
+      </Step>
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cascade to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Cascade understand which tool to use.
+        </Note>
+        
+        1. Open a new chat in Windsurf
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Windsurf can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="Configure manually">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+
+      <Step title="Configure Windsurf">
+        1. Click "Windsurf" in the menu bar
+        2. Select "Settings"
+        3. Click "Windsurf Settings"
+        4. Under "Cascade / Model Context Protocol (MCP) Servers"
+        5. Click "Add Server"
+        6. Click "Add Custom Server"
+        7. Add the following configuration to the opened `mcp_config.json` file:
+
+        ```json
+        {
+          "mcpServers": {
+            "glean": {
+              "command": "npx",
+              "args": ["-y", "@gleanwork/mcp-server"],
+              "env": {
+                "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
+                "GLEAN_API_TOKEN": "<your-glean-api-token>"
+              }
+            }
+          }
+        }
+        ```
+        8. Close the file to save the configuration
+        
+        Your MCP server should now be listed in the servers section, as shown below.
+
+        <Frame>
+          <img src="./images/windsurf-mcp-settings.png" alt="Windsurf MCP Settings" />
+        </Frame>
+      </Step>
+
+
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Cascade to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Cascade understand which tool to use.
+        </Note>
+        
+        1. Open a new chat in Windsurf
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Windsurf can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+</Accordion>
+
+### Application Integrations
+
+<Accordion title="Claude Desktop">
+### Claude Desktop
+
+<Tabs>
+  <Tab title="Configure using the CLI">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+
+      <Step title="Configure Claude Desktop">
+        Run the following command to configure Claude Desktop to use Glean's MCP server. This will add a new MCP server to Claude Desktop's settings.
+
+        Using explicit `domain` and `token` flags:
+        ```bash
+        npx @gleanwork/mcp-server --client claude --domain <your-glean-subdomain> --token <your-glean-api-token>
+        ```
+
+        Using a `.env` file:
+        ```bash
+        npx @gleanwork/mcp-server --client claude --env <path-to-env-file>
+        ```
+      </Step>
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Claude to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Claude understand which tool to use.
+        </Note>
+
+        1. Start a new conversation in Claude Desktop
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Claude can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="Configure manually">
+    <Steps>
+      <Step title="Get Credentials">
+        Ensure you have your Glean API credentials ready from the [Configuration](#configuration) section above. You'll need:
+        - Your Glean subdomain
+        - A [user-scoped API token](/client/authentication#user)
+      </Step>
+
+      <Step title="Configure Claude Desktop">
+        1. Click "Claude" in the menu bar
+        2. Select "Settings..."
+        3. Click on "Developer"
+        4. Click "Edit Config" to open your `claude_desktop_config.json` file
+        5. Add the following configuration:
+
+        ```json
+        {
+          "mcpServers": {
+            "glean": {
+              "command": "npx",
+              "args": ["-y", "@gleanwork/mcp-server"],
+              "env": {
+                "GLEAN_SUBDOMAIN": "<your-glean-subdomain>",
+                "GLEAN_API_TOKEN": "<your-glean-api-token>"
+              }
+            }
+          }
+        }
+        ```
+        6. Save and close the file
+        7. Restart Claude Desktop
+
+        <Note>
+        The config file is typically located at:
+        - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+        - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+        </Note>
+
+        Your MCP server should now be listed, as shown below.
+
+        <Frame>
+          <img src="./images/claude-mcp-settings.png" alt="Claude Desktop MCP Settings" />
+        </Frame>
+      </Step>
+
+
+      <Step title="Test the Integration">
+        <Note>
+          Since MCP [does not mandate a specific tool discovery interface](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/), you may need to explicitly prompt Claude to use Glean's tools. Try prefixing your questions with phrases like "Using Glean, ..." or "Search in Glean for ..." to help Claude understand which tool to use.
+        </Note>
+
+        1. Start a new conversation in Claude Desktop
+        2. Try a query like "Using Glean, what's our company's policy on remote work?"
+        3. Verify that Claude can access and search your Glean content
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+</Accordion>


### PR DESCRIPTION
## Summary

This pull request includes several updates to the `agents/mcp.mdx` file to enhance the documentation for Glean's Model Context Protocol (MCP) server.

Documentation enhancements:

* Added detailed instructions for configuring the `glean_search` and `glean_chat` tools via the new `configure` CLI command.
* Changed section headers from `###` to `##` for better hierarchy and readability.
* Updated page to align with `@gleanwork/mcp-server`'s README.md

Configuration instructions:

* Added step-by-step instructions for configuring the MCP server with `Cursor`, `Windsurf`, and `Claude Desktop` using both CLI commands and manual methods. [[1]](diffhunk://#diff-1e85e18d899dfcbbb3466636fd423f7f5d1a1aa3d2ae580e35bdd962159423faL79) [[2]](diffhunk://#diff-1e85e18d899dfcbbb3466636fd423f7f5d1a1aa3d2ae580e35bdd962159423faR140-R180) [[3]](diffhunk://#diff-1e85e18d899dfcbbb3466636fd423f7f5d1a1aa3d2ae580e35bdd962159423faR231-R274) [[4]](diffhunk://#diff-1e85e18d899dfcbbb3466636fd423f7f5d1a1aa3d2ae580e35bdd962159423faR330-L223)

These changes aim to make it easier for users to understand and utilize the features and tools provided by Glean's MCP server.