### PR TITLE
remove grey bg when hovering over sidebar items

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -446,6 +446,13 @@ h1, h2, h3, h4, h5, h6 {
   margin-bottom: 1rem;
 }
 
+.menu__list-item-collapsible:hover,
+.menu__list-item-collapsible:active,
+.menu__list-item-collapsible:focus-within,
+.menu__list-item-collapsible.menu__list-item-collapsible--active {
+  background: transparent;
+}
+
 .theme-doc-sidebar-item-category-level-1 > .menu__list-item-collapsible > .menu__link {
   text-transform: uppercase;
   font-weight: bold;


### PR DESCRIPTION
### Code changes:
* The change removes the grey background from sidebar items when hovered, active, focused, or when they are in an active state, setting the background to transparent instead.


<img width="284" alt="Screenshot 2025-06-24 at 1 31 48 PM" src="https://github.com/user-attachments/assets/d43cc9d9-3b7e-4b75-ab20-8121d7a614a1" />
