### PR TITLE
internal: Updates reference to client and indexing specs to point to gleanwork/open-api instead of redocly

### DIFF
--- a/actions/openapi.mdx
+++ b/actions/openapi.mdx
@@ -1,5 +1,0 @@
----
-title: "OpenAPI Spec"
-icon: "pen-ruler"
-url: "https://api.redocly.com/registry/assets/glean/Glean%20Tools%20API%20-%20Early%20Access/v1/openapi/public/tools_rest.yaml?branch=main"
----

--- a/client/openapi.mdx
+++ b/client/openapi.mdx
@@ -1,5 +1,5 @@
 ---
 title: "OpenAPI Spec"
 icon: "pen-ruler"
-url: "https://api.redoc.ly/registry/assets/glean/Glean%20Client%20API/v1/public/client_rest.yaml?branch=main"
+url: "https://gleanwork.github.io/open-api/specs/source/client_rest.yaml"
 ---

--- a/docs.json
+++ b/docs.json
@@ -416,11 +416,11 @@
   "redirects": [
     {
       "source": "/oas/client",
-      "destination": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml"
+      "destination": "https://gleanwork.github.io/open-api/specs/source/client_rest.yaml"
     },
     {
       "source": "/oas/indexing",
-      "destination": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml"
+      "destination": "https://gleanwork.github.io/open-api/specs/source/indexing.yaml"
     },
     {
       "source": "/client/overview",

--- a/docs.json
+++ b/docs.json
@@ -194,22 +194,15 @@
           {
             "group": "Indexing API",
             "openapi": {
-              "source": "https://api.redocly.com/registry/assets/glean/Glean%20Indexing%20API/v1/public/indexing.yaml?branch=main",
+              "source": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml",
               "directory": "api-reference/indexing"
             }
           },
           {
             "group": "Client API",
             "openapi": {
-              "source": "https://api.redocly.com/registry/assets/glean/Glean%20Client%20API/v1/public/client_rest.yaml?branch=main",
+              "source": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml",
               "directory": "api-reference/client"
-            }
-          },
-          {
-            "group": "Actions API",
-            "openapi": {
-              "source": "https://api.redocly.com/registry/assets/glean/Glean%20Tools%20API%20-%20Early%20Access/v1/openapi/public/tools_rest.yaml?branch=main",
-              "directory": "api-reference/actions"
             }
           }
         ]
@@ -424,15 +417,11 @@
   "redirects": [
     {
       "source": "/oas/client",
-      "destination": "https://api.redoc.ly/registry/assets/glean/Glean%20Client%20API/v1/public/client_rest.yaml?branch=main"
+      "destination": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml"
     },
     {
       "source": "/oas/indexing",
-      "destination": "https://api.redoc.ly/registry/assets/glean/Glean%20Indexing%20API/v1/public/indexing.yaml?branch=main"
-    },
-    {
-      "source": "/oas/actions",
-      "destination": "https://api.redocly.com/registry/assets/glean/Glean%20Tools%20API%20-%20Early%20Access/v1/openapi/public/tools_rest.yaml?branch=main"
+      "destination": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml"
     },
     {
       "source": "/client/overview",

--- a/docs.json
+++ b/docs.json
@@ -164,8 +164,7 @@
                   "/actions/examples/jira-issue-creation",
                   "/actions/examples/jira-issue-creation-redirect"
                 ]
-              },
-              "/actions/openapi"
+              }
             ]
           },
           {
@@ -194,14 +193,14 @@
           {
             "group": "Indexing API",
             "openapi": {
-              "source": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml",
+              "source": "https://gleanwork.github.io/open-api/specs/source/indexing.yaml",
               "directory": "api-reference/indexing"
             }
           },
           {
             "group": "Client API",
             "openapi": {
-              "source": "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml",
+              "source": "https://gleanwork.github.io/open-api/specs/source/client_rest.yaml",
               "directory": "api-reference/client"
             }
           }

--- a/indexing/authentication/managing-tokens.mdx
+++ b/indexing/authentication/managing-tokens.mdx
@@ -29,7 +29,7 @@ Requests will only be allowed if the source IP matches at least one of the speci
 ## Creating a rotatable token
 
 To create a rotatable token, specify the rotation period in minutes using the rotation period field.
-You can use the [`/rotatetoken`](https://glean.redoc.ly/indexing/tag/Authentication/paths/~1rotatetoken/post/) indexing API endpoint to rotate these tokens. Please refer to the [Token rotation](https://developers.glean.com/docs/indexing_api_token_rotation/) documentation to get more information on rotatable tokens.
+You can use the [`/rotatetoken`](https://developers.glean.com/api-reference/indexing/authentication/rotate-token#rotate-token) indexing API endpoint to rotate these tokens. Please refer to the [Token rotation](https://developers.glean.com/docs/indexing_api_token_rotation/) documentation to get more information on rotatable tokens.
 
 <Frame>
 <img src="./images/rotation-period.png" alt="Rotation period" height="300" />

--- a/indexing/documents/document-model.mdx
+++ b/indexing/documents/document-model.mdx
@@ -4,7 +4,7 @@ icon: file
 ---
 
 The following is the basic document model used for indexing a new document to Glean.
-There are other fields too which you can use for advanced functionality. You can refer to them in the API reference docs [here](https://glean.redoc.ly/indexing/tag/Documents/paths/~1indexdocument/post/#!path=document&t=request).
+There are other fields too which you can use for advanced functionality. You can refer to them in the API reference docs [here](https://developers.glean.com/api-reference/indexing/documents/index-document).
 
 | Field                           | Description                                                                                              |
 | ------------------------------- | -------------------------------------------------------------------------------------------------------- |

--- a/indexing/openapi.mdx
+++ b/indexing/openapi.mdx
@@ -1,5 +1,5 @@
 ---
 title: "OpenAPI Spec"
 icon: "pen-ruler"
-url: "https://api.redoc.ly/registry/assets/glean/Glean%20Indexing%20API/v1/public/indexing.yaml?branch=main"
+url: "https://gleanwork.github.io/open-api/specs/source/indexing.yaml"
 ---

--- a/sdk.mdx
+++ b/sdk.mdx
@@ -62,15 +62,11 @@ npx @openapitools/openapi-generator-cli@latest list
 
 <CodeGroup>
 ```bash Client API
-npx @openapitools/openapi-generator-cli generate -g go -i "https://api.redoc.ly/registry/assets/glean/Glean%20Client%20API/v1/public/client_rest.yaml?branch=main"
+npx @openapitools/openapi-generator-cli generate -g go -i "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml"
 ```
 
 ```bash Indexing API
-npx @openapitools/openapi-generator-cli generate -g go -i "https://api.redoc.ly/registry/assets/glean/Glean%20Indexing%20API/v1/public/indexing.yaml?branch=main"
-```
-
-```bash Actions API
-npx @openapitools/openapi-generator-cli generate -g go -i "https://api.redocly.com/registry/assets/glean/Glean%20Tools%20API%20-%20Early%20Access/v1/openapi/public/tools_rest.yaml?branch=main"
+npx @openapitools/openapi-generator-cli generate -g go -i "https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml"
 ```
 </CodeGroup>
 


### PR DESCRIPTION
## Summary

We've created a new public repository, `gleanwork/open-api`, which houses our pre-processed specs. That repository should be considered the SOT for both our API client generation, and our documentation.

This change represents the first step in updating our docs with the API client references. Once those libraries are released, we'll point the specs to the enhanced versions, which will include our API client documentation.

### Code changes:
* The pull request updates the `docs.json` file to change the sources for the "Indexing API" and "Client API" sections from `api.redocly.com` to the new public repository `gleanwork/open-api`. Specifically, it moves from URLs referencing `redocly` to referencing raw paths in `gleanwork/open-api`, thus aligning future API client generation and documentation under a single source of truth.

### Context of linked documents
* [Glean Client API Specification](https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/client_rest.yaml): Contains the full set of details and usage guidelines for the Glean Client API.

* [Glean Indexing API Specification](https://raw.githubusercontent.com/gleanwork/open-api/refs/heads/main/source_specs/indexing.yaml): Provides information on how to interact with the indexing API, including its capabilities and structure.
