### PR TITLE
chore: Marks Agent APIs as Beta

### DIFF
--- a/_overrides/alpha_endpoints/beta-endpoints.js
+++ b/_overrides/alpha_endpoints/beta-endpoints.js
@@ -5,21 +5,23 @@
  * This script adds a callout to alpha endpoints.
  *************************************************************************/
 
-const alphaWarningText = "This endpoint is in alpha. Expect changes and instability.";
-const alphaPaths = [
-  "/api-reference/client/agents/runs-an-agent",
-  "/api-reference/client/agents/lists-all-agents",
-  "/api-reference/client/agents/gets-the-inputs-to-an-agent",
+const betaWarningText = "This endpoint is in Beta. Expect changes and instability.";
+const betaPaths = [
+  "/api-reference/client/agents/get-agent",
+  "/api-reference/client/agents/get-agent-schemas",
+  "/api-reference/client/agents/search-agents",
+  "/api-reference/client/agents/create-run-stream-output",
+  "/api-reference/client/agents/create-run-wait-for-output",
 ];
 
 // Add callout warning for alpha endpoints.
-function addAlphaWarning() {
+function addBetaWarning() {
   const canonicalLink = document.querySelector('head link[rel="canonical"]');
 
   if (canonicalLink) {
     const url = new URL(canonicalLink.href);
     
-    if (alphaPaths.some(path => url.pathname.includes(path))) {
+    if (betaPaths.some(path => url.pathname.includes(path))) {
       const header = document.querySelector('header');
       const existingWarning = document.querySelector('[data-callout-type="warning"]');
 
@@ -28,7 +30,7 @@ function addAlphaWarning() {
         
         warningDiv.className = "callout my-4 px-5 py-4 overflow-hidden rounded-2xl flex gap-3 border border-amber-500/20 bg-amber-500/10 dark:border-amber-500/30 dark:bg-amber-500/10";
         warningDiv.setAttribute("data-callout-type", "warning");
-        warningDiv.innerHTML = `<div class="mt-0.5 w-4"><svg class="flex-none w-5 h-5 text-amber-400 dark:text-amber-300/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-label="Warning"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg></div><div class="text-sm prose min-w-0 w-full text-amber-900 dark:text-amber-200">${alphaWarningText}</div>`;
+        warningDiv.innerHTML = `<div class="mt-0.5 w-4"><svg class="flex-none w-5 h-5 text-amber-400 dark:text-amber-300/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" aria-label="Warning"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path></svg></div><div class="text-sm prose min-w-0 w-full text-amber-900 dark:text-amber-200">${betaWarningText}</div>`;
         header.insertAdjacentElement('afterend', warningDiv);
       }
     }
@@ -36,5 +38,5 @@ function addAlphaWarning() {
 }
 
 // Listen for route changes and update the document title
-window.next.router.events.on('routeChangeComplete', addAlphaWarning);
-addAlphaWarning();
+window.next.router.events.on('routeChangeComplete', addBetaWarning);
+addBetaWarning();

--- a/_overrides/alpha_endpoints/beta-endpoints.js
+++ b/_overrides/alpha_endpoints/beta-endpoints.js
@@ -1,8 +1,8 @@
 /*************************************************************************
- * Mintlify Alpha Endpoint Callout
+ * Mintlify Beta Endpoint Callout
  *
- * Mintlify doesn't have any support for marking an endpoint as "alpha".
- * This script adds a callout to alpha endpoints.
+ * Mintlify doesn't have any support for marking an endpoint as "beta".
+ * This script adds a callout to beta endpoints.
  *************************************************************************/
 
 const betaWarningText = "This endpoint is in Beta. Expect changes and instability.";
@@ -14,7 +14,7 @@ const betaPaths = [
   "/api-reference/client/agents/create-run-wait-for-output",
 ];
 
-// Add callout warning for alpha endpoints.
+// Add callout warning for beta endpoints.
 function addBetaWarning() {
   const canonicalLink = document.querySelector('head link[rel="canonical"]');
 

--- a/docs.json
+++ b/docs.json
@@ -74,7 +74,13 @@
                   "/indexing/debugging/document-count"
                 ]
               },
-              "/indexing/openapi"
+              {
+                "group": "Indexing API",
+                "openapi": {
+                  "source": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml",
+                  "directory": "api-reference/indexing"
+                }
+              }
             ]
           },
           {


### PR DESCRIPTION
# Summary

This pull request updates the handling of API endpoint warnings and enhances the documentation structure. The most significant changes involve renaming and updating the script for endpoint warnings and adding OpenAPI specifications to the documentation.

### Updates to API Endpoint Warnings:
* Renamed `_overrides/alpha_endpoints/alpha-endpoints.js` to `_overrides/alpha_endpoints/beta-endpoints.js` and updated the script to reflect the transition from "alpha" to "beta" endpoints. This includes changing warning text, endpoint paths, and function names (`addAlphaWarning` to `addBetaWarning`).
* Updated the `innerHTML` of the warning callout to use the `betaWarningText` variable and adjusted the event listener to call `addBetaWarning` instead of `addAlphaWarning`.

### Documentation Enhancements:
* Updated `docs.json` to include OpenAPI specifications for the "Indexing API" group, referencing an external OpenAPI source and specifying the directory for API reference documentation.