### PR TITLE
feat: Setup prettier to ensure consistent formatting

### DIFF
--- a/.github/workflows/format-on-merge.yml
+++ b/.github/workflows/format-on-merge.yml
@@ -1,0 +1,40 @@
+name: Format on merge
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  lint-fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up mise
+        uses: jdx/mise-action@v2
+        with:
+          cache: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Fix code formatting
+        run: pnpm run lint:fix
+
+      - name: Commit formatting fixes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --global user.name 'github-actions[bot]'
+          git add .
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -m "Auto-fix formatting [skip ci]"
+            git push
+          fi

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+# Dependencies
+node_modules/
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Glean Developer Docs",
   "scripts": {
     "dev": "mint dev",
+    "lint": "prettier --check . --ignore-unknown",
+    "lint:fix": "prettier --write . --ignore-unknown",
     "test": "mint broken-links"
   },
   "keywords": [
@@ -20,6 +22,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "mint": "^4.1.40"
+    "mint": "^4.1.40",
+    "prettier": "^3.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       mint:
         specifier: ^4.1.40
         version: 4.1.40(@types/node@22.15.24)(@types/react@19.1.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      prettier:
+        specifier: ^3.5.3
+        version: 3.5.3
 
 packages:
 
@@ -2090,6 +2093,11 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -5606,6 +5614,8 @@ snapshots:
   pony-cause@1.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  prettier@3.5.3: {}
 
   progress@2.0.3: {}
 


### PR DESCRIPTION
Add `prettier` configuration to the repo. Folks using things like "format on save" today (prior to these changes) end up making quite a number of changes that are unrelated to their actual tweaks / modifications. Adding prettier here helps ensure that the repo stays in a consistent state.

Additionally, this adds a GitHub action to automatically fix code formatting on merge. This approach reduces friction for contributors by handling formatting automatically rather than requiring perfect adherence to style rules, which is especially beneficial for quick or drive-by contributions.