### PR TITLE
refactor: Use stable directory for OpenAPI Specs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -80,7 +80,7 @@
           {
             "group": "API Reference",
             "openapi": {
-              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml",
+              "source": "https://gleanwork.github.io/open-api/specs/final/indexing.yaml",
               "directory": "indexing/api"
             }
           },
@@ -116,7 +116,7 @@
           {
             "group": "API Reference",
             "openapi": {
-              "source": "https://gleanwork.github.io/open-api/specs/merged/glean-client-merged-code-samples-spec.yaml",
+              "source": "https://gleanwork.github.io/open-api/specs/final/client_rest.yaml",
               "directory": "client/api"
             }
           },
@@ -399,11 +399,11 @@
   "redirects": [
     {
       "source": "/oas/client",
-      "destination": "https://gleanwork.github.io/open-api/specs/merged/glean-client-merged-code-samples-spec.yaml"
+      "destination": "https://gleanwork.github.io/open-api/specs/final/client_rest.yaml"
     },
     {
       "source": "/oas/indexing",
-      "destination": "https://gleanwork.github.io/open-api/specs/merged/glean-index-merged-code-samples-spec.yaml"
+      "destination": "https://gleanwork.github.io/open-api/specs/final/indexing.yaml"
     },
     {
       "source": "/client/overview",


### PR DESCRIPTION
This updates the various references for the OpenAPI specs to use a new stable path for the "final" spec location. This allows us to continue iterating the processing steps in gleanwork/open-api without breaking the site deployment.

~Requires https://github.com/gleanwork/open-api/pull/38 to land (and deploy to gh-pages) first.~