### PR TITLE
internal: Adds CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gleanwork/gleanwork-docs-reviewers


### PR DESCRIPTION
# Summary

This pull request includes a small change to the `CODEOWNERS` file. The change adds the `@gleanwork/gleanwork-docs-reviewers` team as the owner for all files.