### PR TITLE
chore: Remove 'edit this page' links

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,10 +44,6 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',
           docItemComponent: '@theme/ApiItem',
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
This pull request removes the `editUrl` configuration from the `docusaurus.config.ts` file, which previously linked to the Docusaurus GitHub repository. This change simplifies the configuration by eliminating the "edit this page" links in the generated documentation.

Key change:

* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784L47-L50): Removed the `editUrl` field under the `Config` object, which previously pointed to the Docusaurus GitHub repository. This removes the "edit this page" links from the documentation.