### PR TITLE
fix: Adds beta labels back to Agent API pages (they were broken with the agent docs renames)

### DIFF
--- a/_overrides/beta_endpoints/beta-endpoints.js
+++ b/_overrides/beta_endpoints/beta-endpoints.js
@@ -8,11 +8,11 @@
 const betaWarningText =
   'This endpoint is in Beta. Expect changes and instability.';
 const betaPaths = [
-  '/api-reference/client/agents/get-agent',
-  '/api-reference/client/agents/get-agent-schemas',
-  '/api-reference/client/agents/search-agents',
-  '/api-reference/client/agents/create-run-stream-output',
-  '/api-reference/client/agents/create-run-wait-for-output',
+  '/client/api/agents/retrieve-an-agent',
+  '/client/api/agents/list-an-agents-schemas',
+  '/client/api/agents/search-agents',
+  '/client/api/agents/create-an-agent-run-and-stream-the-response',
+  '/client/api/agents/create-an-agent-run-and-wait-for-the-response',
 ];
 
 // Add callout warning for beta endpoints.


### PR DESCRIPTION
This pull request updates the file `_overrides/beta_endpoints/beta-endpoints.js` (renamed from `_overrides/alpha_endpoints/beta-endpoints.js`) to reflect changes in API endpoint paths and improve clarity in naming conventions.

### Changes to API endpoint paths:

* Updated the paths in the `betaPaths` array to use clearer and more descriptive naming conventions for the endpoints:
  - Example: `/api-reference/client/agents/get-agent` is now `/client/api/agents/retrieve-an-agent`.

### File rename:

* Renamed the file from `_overrides/alpha_endpoints/beta-endpoints.js` to `_overrides/beta_endpoints/beta-endpoints.js` to align with the current naming convention.