### PR TITLE
fix: Fixes yarn version in mise

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "22.16.0"
-yarn = "lts"
+yarn = "3.8.7"


### PR DESCRIPTION
This pull request updates the `mise.toml` configuration file to specify a more precise version of Yarn.

* [`mise.toml`](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L3-R3): Changed the Yarn version from "lts" to "3.8.7" to ensure compatibility and consistency across environments.