### PR TITLE
fix: Incorrect reference to instance placeholder

### DIFF
--- a/client/chat.mdx
+++ b/client/chat.mdx
@@ -8,7 +8,7 @@ icon: 'message-bot'
 
 The Glean Chat API provides a programmatic interface to interact with the Glean chat system. It allows developers to send and receive messages and handle conversation streams.
 
-The Glean Chat API utilizes a streaming POST endpoint at `https://<your-domain>-be.glean.com/rest/api/v1/chat` for continuous, real-time conversational interactions. Remember to replace `<your-domain-be>` with your specific domain.
+The Glean Chat API utilizes a streaming POST endpoint at `https://<your-domain>-be.glean.com/rest/api/v1/chat` for continuous, real-time conversational interactions. Remember to replace `<your-domain>` with your specific domain.
 
 ## Setup
 


### PR DESCRIPTION
We call it out as:

```https://<your-domain>-be.glean.com/rest/api/v1/chat```

But then we state to replace it as `<your-domain-be>` (it should reference `<your-domain>`).

Fixes https://github.com/gleanwork/glean-developer-site/issues/50