### PR TITLE
fix: Removes sidebar classes for createauthtoken

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -872,7 +872,6 @@ const sidebars: SidebarsConfig = {
                 type: "doc",
                 id: "api/client-api/authentication/createauthtoken",
                 label: "Create authentication token",
-                className: "api-method post",
               },
             ],
           },


### PR DESCRIPTION
This pull request includes a small change to the `sidebars.ts` file. The change removes the `className` property with the value `"api-method post"` from the `Create authentication token` documentation entry.