### PR TITLE
fix: Fixes alpha and deprecated warnings duplications

### DIFF
--- a/_overrides/alpha_endpoints/alpha-endpoints.js
+++ b/_overrides/alpha_endpoints/alpha-endpoints.js
@@ -1,4 +1,3 @@
-
 /*************************************************************************
  * Mintlify Alpha Endpoint Callout
  *
@@ -19,10 +18,14 @@ function addAlphaWarning() {
 
   if (canonicalLink) {
     const url = new URL(canonicalLink.href);
+    
     if (alphaPaths.some(path => url.pathname.includes(path))) {
       const header = document.querySelector('header');
-      if (header) {
+      const existingWarning = document.querySelector('[data-callout-type="warning"]');
+
+      if (header && !existingWarning) {
         const warningDiv = document.createElement('div');
+        
         warningDiv.className = "callout my-4 px-5 py-4 overflow-hidden rounded-2xl flex gap-3 border border-amber-500/20 bg-amber-500/10 dark:border-amber-500/30 dark:bg-amber-500/10";
         warningDiv.setAttribute("data-callout-type", "warning");
         warningDiv.innerHTML = `<div class="mt-0.5 w-4"><svg class="flex-none w-5 h-5 text-amber-400 dark:text-amber-300/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-label="Warning"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg></div><div class="text-sm prose min-w-0 w-full text-amber-900 dark:text-amber-200">${alphaWarningText}</div>`;

--- a/_overrides/deprecations/deprecated.js
+++ b/_overrides/deprecations/deprecated.js
@@ -28,8 +28,11 @@ function addDeprecatedWarning() {
             document.body.classList.add("deprecated");
 
             const header = document.querySelector('header');
-            if (header) {
+            const existingWarning = document.querySelector('[data-callout-type="warning"]');
+
+            if (header && !existingWarning) {
                 const warningDiv = document.createElement('div');
+                
                 warningDiv.className = "callout my-4 px-5 py-4 overflow-hidden rounded-2xl flex gap-3 border border-amber-500/20 bg-amber-500/10 dark:border-amber-500/30 dark:bg-amber-500/10";
                 warningDiv.setAttribute("data-callout-type", "warning");
                 warningDiv.innerHTML = `<div class="mt-0.5 w-4"><svg class="flex-none w-5 h-5 text-amber-400 dark:text-amber-300/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-label="Warning"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg></div><div class="text-sm prose min-w-0 w-full text-amber-900 dark:text-amber-200">${deprecatedWarningText}</div>`;


### PR DESCRIPTION
## Summary

Fixes issue where repeated clicks on the sidebar links for pages containing the alpha or deprecated warnings cause the div to be rendered multiple times.