### PR TITLE
internal: Updates styles to better match exiting CSS

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -40,7 +40,7 @@ const config: Config = {
 
   presets: [
     [
-      'classic',
+      '@docusaurus/preset-classic',
       {
         docs: {
           sidebarPath: './sidebars.ts',
@@ -81,12 +81,6 @@ const config: Config = {
         src: 'img/glean-developer-logo-light.svg',
       },
       items: [
-        {
-          type: 'docSidebar',
-          sidebarId: 'docSidebar',
-          position: 'left',
-          label: 'Documentation',
-        },
         {
           to: '/changelog',
           label: 'Changelog',

--- a/src/components/Accordion/styles.module.css
+++ b/src/components/Accordion/styles.module.css
@@ -54,7 +54,7 @@
   
   .accordionTitle {
     margin: 0;
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 600;
     color: #111827;
     line-height: 1.4;
@@ -62,7 +62,7 @@
   
   .accordionDescription {
     margin: 4px 0 0 0;
-    font-size: 14px;
+    font-size: 12px;
     color: #6b7280;
     line-height: 1.4;
   }
@@ -112,7 +112,7 @@
     margin: 16px 0;
     overflow-x: auto;
     font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
-    font-size: 14px;
+    font-size: 12px;
     line-height: 1.4;
   }
   
@@ -121,7 +121,7 @@
     padding: 2px 4px;
     border-radius: 3px;
     font-family: "Monaco", "Menlo", "Ubuntu Mono", monospace;
-    font-size: 13px;
+    font-size: 12px;
   }
   
   .accordionContentInner pre code {

--- a/src/components/ResponseField/styles.module.css
+++ b/src/components/ResponseField/styles.module.css
@@ -13,7 +13,7 @@
   
   .fieldName {
     font-weight: 600;
-    font-size: 16px;
+    font-size: 14px;
     color: #059669;
     font-family: "SF Mono", "Monaco", "Inconsolata", "Roboto Mono", "Source Code Pro", monospace;
   }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -25,7 +25,16 @@
   /* Accent color (light yellow/green) */
   --ifm-color-accent: #d8fd49; /* hover highlight color */
   
-  --ifm-code-font-size: 95%;
+  --ifm-font-size-base: 87.5%;
+  --ifm-code-font-size: 85%;
+  
+  --ifm-h1-font-size: 2rem;
+  --ifm-h2-font-size: 1.6rem;
+  --ifm-h3-font-size: 1.3rem;
+  --ifm-h4-font-size: 1.1rem;
+  --ifm-h5-font-size: 1rem;
+  --ifm-h6-font-size: 0.9rem;
+
   --docusaurus-highlighted-code-line-bg: rgba(216, 253, 73, 0.15); /* code block highlight color */
   
   /* Font family overrides */
@@ -422,11 +431,28 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
+
+.menu__list .menu__list {
+  padding-left: 0;
+}
 /* Sidebar Styling */
 /* Menu links should not have underlines */
 .menu__link {
   text-decoration: none !important;
-  color: rgb(var(--gray-700));
+  color: var(--ifm-color-emphasis-700);
+}
+
+.theme-doc-sidebar-item-category-level-1 {
+  margin-bottom: 1rem;
+}
+
+.theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link {
+  text-transform: uppercase;
+  font-weight: bold;
+  letter-spacing: .5px;
+  line-height: 16px;
+  text-transform: uppercase;
+  font-size: 12px;
 }
 
 /* Remove background on hover, only darken text */
@@ -450,7 +476,7 @@ h1, h2, h3, h4, h5, h6 {
   background-color: transparent !important;
 }
 
-/* Add vertical line for nested menu items */
+/* Add vertical line for nested menu items
 .menu__list .menu__list {
   position: relative;
 }
@@ -463,7 +489,7 @@ h1, h2, h3, h4, h5, h6 {
   bottom: 0;
   width: 1px;
   background-color: var(--ifm-color-emphasis-300);
-}
+} */
 
 .menu__link--sublist-caret:after,
 .menu__caret::before {
@@ -501,7 +527,8 @@ h1, h2, h3, h4, h5, h6 {
 .markdown h1,
 article h1,
 .main-wrapper h1 {
-  font-size: 2.5rem;
+  font-size: 2rem;
+  letter-spacing: 0.025em;
   font-weight: 700;
   line-height: 1.2;
   margin-bottom: 1.5rem;


### PR DESCRIPTION
This pull request introduces updates to the Docusaurus configuration, adjusts font sizes across various components, and refines the CSS for improved styling and consistency. The most significant changes include switching to the `@docusaurus/preset-classic` preset, reducing font sizes for better readability, and enhancing the styling of the sidebar and headings.

![Screenshot 2025-06-24 at 8 57 39 AM](https://github.com/user-attachments/assets/082d38fa-b1b0-4090-87fa-a44ef186151f)

### Docusaurus Configuration Updates:
* Updated `docusaurus.config.ts` to use `@docusaurus/preset-classic` instead of `classic`.
* Removed the "Documentation" link from the navbar in `docusaurus.config.ts`.

### Font Size Adjustments:
* Reduced font sizes in `src/components/Accordion/styles.module.css` for titles, descriptions, and code blocks. [[1]](diffhunk://#diff-f744d7be46844e82c7831e429efec63624de1a86c5867b889e8ee65919179e10L57-R65) [[2]](diffhunk://#diff-f744d7be46844e82c7831e429efec63624de1a86c5867b889e8ee65919179e10L115-R115) [[3]](diffhunk://#diff-f744d7be46844e82c7831e429efec63624de1a86c5867b889e8ee65919179e10L124-R124)
* Adjusted the font size of field names in `src/components/ResponseField/styles.module.css`.
* Updated base font size and heading sizes in `src/css/custom.css` for better scaling and consistency. [[1]](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fL28-R37) [[2]](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fL504-R531)

### Sidebar and Styling Enhancements:
* Improved sidebar styling in `src/css/custom.css` by adjusting margins, text transformation, and font weights.
* Refined nested menu item styling and removed unnecessary vertical line styling. [[1]](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fL453-R479) [[2]](diffhunk://#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570fL466-R492)