### PR TITLE
fix: Fixes npx command to include the configure subcommand

### DIFF
--- a/agents/mcp.mdx
+++ b/agents/mcp.mdx
@@ -67,12 +67,12 @@ Currently, our MCP implementation uses API tokens for authentication. While the 
 
         Using explicit `domain` and `token` flags:
         ```bash
-        npx @gleanwork/mcp-server --client cursor --domain <your-glean-subdomain> --token <your-glean-api-token>
+        npx @gleanwork/mcp-server configure --client cursor --domain <your-glean-subdomain> --token <your-glean-api-token>
         ```
 
         Using a `.env` file:
         ```bash
-        npx @gleanwork/mcp-server --client cursor --env <path-to-env-file>
+        npx @gleanwork/mcp-server configure --client cursor --env <path-to-env-file>
         ```
       </Step>
 
@@ -157,12 +157,12 @@ Currently, our MCP implementation uses API tokens for authentication. While the 
 
         Using explicit `domain` and `token` flags:
         ```bash
-        npx @gleanwork/mcp-server --client windsurf --domain <your-glean-subdomain> --token <your-glean-api-token>
+        npx @gleanwork/mcp-server configure --client windsurf --domain <your-glean-subdomain> --token <your-glean-api-token>
         ```
 
         Using a `.env` file:
         ```bash
-        npx @gleanwork/mcp-server --client windsurf --env <path-to-env-file>
+        npx @gleanwork/mcp-server configure --client windsurf --env <path-to-env-file>
         ```
       </Step>
       <Step title="Test the Integration">
@@ -251,12 +251,12 @@ Currently, our MCP implementation uses API tokens for authentication. While the 
 
         Using explicit `domain` and `token` flags:
         ```bash
-        npx @gleanwork/mcp-server --client claude --domain <your-glean-subdomain> --token <your-glean-api-token>
+        npx @gleanwork/mcp-server configure --client claude --domain <your-glean-subdomain> --token <your-glean-api-token>
         ```
 
         Using a `.env` file:
         ```bash
-        npx @gleanwork/mcp-server --client claude --env <path-to-env-file>
+        npx @gleanwork/mcp-server configure --client claude --env <path-to-env-file>
         ```
       </Step>
       <Step title="Test the Integration">


### PR DESCRIPTION
## Summary

#23 added documentation to run the `configure` command to aid in configuring the MCP server. The docs added to this repo unintentionally omitted that subcommand. This PR addresses that.

### Code changes:
* Updated `npx @gleanwork/mcp-server` commands by adding the `configure` subcommand to improve clarity and functionality in command usage, replacing direct calls with enhanced structure for configuration processes.
