### PR TITLE
fix broken links

### DIFF
--- a/docs/agents/agents.md
+++ b/docs/agents/agents.md
@@ -58,7 +58,7 @@ Glean's official LangChain integration enables you to build powerful AI agents t
 
 #### API Tokens
 
-You'll need Glean [API credentials](/docs/guides/client/authentication/glean-issued), and specifically a [user-scoped API token](docs/guides/client/authentication/glean-issued#selecting-permissions-and-scopes). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
+You'll need Glean [API credentials](/guides/client/authentication/glean-issued), and specifically a [user-scoped API token](/guides/client/authentication/glean-issued#selecting-permissions-and-scopes). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
 
 #### Configure Environment Variables
 

--- a/docs/guides/client/authentication/overview.mdx
+++ b/docs/guides/client/authentication/overview.mdx
@@ -2,7 +2,7 @@
 title: Overview
 ---
 
-The developer-ready Client API endpoints can be accessed via one of two types of Bearer tokens: [OAuth Access Tokens](/docs/guides/client/authentication/oauth) issued by an SSO provider or [Glean-issued tokens](#glean-issued-tokens). Both methods can be used concurrently, but we recommend using OAuth access tokens for a more secure authentication for Client API requests, scoped to the individual user it's issued to.
+The developer-ready Client API endpoints can be accessed via one of two types of Bearer tokens: [OAuth Access Tokens](/guides/client/authentication/oauth) issued by an SSO provider or [Glean-issued tokens](/guides/client/authentication/glean-issued). Both methods can be used concurrently, but we recommend using OAuth access tokens for a more secure authentication for Client API requests, scoped to the individual user it's issued to.
 
 ## Navigating to Client API Settings
 


### PR DESCRIPTION
### Code changes:
* The revisions involve correcting the links in the API token section of the `agents.md` file and the authentication overview in the `overview.mdx` file, ensuring that they point to the correct paths. In particular, the changes remove "docs" from the links, changing `/docs/guides/client/authentication/glean-issued` to `/guides/client/authentication/glean-issued`, which clarifies the resource locations. 

This adjustment improves the accessibility of the API credentials and token information for the users, enhancing their ability to navigate to the necessary resources effectively.
