### PR TITLE
docs: Updates references to domain after API Client rename from domain to instance

### DIFF
--- a/actions/examples/google-calendar-events.mdx
+++ b/actions/examples/google-calendar-events.mdx
@@ -153,9 +153,9 @@ Before beginning this implementation, ensure you have:
        </Frame>
 
     ### Redirect URI Configuration
-    Add this URI to your OAuth client:
+    Add this URI to your OAuth client (Note your instance name is typically the email domain without the extension):
     ```text
-    https://{your-glean-domain-name}-be.glean.com/tools/oauth/verify_code/{your-action-unique-identifier-name}
+    https://{instance-name}-be.glean.com/tools/oauth/verify_code/{your-action-unique-identifier-name}
     ```
 
     ### OAuth Settings

--- a/actions/examples/google-docs-update.mdx
+++ b/actions/examples/google-docs-update.mdx
@@ -174,9 +174,9 @@ Before proceeding, ensure you have:
        </Frame>
 
     ### Redirect URI Configuration
-    Add the following redirect URI to your OAuth client configuration:
+    Add the following redirect URI to your OAuth client configuration (Note your instance name is typically the email domain without the extension):
     ```text
-    https://{your-glean-domain-name}-be.glean.com/tools/oauth/verify_code/{your-action-unique-identifier-name}
+    https://{instance-name}-be.glean.com/tools/oauth/verify_code/{your-action-unique-identifier-name}
     ```
 
     <Warning>

--- a/actions/examples/jira-issue-creation.mdx
+++ b/actions/examples/jira-issue-creation.mdx
@@ -145,11 +145,11 @@ info:
   title: Jira Execution Action
   version: 1.0.0
 servers:
-  - url: https://{domain}-be.glean.com/tools/jira
+  - url: https://{instance-name}-be.glean.com/tools/jira
     variables:
-      domain:
-        default: domain
-        description: Email domain (without extension) that determines the deployment backend.
+      instance:
+        default: instance-name
+        description: The instance name (typically the email domain without the extension) that determines the deployment backend.
 paths:
   /create_issue:
     post:

--- a/client/guides/chatbot.mdx
+++ b/client/guides/chatbot.mdx
@@ -29,7 +29,7 @@ sequenceDiagram
 
 <CodeGroup>
 ```bash User Token
-curl 'https://<your-domain>-be.glean.com/rest/api/v1/chat' \
+curl 'https://<instance-name>-be.glean.com/rest/api/v1/chat' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <TOKEN>' \
   -d '{
@@ -48,7 +48,7 @@ curl 'https://<your-domain>-be.glean.com/rest/api/v1/chat' \
 ```
 
 ```bash Global Token
-curl 'https://<your-domain>-be.glean.com/rest/api/v1/chat' \
+curl 'https://<instance-name>-be.glean.com/rest/api/v1/chat' \
   -H 'Content-Type: application/json' \
   -H 'Authorization: Bearer <TOKEN>' \
   -H 'X-Glean-ActAs: john.doe@yourcompany.com' \
@@ -125,7 +125,7 @@ def process_response_message_stream(response):
                 process_message_fragment(message)
 
 def main():
-    url = 'https://<your-domain>-be.glean.com/rest/api/v1/chat'
+    url = 'https://<instance-name>-be.glean.com/rest/api/v1/chat'
     headers = {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer <TOKEN>'
@@ -247,7 +247,7 @@ def send_conversation_message(url, headers, payload):
 
 
 def main():
-    url = 'https://<your-domain>-be.glean.com/rest/api/v1/chat'
+    url = 'https://<instance-name>-be.glean.com/rest/api/v1/chat'
     headers = {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer <TOKEN>'
@@ -365,7 +365,7 @@ def send_conversation_message(url, headers, payload):
 
 
 def main():
-    url = 'https://<your-domain>-be.glean.com/rest/api/v1/chat'
+    url = 'https://<instance-name>-be.glean.com/rest/api/v1/chat'
     headers = {
         'Content-Type': 'application/json',
         'Authorization': 'Bearer <TOKEN>'


### PR DESCRIPTION
## Summary

Redeployment of docs follow rename of `domain` to `instance` in API Clients. This more closely matches what this property represents.

We'll be following this change with a number of others in order to standardize the definition across our libraries etc.

### Code changes:
* Updated API references from "domain" to "instance" in various files, clarifying that the instance name typically corresponds to the email domain without the extension. This change enhances clarity in the OAuth client configuration across different implementations.

### Context of linked documents
* No linked documents to summarize.
