### PR TITLE
chore(changelog): Add glean-api-client@0.6.0 breaking change entry

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -2,6 +2,76 @@
 title: Change Log
 icon: list-timeline
 ---
+
+<Update label="May 31, 2025">
+## Python API Client v0.6.0 - Breaking Changes
+
+**Breaking Change**: The Python API client now uses a namespaced package
+structure. All imports must be updated from `glean` to `glean.api_client`.
+
+### What Changed
+
+- Import paths have changed from `from glean import ...` to `from glean.api_client import ...`
+- This affects all classes including `Glean`, `models`, and other API components
+
+### Migration Required
+
+**Before:**
+```python
+from glean import Glean
+from glean import models
+from glean.models import Something
+from glean.exceptions import ApiError
+```
+
+**After:**
+```python
+from glean.api_client import Glean
+from glean.api_client import models
+from glean.api_client.models import Something
+from glean.api_client.exceptions import ApiError
+```
+
+### Automated Migration
+
+Use [ast-grep](https://ast-grep.github.io/) (a structural search and replace tool) to automatically update your Python code:
+
+```bash
+# First, update imports from glean submodules (e.g., from glean.models import ...)
+ast-grep --update-all \
+  --pattern 'from glean.$SUBMODULE import $$$REST' \
+  --rewrite 'from glean.api_client.$SUBMODULE import $$$REST' \
+  --lang python \
+  path/to/your/code
+
+# Then, update basic glean imports (e.g., from glean import ...)
+ast-grep --update-all \
+  --pattern 'from glean import $$$REST' \
+  --rewrite 'from glean.api_client import $$$REST' \
+  --lang python \
+  path/to/your/code
+
+# Finally, fix any double-nesting that may have occurred
+ast-grep --update-all \
+  --pattern 'from glean.api_client.api_client import $$$REST' \
+  --rewrite 'from glean.api_client import $$$REST' \
+  --lang python \
+  path/to/your/code
+```
+
+### Manual Steps
+
+If you prefer to update manually, search for all instances of:
+- `from glean import` → `from glean.api_client import`
+- `from glean.` (but not glean.api_client) → `from glean.api_client.`
+
+### Compatibility
+
+- This change affects all Python API client users
+- No functional changes to the API itself - only import paths
+- Ensure you're using the latest version of the Python API client package
+</Update>
+
 <Update label="May 27, 2025">
 ## Remote MCP Server (private beta) 
 With Glean’s [remote MCP server](https://docs.anthropic.com/en/docs/agents-and-tools/remote-mcp-servers), you can access Glean from MCP clients like Claude Desktop, Cursor, or Goose.


### PR DESCRIPTION
This adds a changelog entry for the changes in https://github.com/gleanwork/api-client-python/pull/23 which will be released in https://github.com/gleanwork/api-client-python/pull/25.

Steps to land things:

1. this PR
2. https://github.com/gleanwork/glean-developer-site/pull/60
3. https://github.com/gleanwork/api-client-python/pull/25
4. https://github.com/gleanwork/open-api/pull/41 (once ^ is published)
5. Trigger a rebuild of the mintlify site once ^ is published

---

## Python API Client v0.6.0 - Breaking Changes

**Breaking Change**: The Python API client now uses a namespaced package
structure. All imports must be updated from `glean` to `glean.api_client`.

### What Changed

- Import paths have changed from `from glean import ...` to `from glean.api_client import ...`
- This affects all classes including `Glean`, `models`, and other API components

### Migration Required

**Before:**
```python
from glean import Glean
from glean import models
from glean.models import Something
from glean.exceptions import ApiError
```

**After:**
```python
from glean.api_client import Glean
from glean.api_client import models
from glean.api_client.models import Something
from glean.api_client.exceptions import ApiError
```

### Automated Migration

Use [ast-grep](https://ast-grep.github.io/) (a structural search and replace tool) to automatically update your Python code:

```bash
# First, update imports from glean submodules (e.g., from glean.models import ...)
ast-grep --update-all \
  --pattern 'from glean.$SUBMODULE import $$$REST' \
  --rewrite 'from glean.api_client.$SUBMODULE import $$$REST' \
  --lang python \
  path/to/your/code

# Then, update basic glean imports (e.g., from glean import ...)
ast-grep --update-all \
  --pattern 'from glean import $$$REST' \
  --rewrite 'from glean.api_client import $$$REST' \
  --lang python \
  path/to/your/code

# Finally, fix any double-nesting that may have occurred
ast-grep --update-all \
  --pattern 'from glean.api_client.api_client import $$$REST' \
  --rewrite 'from glean.api_client import $$$REST' \
  --lang python \
  path/to/your/code
```

### Manual Steps

If you prefer to update manually, search for all instances of:
- `from glean import` → `from glean.api_client import`
- `from glean.` (but not glean.api_client) → `from glean.api_client.`

### Compatibility

- This change affects all Python API client users
- No functional changes to the API itself - only import paths
- Ensure you're using the latest version of the Python API client package
