### PR TITLE
docs(changelog): add entry for OpenAPI spec request body requirements

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -12,8 +12,17 @@ icon: list-timeline
     - Added support for the new `GET /tools/list` and `POST /tools/call` endpoints
   - MCP Server
     - Support for configuring MCP server with VS Code
+- Bug Fixes:
+  - Update the OpenAPI Spec to properly mark the request body as a required
+    field. This change more accurately reflects how the API handles the case when
+    the request body is not provided. This affects the following API endpoints:
+    - `/rest/api/v1/search`
+    - `/rest/api/v1/recommendations`
+    - `rest/api/v1/adminsearch`
 - Breaking Changes:
-  - Python API client: aligned method parameters with the other methods in the API client.
+  - Python API client: the request body OpenAPI spec change resulted in a
+    breaking change due to language semantics. This aligns search method
+    parameters with other methods in the API.
 </Update>
 
 <Update label="May 16, 2025" tags={["Governance API", "Agent API"]}>


### PR DESCRIPTION
- Documents required request body changes for search and recommendations endpoints
- Notes breaking change in Python client v0.5.0