### PR TITLE
chore: silence broken-links linting

### DIFF
--- a/client.mdx
+++ b/client.mdx
@@ -8,7 +8,7 @@ Kindly read the [Authentication](/client/authentication) page to know about the 
 Let's walk through some sample requests to get familiar with the general usage of the developer-ready endpoints!
 
 <Note>
-For the sake of the example, we shall demonstrate the usage of the [/createcollection](/api-reference/client/collections/create-collection) developer-ready endpoint.
+For the sake of the example, we shall demonstrate the usage of the [/createcollection](https://developers.glean.com/api-reference/client/collections/create-collection) developer-ready endpoint.
 To find out more about a specific endpoint's fields and usage, please refer to its API reference page!
 </Note>
 

--- a/indexing.mdx
+++ b/indexing.mdx
@@ -11,4 +11,4 @@ Glean provides advance notice of any planned backwards incompatible changes alon
 
 A [Python SDK](/sdk#indexing-api) is available to make it easier to use the Indexing API. SDK bindings can be generated for other popular languages (Java, NodeJS, etc.), too!
 
-For more detailed information, please refer to the [API Reference](/api-reference/indexing).
+For more detailed information, please refer to the [API Reference](https://developers.glean.com/api-reference/indexing).

--- a/indexing/people-teams-identity.mdx
+++ b/indexing/people-teams-identity.mdx
@@ -36,7 +36,7 @@ Glean provides individual and bulk upload endpoints for people and teams.
 | [/bulkindexteams](https://developers.glean.com/indexing/tag/People/paths/~1bulkindexteams/post/) | Index or update multiple teams.     |
 | [/deleteteam](https://developers.glean.com/indexing/tag/People/paths/~1deleteteam/post/)         | Delete information about a team.    |
 
-By default, people and teams are updated in the index within an hour of a successful upload. Glean also provides an API ([/processallemployeesandteams](/api-reference/indexing/people/schedules-the-processing-of-uploaded-employees-and-teams)) to trigger processing of all recently uploaded people and teams immediately after an upload.
+By default, people and teams are updated in the index within an hour of a successful upload. Glean also provides an API ([/processallemployeesandteams](https://developers.glean.com/api-reference/indexing/people/schedules-the-processing-of-uploaded-employees-and-teams)) to trigger processing of all recently uploaded people and teams immediately after an upload.
 
 <Note>
 


### PR DESCRIPTION
Lots of our prs complain about broken links to `/api-reference/`.  As far as I can tell, the link checking happens with no regard for the generation configured in docs.json.

Updating the paths to full URLs is consistent with similar links, like the ones in changelog.mdx.

Note though, that the link checker doesn't actually *check* these links. It seems to skip links specified as full URLs.
