### PR TITLE
task: Ensure codeblocks render color based on light/dark modes

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -17,6 +17,9 @@
       "display": "none"
     }
   },
+  "styling": {
+    "codeblocks": "system"
+  },
   "navigation": {
     "anchors": [
       {
@@ -32,11 +35,18 @@
             "pages": [
               {
                 "group": "Get Started",
-                "pages": ["/indexing", "/indexing/rendering-search-results", "/indexing/people-teams-identity"]
+                "pages": [
+                  "/indexing",
+                  "/indexing/rendering-search-results",
+                  "/indexing/people-teams-identity"
+                ]
               },
               {
                 "group": "Guides",
-                "pages": ["/indexing/guides/setup-datasource", "/indexing/guides/indexing-documents"]
+                "pages": [
+                  "/indexing/guides/setup-datasource",
+                  "/indexing/guides/indexing-documents"
+                ]
               },
               {
                 "group": "Authentication",
@@ -88,7 +98,10 @@
               },
               {
                 "group": "Guides",
-                "pages": ["/client/guides/chatbot", "/client/guides/nvidia-enterprise-kb-chatbot"]
+                "pages": [
+                  "/client/guides/chatbot",
+                  "/client/guides/nvidia-enterprise-kb-chatbot"
+                ]
               },
               {
                 "group": "Search",
@@ -106,7 +119,11 @@
             "pages": [
               {
                 "group": "Get Started",
-                "pages": ["/web", "/web/3rd-party-cookies", "/web/documentation"]
+                "pages": [
+                  "/web",
+                  "/web/3rd-party-cookies",
+                  "/web/documentation"
+                ]
               },
               {
                 "group": "Components",
@@ -120,7 +137,12 @@
               },
               {
                 "group": "Guides",
-                "pages": ["/web/guides/react", "/web/guides/zendesk", "/web/guides/lumapps", "/web/guides/brightspot"]
+                "pages": [
+                  "/web/guides/react",
+                  "/web/guides/zendesk",
+                  "/web/guides/lumapps",
+                  "/web/guides/brightspot"
+                ]
               }
             ]
           },
@@ -129,7 +151,12 @@
             "pages": [
               {
                 "group": "Get Started",
-                "pages": ["/actions", "/actions/authentication", "/actions/create-actions", "/actions/faq"]
+                "pages": [
+                  "/actions",
+                  "/actions/authentication",
+                  "/actions/create-actions",
+                  "/actions/faq"
+                ]
               },
               {
                 "group": "Examples",
@@ -145,11 +172,20 @@
           },
           {
             "group": "Tools",
-            "pages": ["/api-clients", "/agents/index", "/home/opensource", "/home/community"]
+            "pages": [
+              "/api-clients",
+              "/agents/index",
+              "/home/opensource",
+              "/home/community"
+            ]
           },
           {
             "group": "Feedback",
-            "pages": ["/home/feedback/discussions", "/home/feedback/bugs", "/home/feedback/features"]
+            "pages": [
+              "/home/feedback/discussions",
+              "/home/feedback/bugs",
+              "/home/feedback/features"
+            ]
           }
         ]
       },


### PR DESCRIPTION
## Summary

Even in light mode the codeblocks on the API pages were rendering in dark mode. This change ensures they render with the associated mode that's active.

### Code changes:
* Added a new "styling" section to `docs.json`, including a setting for "codeblocks" to support rendering based on light/dark modes.

### Screenshots

![Screenshot 2025-05-08 at 1 02 27 PM](https://github.com/user-attachments/assets/73c7a041-cb8f-44aa-ba65-2985916ec75d)
![Screenshot 2025-05-08 at 1 02 38 PM](https://github.com/user-attachments/assets/b9633916-35fc-4fdd-bc0b-811c73df8aa6)
