### PR TITLE
release notes: Add release notes for new indexing api endpoints launch

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -3,6 +3,11 @@ title: Change Log
 icon: list-timeline
 ---
 
+<Update label="May 2, 2025" tags={["Indexing API"]}>
+- [/updatepermissions](https://developers.glean.com/api-reference/indexing/documents/update-document-permissions) - Endpoint to update document permissions: Generally available
+- [/debug/[datasource]/documents](https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents) - Troubleshooting endpoint for batch queries: Generally available
+</Update>
+
 <Update label="Apr 18, 2025" tags={["Auth"]}>
 - Deprecate X-Scio-ActAs in favor of X-Glean-ActAs.  X-Scio-ActAs continues to work, but it is an error to specify both headers.
 </Update>
@@ -41,6 +46,6 @@ And much more...
 </Update>
 
 <Update label="Feb 19, 2025" tags={["Indexing API"]}>
-    - [/updatepermissions](https://developers.glean.com/indexing/tag/Documents/paths/~1updatepermissions/post/) - Beta launch of new endpoint to update document permissions
-    - [/debug/[datasource]/documents](https://developers.glean.com/indexing/tag/Troubleshooting/paths/~1debug~1%7Bdatasource%7D~1documents/post/) - Beta launch of new troubleshooting endpoint for batch queries
+    - [/updatepermissions](https://developers.glean.com/api-reference/indexing/documents/update-document-permissions) - Beta launch of new endpoint to update document permissions
+    - [/debug/[datasource]/documents](https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents) - Beta launch of new troubleshooting endpoint for batch queries
 </Update>


### PR DESCRIPTION
Release notes for GA of new endpoints
<img width="1495" alt="Screenshot 2025-04-25 at 1 35 15 PM" src="https://github.com/user-attachments/assets/03873613-767a-4cf1-8261-47a0ed71410b" />
