### PR TITLE
chore: Adds CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @gleanwork/gleanwork-reviewers


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds `@gleanwork/gleanwork-reviewers` as the code owners for all files.