### PR TITLE
feat(ci): Add GitHub Actions workflow to trigger a redeployment

### DIFF
--- a/.github/workflows/trigger-redeploy.yml
+++ b/.github/workflows/trigger-redeploy.yml
@@ -1,0 +1,48 @@
+name: Trigger Redeploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for redeployment (optional)'
+        required: false
+        default: 'Manual trigger'
+
+permissions:
+  contents: write
+
+jobs:
+  trigger-redeploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.FORMATTING_TOKEN }}
+
+      - name: Update redeploy trigger file
+        run: |
+          # Get current timestamp with seconds
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          REASON="${{ github.event.inputs.reason }}"
+
+          # Create the content for the trigger file
+          cat > _redeploy-trigger.mdx << EOF
+          ---
+          noindex: true
+          ---
+
+          Last updated: $TIMESTAMP
+          Reason: $REASON
+          Triggered by: ${{ github.actor }}
+          Run ID: ${{ github.run_id }}
+          EOF
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "github-actions[bot]"
+          git add _redeploy-trigger.mdx
+          git commit -m "Trigger redeploy: ${{ github.event.inputs.reason || 'Manual trigger' }} [skip ci]"
+          git push

--- a/_redeploy-trigger.mdx
+++ b/_redeploy-trigger.mdx
@@ -1,0 +1,5 @@
+---
+noindex: true
+---
+
+Last updated: 2024-12-28T08:00:00Z


### PR DESCRIPTION
Add GitHub workflow to manually trigger redeployments. Includes workflow dispatch trigger and automatic commit of timestamp updates to `_redeploy-trigger.mdx` file. The `_redeploy-trigger.mdx` file is explictly excluded from search indexing and whatnot (see [Hidden Pages](https://mintlify.com/docs/guides/hidden-pages#search-and-seo)).