### PR TITLE
fix(ci): Fix `link-rot` CI check

### DIFF
--- a/agents/agents-api.mdx
+++ b/agents/agents-api.mdx
@@ -18,10 +18,10 @@ The Agents API enables:
 ### Agent Builder
 
 Users in your organization can create and configure agents through Glean's no-code/low-code Agent Builder interface.
-![Agent Builder](images/agent-builder.png)
+![Agent Builder](/agents/images/agent-builder.png)
 
 ### Considerations
 
 - The Agents API implements a subset of the [LangChain Agent Protocol](https://langchain-ai.github.io/agent-protocol/api.html#tag/agents), specifically [Runs](https://langchain-ai.github.io/agent-protocol/api.html#tag/runs) and [Agents](https://langchain-ai.github.io/agent-protocol/api.html#tag/agents), ensuring compatibility with any agent runtime that supports this standard.
 - You can look up an agent ID by examining the Agent Builder URL.
-  ![Agent ID in Agent Builder](images/agent-id.png)
+  ![Agent ID in Agent Builder](/agents/images/agent-id.png)


### PR DESCRIPTION
CI failure was introduced by #78. The original links did work properly, but the CI check was failing (both in the original PR and in subsequent ones).

/cc @steve-calvert-glean @andriy-mysyk-glean 