### PR TITLE
fix: Add `instance` parameter to API client initialization

### DIFF
--- a/api-clients.mdx
+++ b/api-clients.mdx
@@ -51,6 +51,7 @@ Glean provides official API clients for the following languages:
         # Initialize with API token
         with Glean(
             api_token=os.getenv("GLEAN_API_TOKEN", ""),
+            instance=os.getenv("GLEAN_INSTANCE", ""),
         ) as client:
             # Use the client...
             pass
@@ -64,6 +65,7 @@ Glean provides official API clients for the following languages:
 
         with Glean(
             api_token=os.getenv("GLEAN_API_TOKEN", ""),
+            instance=os.getenv("GLEAN_INSTANCE", ""),
         ) as client:
             # Send a chat message to Glean
             res = client.client.chat.create(messages=[
@@ -104,6 +106,7 @@ Glean provides official API clients for the following languages:
         // Initialize with API token
         const client = new Glean({
           apiToken: process.env.GLEAN_API_TOKEN,
+          instance: process.env.GLEAN_INSTANCE,
         });
         ```
       </Step>
@@ -115,6 +118,7 @@ Glean provides official API clients for the following languages:
         async function run() {
           const glean = new Glean({
             apiToken: process.env.GLEAN_API_TOKEN,
+            instance: process.env.GLEAN_INSTANCE,
           });
 
           const result = await glean.client.chat.create({
@@ -161,6 +165,7 @@ Glean provides official API clients for the following languages:
           // Initialize with API token
           client := glean.New(
             glean.WithAPIToken(os.Getenv("GLEAN_API_TOKEN")),
+            glean.WithInstance(os.Getenv("GLEAN_INSTANCE")),
           )
         }
         ```
@@ -180,6 +185,7 @@ Glean provides official API clients for the following languages:
           
           client := glean.New(
             glean.WithAPIToken(os.Getenv("GLEAN_API_TOKEN")),
+            glean.WithInstance(os.Getenv("GLEAN_INSTANCE")),
           )
           
           // Send a chat message to Glean
@@ -237,6 +243,7 @@ Glean provides official API clients for the following languages:
             // Initialize with API token
             Glean client = Glean.builder()
                 .apiToken(System.getenv("GLEAN_API_TOKEN"))
+                .instance(System.getenv("GLEAN_INSTANCE"))
                 .build();
           }
         }
@@ -254,6 +261,7 @@ Glean provides official API clients for the following languages:
             public static void main(String[] args) {
                 Glean apiClient = Glean.builder()
                     .apiToken(System.getenv("GLEAN_API_TOKEN"))
+                    .instance(System.getenv("GLEAN_INSTANCE"))
                     .build();
 
                 ChatResponse res = apiClient.client().chat().create()


### PR DESCRIPTION
This was fixed for the `https://develpers.glean.com/client/api/` and `https://developers.glean.com/indexing/api/` a few days ago, but these examples are not driven from the generated code samples just yet (so they have to be manually updated).