### PR TITLE
chore: Add changelog entry for API reference code snippet updates

### DIFF
--- a/changelog.mdx
+++ b/changelog.mdx
@@ -4,6 +4,14 @@ icon: list-timeline
 ---
 
 <Update label="May 31, 2025">
+
+## Updates to API Reference Code Snippets
+
+Update the generated code snippets that are displayed throughout the [Client
+API Reference](https://developers.glean.com/client/api/) and [Indexing API
+Reference](https://developers.glean.com/indexing/api/) docs to include the
+required `instance` parameter in the API client constructor.
+
 ## Python API Client v0.6.0 - Breaking Changes
 
 **Breaking Change**: The Python API client now uses a namespaced package


### PR DESCRIPTION
Requires https://github.com/gleanwork/open-api/pull/42 to land and be deployed first.

Stacked on top of #62 (which needs to land first).