### PR TITLE
fix: Fix MDX parsing errors (close component after unindented list item)

### DIFF
--- a/actions/examples/google-calendar-events.mdx
+++ b/actions/examples/google-calendar-events.mdx
@@ -219,7 +219,10 @@ This guide walks through creating a retrieval action that allows Glean Assistant
 - Include timezone offsets in timestamp examples
 - Provide clear descriptions for search parameters
 - Consider default values for time ranges
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 <Card title="Response Handling" icon="exchange">
   Important considerations for handling calendar data:
@@ -228,7 +231,10 @@ This guide walks through creating a retrieval action that allows Glean Assistant
 - Handle timezone conversions appropriately
 - Consider pagination for large result sets
 - Process cancelled or declined events properly
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Authentication Considerations
 
@@ -239,7 +245,10 @@ This guide walks through creating a retrieval action that allows Glean Assistant
 - Request minimal scopes (readonly for calendar access)
 - Handle token refresh scenarios gracefully
 - Implement proper token storage and security
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Common Implementation Challenges
 
@@ -262,7 +271,10 @@ Watch out for these common issues:
    - Inefficient time range queries
    - Missing recurring event instances
    - Incomplete search term matching
-     </Warning>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Warning>
 
 ### Performance Optimization
 
@@ -273,7 +285,10 @@ Watch out for these common issues:
 - Implementing result caching
 - Limiting returned fields
 - Managing API quota usage
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Testing Strategy
 
@@ -285,7 +300,10 @@ Watch out for these common issues:
 - Different time zones and formats
 - Search functionality across event fields
 - Error handling and recovery
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ## Maintenance and Operations
 

--- a/actions/examples/google-docs-update.mdx
+++ b/actions/examples/google-docs-update.mdx
@@ -250,7 +250,10 @@ When preparing your OpenAPI specification for Google Docs integration:
 - Include examples of valid values
 - Explain the business context of each field
 - Clarify relationships between fields
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 <Card title="Schema Structure" icon="sitemap">
   Your schema structure affects how Glean Assistant interprets the API:
@@ -259,7 +262,10 @@ When preparing your OpenAPI specification for Google Docs integration:
 - Use meaningful field names that reflect their purpose
 - Leverage built-in formats (like `date-time`) where applicable
 - Include proper type constraints and validations
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Google Docs API Considerations
 
@@ -272,7 +278,10 @@ When working with the Google Docs API:
 - Use `replaceAllText` when you need to modify existing content
 - Consider using `index: 1` for insertions to maintain consistent behavior
 - Handle formatting through plain text markers (like asterisks for bullets)
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 <Card title="Error Handling" icon="bug">
   Common issues to watch for:
@@ -281,7 +290,10 @@ When working with the Google Docs API:
 - Rate limiting constraints
 - Invalid document IDs
 - Concurrent modification conflicts
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Authentication Setup Tips
 
@@ -292,7 +304,10 @@ When working with the Google Docs API:
 - Include appropriate error handling for token expiration
 - Consider implementing token rotation for security
 - Monitor token usage and implement proper logging
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Integration Best Practices
 
@@ -303,7 +318,10 @@ When working with the Google Docs API:
 - Include meaningful error messages
 - Allow users to preview changes before applying them
 - Maintain consistent behavior across different document types
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 <Card title="Performance Optimization" icon="gauge">
   Ensure efficient operation:
@@ -312,7 +330,10 @@ When working with the Google Docs API:
 - Implement appropriate timeouts
 - Cache frequently used document metadata
 - Monitor action execution times
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Common Pitfalls to Avoid
 
@@ -332,7 +353,10 @@ When working with the Google Docs API:
    - Incorrect service account configuration
 
 3. **Content Formatting** - Ignoring existing document structure - Not handling special characters properly - Incorrect handling of line breaks and paragraphs
-   </Warning>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Warning>
 
 ### Testing Recommendations
 
@@ -344,7 +368,10 @@ When working with the Google Docs API:
 - Edge cases in text replacement
 - Multiple user permission levels
 - Concurrent access situations
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ### Maintenance and Monitoring
 
@@ -356,7 +383,10 @@ When working with the Google Docs API:
 - Error rate tracking
 - User feedback collection
 - Performance metric monitoring
-  </Card>
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
+</Card>
 
 ## Troubleshooting
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -21,6 +21,7 @@ required `instance` parameter in the API client constructor.
 The Python API client now uses a namespaced package structure. All imports must be updated from `glean` to `glean.api_client`.
 
   <Accordion title="See more details...">
+
 ### What Changed
 
 - Import paths have changed from `from glean import ...` to `from glean.api_client import ...`
@@ -85,8 +86,11 @@ If you prefer to update manually, search for all instances of:
 - This change affects all Python API client users
 - No functional changes to the API itself - only import paths
 - Ensure you're using the latest version of the Python API client package
+
+{/* break up the unindented `<li>` and `</Component>` to avoid mdx parsing error */}
+
   </Accordion>
-  </Update>
+</Update>
 
 <Update label="May 27, 2025">
   ## Remote MCP Server (private beta) With Glean’s [remote MCP


### PR DESCRIPTION
In `.mdx` if you have the following:

```mdx
<div>
  <Card>
- Some item here
  </Card>
</div>
```

^ is a parse error:

```
17:3-17:10: Expected the closing tag `</Card>` either after the end of `listItem` (17:10) or another opening tag after the start of `listItem` (16:1)
```

This PR adds a comment in all of the locations where we have that issue, so that there is at least one linebreak between the end of the list item and the close of the component. 