### PR TITLE
chore: Add mise.toml to make working in the repo easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ This repository contains the source code for [developers.glean.com](https://deve
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org/) (v14 or higher)
-- [pnpm](https://pnpm.io/) (recommended for package management)
+If you are using [mise](https://mise.jdx.dev/), you can run the following:
+
+- `mise trust`
+- `mise install`
+
+Otherwise, you can manually install/setup the following prerequisites:
+
+- [Node.js](https://nodejs.org/) (v24 or higher)
+- [pnpm](https://pnpm.io/) (v10)
+- [vale](https://vale.sh/) (for linting)
 
 ### Installation
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,4 @@
+[tools]
+node = "24"
+pnpm = "10"
+vale = "3"


### PR DESCRIPTION
[mise](https://mise.jdx.dev/) is certainly not required but a bunch of us use it and this project configuration makes working in this project a little bit nicer (ensuring we all use the same versions of node, pnpm, and vale).