### PR TITLE
Merged API References with Documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -16,202 +16,180 @@
     "codeblocks": "system"
   },
   "navigation": {
-    "anchors": [
+    "groups": [
       {
-        "anchor": "Documentation",
-        "icon": "book",
-        "groups": [
+        "group": "Get Started",
+        "pages": ["/home", "/changelog"]
+      },
+      {
+        "group": "Indexing",
+        "pages": [
           {
             "group": "Get Started",
-            "pages": ["/home", "/changelog"]
-          },
-          {
-            "group": "Indexing",
             "pages": [
-              {
-                "group": "Get Started",
-                "pages": [
-                  "/indexing",
-                  "/indexing/rendering-search-results",
-                  "/indexing/people-teams-identity"
-                ]
-              },
-              {
-                "group": "Guides",
-                "pages": [
-                  "/indexing/guides/setup-datasource",
-                  "/indexing/guides/indexing-documents"
-                ]
-              },
-              {
-                "group": "Authentication",
-                "pages": [
-                  "/indexing/authentication/managing-tokens",
-                  "/indexing/authentication/token-rotation",
-                  "/indexing/authentication/permissions"
-                ]
-              },
-              {
-                "group": "Datasources",
-                "pages": [
-                  "/indexing/datasource/custom-properties",
-                  "/indexing/datasource/test-datasource",
-                  "/indexing/datasource/category"
-                ]
-              },
-              {
-                "group": "Documents",
-                "pages": [
-                  "/indexing/documents/activity",
-                  "/indexing/documents/permissions",
-                  "/indexing/documents/bulk-indexing",
-                  "/indexing/documents/bulk-upload-model",
-                  "/indexing/documents/document-model",
-                  "/indexing/documents/supported-mimetypes"
-                ]
-              },
-              {
-                "group": "Debugging",
-                "pages": [
-                  "/indexing/debugging/datasource-config",
-                  "/indexing/debugging/datasource-status",
-                  "/indexing/debugging/datasource-document",
-                  "/indexing/debugging/datasource-user",
-                  "/indexing/debugging/document-access",
-                  "/indexing/debugging/document-count"
-                ]
-              },
-              {
-                "group": "Indexing API",
-                "openapi": {
-                  "source": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml",
-                  "directory": "api-reference/indexing"
-                }
-              }
+              "/indexing",
+              "/indexing/rendering-search-results",
+              "/indexing/people-teams-identity"
             ]
           },
           {
-            "group": "Client",
+            "group": "Guides",
             "pages": [
-              {
-                "group": "Get Started",
-                "pages": ["/client", "/client/authentication", "/client/chat"]
-              },
-              {
-                "group": "Guides",
-                "pages": [
-                  "/client/guides/chatbot",
-                  "/client/guides/nvidia-enterprise-kb-chatbot"
-                ]
-              },
-              {
-                "group": "Search",
-                "pages": [
-                  "/client/search/filtering-results",
-                  "/client/search/datasource-filters",
-                  "/client/search/faceted-filters"
-                ]
-              },
-              {
-                "group": "Governance",
-                "pages": ["/api-admin"]
-              },
-              "/client/openapi"
+              "/indexing/guides/setup-datasource",
+              "/indexing/guides/indexing-documents"
             ]
           },
           {
-            "group": "Web SDK",
+            "group": "Authentication",
             "pages": [
-              {
-                "group": "Get Started",
-                "pages": [
-                  "/web",
-                  "/web/3rd-party-cookies",
-                  "/web/documentation"
-                ]
-              },
-              {
-                "group": "Components",
-                "pages": [
-                  "/web/components/chat",
-                  "/web/components/autocomplete",
-                  "/web/components/modal-search",
-                  "/web/components/sidebar",
-                  "/web/components/recommendations"
-                ]
-              },
-              {
-                "group": "Guides",
-                "pages": [
-                  "/web/guides/react",
-                  "/web/guides/zendesk",
-                  "/web/guides/lumapps",
-                  "/web/guides/brightspot"
-                ]
-              }
+              "/indexing/authentication/managing-tokens",
+              "/indexing/authentication/token-rotation",
+              "/indexing/authentication/permissions"
             ]
           },
           {
-            "group": "Actions",
+            "group": "Datasources",
             "pages": [
-              {
-                "group": "Get Started",
-                "pages": [
-                  "/actions",
-                  "/actions/authentication",
-                  "/actions/create-actions",
-                  "/actions/faq"
-                ]
-              },
-              {
-                "group": "Examples",
-                "pages": [
-                  "/actions/examples/google-docs-update",
-                  "/actions/examples/google-calendar-events",
-                  "/actions/examples/zendesk-ticket-redirection",
-                  "/actions/examples/jira-issue-creation",
-                  "/actions/examples/jira-issue-creation-redirect"
-                ]
-              }
+              "/indexing/datasource/custom-properties",
+              "/indexing/datasource/test-datasource",
+              "/indexing/datasource/category"
             ]
           },
           {
-            "group": "Tools",
+            "group": "Documents",
             "pages": [
-              "/api-clients",
-              "/agents/index",
-              "/home/opensource",
-              "/home/community"
+              "/indexing/documents/activity",
+              "/indexing/documents/permissions",
+              "/indexing/documents/bulk-indexing",
+              "/indexing/documents/bulk-upload-model",
+              "/indexing/documents/document-model",
+              "/indexing/documents/supported-mimetypes"
             ]
           },
           {
-            "group": "Feedback",
+            "group": "Debugging",
             "pages": [
-              "/home/feedback/discussions",
-              "/home/feedback/bugs",
-              "/home/feedback/features"
+              "/indexing/debugging/datasource-config",
+              "/indexing/debugging/datasource-status",
+              "/indexing/debugging/datasource-document",
+              "/indexing/debugging/datasource-user",
+              "/indexing/debugging/document-access",
+              "/indexing/debugging/document-count"
+            ]
+          },
+          {
+            "group": "API Reference",
+            "openapi": {
+              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml",
+              "directory": "indexing/api"
+            }
+          },
+          "/indexing/openapi"
+        ]
+      },
+      {
+        "group": "Client",
+        "pages": [
+          {
+            "group": "Get Started",
+            "pages": ["/client", "/client/authentication", "/client/chat"]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "/client/guides/chatbot",
+              "/client/guides/nvidia-enterprise-kb-chatbot"
+            ]
+          },
+          {
+            "group": "Search",
+            "pages": [
+              "/client/search/filtering-results",
+              "/client/search/datasource-filters",
+              "/client/search/faceted-filters"
+            ]
+          },
+          {
+            "group": "Governance",
+            "pages": ["/api-admin"]
+          },
+          {
+            "group": "API Reference",
+            "openapi": {
+              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-client-merged-code-samples-spec.yaml",
+              "directory": "client/api"
+            }
+          },
+          "/client/openapi"
+        ]
+      },
+      {
+        "group": "Web SDK",
+        "pages": [
+          {
+            "group": "Get Started",
+            "pages": ["/web", "/web/3rd-party-cookies", "/web/documentation"]
+          },
+          {
+            "group": "Components",
+            "pages": [
+              "/web/components/chat",
+              "/web/components/autocomplete",
+              "/web/components/modal-search",
+              "/web/components/sidebar",
+              "/web/components/recommendations"
+            ]
+          },
+          {
+            "group": "Guides",
+            "pages": [
+              "/web/guides/react",
+              "/web/guides/zendesk",
+              "/web/guides/lumapps",
+              "/web/guides/brightspot"
             ]
           }
         ]
       },
       {
-        "anchor": "API Reference",
-        "icon": "code",
-        "groups": [
+        "group": "Actions",
+        "pages": [
           {
-            "group": "Indexing API",
-            "openapi": {
-              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml",
-              "directory": "api-reference/indexing"
-            }
+            "group": "Get Started",
+            "pages": [
+              "/actions",
+              "/actions/authentication",
+              "/actions/create-actions",
+              "/actions/faq"
+            ]
           },
           {
-            "group": "Client API",
-            "openapi": {
-              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-client-merged-code-samples-spec.yaml",
-              "directory": "api-reference/client"
-            }
+            "group": "Examples",
+            "pages": [
+              "/actions/examples/google-docs-update",
+              "/actions/examples/google-calendar-events",
+              "/actions/examples/zendesk-ticket-redirection",
+              "/actions/examples/jira-issue-creation",
+              "/actions/examples/jira-issue-creation-redirect"
+            ]
           }
+        ]
+      },
+      {
+        "group": "Tools",
+        "pages": [
+          "/api-clients",
+          "/agents/index",
+          "/home/opensource",
+          "/home/community"
+        ]
+      },
+      {
+        "group": "Feedback",
+        "pages": [
+          "/home/feedback/discussions",
+          "/home/feedback/bugs",
+          "/home/feedback/features"
         ]
       }
     ]
@@ -536,8 +514,12 @@
       "destination": "/actions/authentication"
     },
     {
-      "source": "/lab",
-      "destination": "https://docs.johnagan.com/glean-go"
+      "source": "/api-reference/client",
+      "destination": "/client/api"
+    },
+    {
+      "source": "/api-reference/indexing",
+      "destination": "/indexing/api"
     }
   ]
 }


### PR DESCRIPTION
Mintlify has resolved the bug that prevented nested OpenAPI references in groups. This PR merges "documentation" and "API References" into a single page by moving the API reference under their respective sections.

![CleanShot 2025-05-29 at 10 12 14@2x](https://github.com/user-attachments/assets/e1b28dfc-efad-40cb-a97d-76107e4c956f)
