### PR TITLE
fix(changelog): fix most of the links in changelog

### DIFF
--- a/changelog/entries/2025-02-19-update-permissions.md
+++ b/changelog/entries/2025-02-19-update-permissions.md
@@ -4,9 +4,9 @@ title: Update Permissions Endpoint
 categories: [Indexing API]
 ---
 
-  [`/updatepermissions`](https://developers.glean.com/api-reference/indexing/documents/update-document-permissions)
+  [`/updatepermissions`](../api/indexing-api/update-document-permissions)
   - Beta launch of new endpoint to update document permissions -
-  [`/debug/[datasource]/documents`](https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents)
+  [`/debug/[datasource]/documents`](../api/indexing-api/beta-get-information-of-a-batch-of-documents)
   - Beta launch of new troubleshooting endpoint for batch queries
 
   {/* truncate */}

--- a/changelog/entries/2025-03-05-general-updates.md
+++ b/changelog/entries/2025-03-05-general-updates.md
@@ -6,6 +6,6 @@ categories: [LangChain SDK]
 
 Added LangChain SDK for Python on [GitHub](https://github.com/gleanwork/langchain-glean). This SDK provides a simple interface for interacting with Glean's search and chat capabilities when using LangChain.
 
-Visit the [Agents](/guides/agents/) for more information.
+Visit the [Agents](../guides/agents/) for more information.
 
 {/* truncate */}

--- a/changelog/entries/2025-03-11-add-mcp.md
+++ b/changelog/entries/2025-03-11-add-mcp.md
@@ -8,6 +8,6 @@ Added a Model Context Protocol (MCP) server implementation for Glean's search an
 
 This server provides a standardized interface for AI models to interact with Glean's content search and conversational AI features through stdio communication.
 
-Visit the [Agents](/guides/agents/) for more information.
+Visit the [Agents](../guides/agents/) for more information.
 
 {/* truncate */}

--- a/changelog/entries/2025-03-26-update-dev-site.md
+++ b/changelog/entries/2025-03-26-update-dev-site.md
@@ -9,7 +9,7 @@ The developer site has been updated with a new look, content, and features. Some
 - This documentation site is now open sourced on [GitHub](https://github.com/gleanwork/glean-developer-site)
 - This changelog page, which gives you a single place to see updates across the platform.
 - Ability to switch between light and dark mode.
-- A new [API Clients](/libraries/api-clients) page with documentation for all available API Clients.
+- A new [API Clients](../libraries/api-clients) page with documentation for all available API Clients.
 - A list of [community projects and resources](/community) to help you get started with Glean.
 - Each API has its own documentation page with detailed information.
 

--- a/changelog/entries/2025-04-17-placeholder.md
+++ b/changelog/entries/2025-04-17-placeholder.md
@@ -4,8 +4,8 @@ title: Debug Endpoints Permission Status
 categories: [Indexing API]
 ---
 
-- [`/debug/\{datasource\}/document`](https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-document-information) - New response field `permissionIdentityStatus` under `status`: Provides information regarding upload status of users and groups specified in document permissions
+- [`/debug/{datasource}/document`](../api/indexing-api/beta-get-document-information) - New response field `permissionIdentityStatus` under `status`: Provides information regarding upload status of users and groups specified in document permissions
 
 {/* truncate */}
 
-- [`/debug/\{datasource\}/documents`](https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents) - New response field `permissionIdentityStatus` under `status`: Provides information regarding upload status of users and groups specified in document permissions
+- [`/debug/{datasource}/documents`](../api/indexing-api/beta-get-document-information) - New response field `permissionIdentityStatus` under `status`: Provides information regarding upload status of users and groups specified in document permissions

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -8,8 +8,8 @@
       "categories": [
         "Indexing API"
       ],
-      "summary": "<ul>\n<li><a href=\"https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-document-information\"><code>/debug/\\{datasource\\}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</li>\n</ul>\n",
-      "fullContent": "<ul>\n<li><p><a href=\"https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-document-information\"><code>/debug/\\{datasource\\}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>\n</li>\n<li><p><a href=\"https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents\"><code>/debug/\\{datasource\\}/documents</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>\n</li>\n</ul>\n",
+      "summary": "<ul>\n<li><a href=\"../api/indexing-api/beta-get-document-information\"><code>/debug/{datasource}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</li>\n</ul>\n",
+      "fullContent": "<ul>\n<li><p><a href=\"../api/indexing-api/beta-get-document-information\"><code>/debug/{datasource}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>\n</li>\n<li><p><a href=\"../api/indexing-api/beta-get-document-information\"><code>/debug/{datasource}/documents</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>\n</li>\n</ul>\n",
       "hasTruncation": true,
       "fileName": "2025-04-17-placeholder.md"
     },
@@ -22,7 +22,7 @@
         "Website"
       ],
       "summary": "<p>The developer site has been updated with a new look, content, and features. Some new features include:</p>\n",
-      "fullContent": "<p>The developer site has been updated with a new look, content, and features. Some new features include:</p>\n<ul>\n<li>This documentation site is now open sourced on <a href=\"https://github.com/gleanwork/glean-developer-site\">GitHub</a></li>\n<li>This changelog page, which gives you a single place to see updates across the platform.</li>\n<li>Ability to switch between light and dark mode.</li>\n<li>A new <a href=\"/libraries/api-clients\">API Clients</a> page with documentation for all available API Clients.</li>\n<li>A list of <a href=\"/community\">community projects and resources</a> to help you get started with Glean.</li>\n<li>Each API has its own documentation page with detailed information.</li>\n</ul>\n<p>And much more...</p>\n",
+      "fullContent": "<p>The developer site has been updated with a new look, content, and features. Some new features include:</p>\n<ul>\n<li>This documentation site is now open sourced on <a href=\"https://github.com/gleanwork/glean-developer-site\">GitHub</a></li>\n<li>This changelog page, which gives you a single place to see updates across the platform.</li>\n<li>Ability to switch between light and dark mode.</li>\n<li>A new <a href=\"../libraries/api-clients\">API Clients</a> page with documentation for all available API Clients.</li>\n<li>A list of <a href=\"../community\">community projects and resources</a> to help you get started with Glean.</li>\n<li>Each API has its own documentation page with detailed information.</li>\n</ul>\n<p>And much more...</p>\n",
       "hasTruncation": true,
       "fileName": "2025-03-26-update-dev-site.md"
     },
@@ -34,8 +34,8 @@
       "categories": [
         "MCP"
       ],
-      "summary": "<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href=\"https://github.com/gleanwork/mcp-server\">GitHub</a>.</p>\n<p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>\n<p>Visit the <a href=\"/guides/agents/\">Agents</a> for more information.</p>\n",
-      "fullContent": "<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href=\"https://github.com/gleanwork/mcp-server\">GitHub</a>.</p>\n<p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>\n<p>Visit the <a href=\"/guides/agents/\">Agents</a> for more information.</p>\n",
+      "summary": "<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href=\"https://github.com/gleanwork/mcp-server\">GitHub</a>.</p>\n<p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>\n<p>Visit the <a href=\"../guides/agents/\">Agents</a> for more information.</p>\n",
+      "fullContent": "<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href=\"https://github.com/gleanwork/mcp-server\">GitHub</a>.</p>\n<p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>\n<p>Visit the <a href=\"../guides/agents/\">Agents</a> for more information.</p>\n",
       "hasTruncation": true,
       "fileName": "2025-03-11-add-mcp.md"
     },
@@ -47,8 +47,8 @@
       "categories": [
         "LangChain SDK"
       ],
-      "summary": "<p>Added LangChain SDK for Python on <a href=\"https://github.com/gleanwork/langchain-glean\">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>\n<p>Visit the <a href=\"/guides/agents/\">Agents</a> for more information.</p>\n",
-      "fullContent": "<p>Added LangChain SDK for Python on <a href=\"https://github.com/gleanwork/langchain-glean\">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>\n<p>Visit the <a href=\"/guides/agents/\">Agents</a> for more information.</p>\n",
+      "summary": "<p>Added LangChain SDK for Python on <a href=\"https://github.com/gleanwork/langchain-glean\">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>\n<p>Visit the <a href=\"../guides/agents/\">Agents</a> for more information.</p>\n",
+      "fullContent": "<p>Added LangChain SDK for Python on <a href=\"https://github.com/gleanwork/langchain-glean\">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>\n<p>Visit the <a href=\"../guides/agents/\">Agents</a> for more information.</p>\n",
       "hasTruncation": true,
       "fileName": "2025-03-05-general-updates.md"
     },
@@ -60,8 +60,8 @@
       "categories": [
         "Indexing API"
       ],
-      "summary": "<p><a href=\"https://developers.glean.com/api-reference/indexing/documents/update-document-permissions\"><code>/updatepermissions</code></a></p>\n<ul>\n<li>Beta launch of new endpoint to update document permissions -<br>  <a href=\"https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents\"><code>/debug/[datasource]/documents</code></a></li>\n<li>Beta launch of new troubleshooting endpoint for batch queries</li>\n</ul>\n",
-      "fullContent": "<p><a href=\"https://developers.glean.com/api-reference/indexing/documents/update-document-permissions\"><code>/updatepermissions</code></a></p>\n<ul>\n<li>Beta launch of new endpoint to update document permissions -<br>  <a href=\"https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents\"><code>/debug/[datasource]/documents</code></a></li>\n<li>Beta launch of new troubleshooting endpoint for batch queries</li>\n</ul>\n",
+      "summary": "<p><a href=\"../api/indexing-api/update-document-permissions\"><code>/updatepermissions</code></a></p>\n<ul>\n<li>Beta launch of new endpoint to update document permissions -<br>  <a href=\"../api/indexing-api/beta-get-information-of-a-batch-of-documents\"><code>/debug/[datasource]/documents</code></a></li>\n<li>Beta launch of new troubleshooting endpoint for batch queries</li>\n</ul>\n",
+      "fullContent": "<p><a href=\"../api/indexing-api/update-document-permissions\"><code>/updatepermissions</code></a></p>\n<ul>\n<li>Beta launch of new endpoint to update document permissions -<br>  <a href=\"../api/indexing-api/beta-get-information-of-a-batch-of-documents\"><code>/debug/[datasource]/documents</code></a></li>\n<li>Beta launch of new troubleshooting endpoint for batch queries</li>\n</ul>\n",
       "hasTruncation": true,
       "fileName": "2025-02-19-update-permissions.md"
     }
@@ -72,6 +72,6 @@
     "MCP",
     "Website"
   ],
-  "generatedAt": "2025-07-01T16:02:00.954Z",
+  "generatedAt": "2025-07-02T00:32:31.132Z",
   "totalEntries": 5
 }

--- a/static/changelog.xml
+++ b/static/changelog.xml
@@ -4,7 +4,7 @@
         <title>Glean Developer Changelog</title>
         <link>https://gleanwork.github.io/glean-developer-site-wip</link>
         <description>Updates and changes to the Glean Developer Platform</description>
-        <lastBuildDate>Tue, 01 Jul 2025 16:02:00 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 02 Jul 2025 00:32:31 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Glean Developer Site</generator>
         <language>en</language>
@@ -20,13 +20,13 @@
             <guid isPermaLink="false">2025-04-17-placeholder</guid>
             <pubDate>Thu, 17 Apr 2025 00:00:00 GMT</pubDate>
             <description><![CDATA[<ul>
-<li><a href="https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-document-information"><code>/debug/\{datasource\}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</li>
+<li><a href="../api/indexing-api/beta-get-document-information"><code>/debug/{datasource}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</li>
 </ul>
 ]]></description>
             <content:encoded><![CDATA[<ul>
-<li><p><a href="https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-document-information"><code>/debug/\{datasource\}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>
+<li><p><a href="../api/indexing-api/beta-get-document-information"><code>/debug/{datasource}/document</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>
 </li>
-<li><p><a href="https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents"><code>/debug/\{datasource\}/documents</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>
+<li><p><a href="../api/indexing-api/beta-get-document-information"><code>/debug/{datasource}/documents</code></a> - New response field <code>permissionIdentityStatus</code> under <code>status</code>: Provides information regarding upload status of users and groups specified in document permissions</p>
 </li>
 </ul>
 ]]></content:encoded>
@@ -44,8 +44,8 @@
 <li>This documentation site is now open sourced on <a href="https://github.com/gleanwork/glean-developer-site">GitHub</a></li>
 <li>This changelog page, which gives you a single place to see updates across the platform.</li>
 <li>Ability to switch between light and dark mode.</li>
-<li>A new <a href="/libraries/api-clients">API Clients</a> page with documentation for all available API Clients.</li>
-<li>A list of <a href="/community">community projects and resources</a> to help you get started with Glean.</li>
+<li>A new <a href="../libraries/api-clients">API Clients</a> page with documentation for all available API Clients.</li>
+<li>A list of <a href="../community">community projects and resources</a> to help you get started with Glean.</li>
 <li>Each API has its own documentation page with detailed information.</li>
 </ul>
 <p>And much more...</p>
@@ -59,11 +59,11 @@
             <pubDate>Tue, 11 Mar 2025 00:00:00 GMT</pubDate>
             <description><![CDATA[<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href="https://github.com/gleanwork/mcp-server">GitHub</a>.</p>
 <p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>
-<p>Visit the <a href="/guides/agents/">Agents</a> for more information.</p>
+<p>Visit the <a href="../guides/agents/">Agents</a> for more information.</p>
 ]]></description>
             <content:encoded><![CDATA[<p>Added a Model Context Protocol (MCP) server implementation for Glean&#39;s search and chat capabilities on <a href="https://github.com/gleanwork/mcp-server">GitHub</a>.</p>
 <p>This server provides a standardized interface for AI models to interact with Glean&#39;s content search and conversational AI features through stdio communication.</p>
-<p>Visit the <a href="/guides/agents/">Agents</a> for more information.</p>
+<p>Visit the <a href="../guides/agents/">Agents</a> for more information.</p>
 ]]></content:encoded>
             <category>MCP</category>
         </item>
@@ -73,10 +73,10 @@
             <guid isPermaLink="false">2025-03-05-general-updates</guid>
             <pubDate>Wed, 05 Mar 2025 00:00:00 GMT</pubDate>
             <description><![CDATA[<p>Added LangChain SDK for Python on <a href="https://github.com/gleanwork/langchain-glean">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>
-<p>Visit the <a href="/guides/agents/">Agents</a> for more information.</p>
+<p>Visit the <a href="../guides/agents/">Agents</a> for more information.</p>
 ]]></description>
             <content:encoded><![CDATA[<p>Added LangChain SDK for Python on <a href="https://github.com/gleanwork/langchain-glean">GitHub</a>. This SDK provides a simple interface for interacting with Glean&#39;s search and chat capabilities when using LangChain.</p>
-<p>Visit the <a href="/guides/agents/">Agents</a> for more information.</p>
+<p>Visit the <a href="../guides/agents/">Agents</a> for more information.</p>
 ]]></content:encoded>
             <category>LangChain SDK</category>
         </item>
@@ -85,15 +85,15 @@
             <link>https://gleanwork.github.io/glean-developer-site-wip/changelog#update-permissions</link>
             <guid isPermaLink="false">2025-02-19-update-permissions</guid>
             <pubDate>Wed, 19 Feb 2025 00:00:00 GMT</pubDate>
-            <description><![CDATA[<p><a href="https://developers.glean.com/api-reference/indexing/documents/update-document-permissions"><code>/updatepermissions</code></a></p>
+            <description><![CDATA[<p><a href="../api/indexing-api/update-document-permissions"><code>/updatepermissions</code></a></p>
 <ul>
-<li>Beta launch of new endpoint to update document permissions -<br>  <a href="https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents"><code>/debug/[datasource]/documents</code></a></li>
+<li>Beta launch of new endpoint to update document permissions -<br>  <a href="../api/indexing-api/beta-get-information-of-a-batch-of-documents"><code>/debug/[datasource]/documents</code></a></li>
 <li>Beta launch of new troubleshooting endpoint for batch queries</li>
 </ul>
 ]]></description>
-            <content:encoded><![CDATA[<p><a href="https://developers.glean.com/api-reference/indexing/documents/update-document-permissions"><code>/updatepermissions</code></a></p>
+            <content:encoded><![CDATA[<p><a href="../api/indexing-api/update-document-permissions"><code>/updatepermissions</code></a></p>
 <ul>
-<li>Beta launch of new endpoint to update document permissions -<br>  <a href="https://developers.glean.com/api-reference/indexing/troubleshooting/beta:-get-information-of-a-batch-of-documents"><code>/debug/[datasource]/documents</code></a></li>
+<li>Beta launch of new endpoint to update document permissions -<br>  <a href="../api/indexing-api/beta-get-information-of-a-batch-of-documents"><code>/debug/[datasource]/documents</code></a></li>
 <li>Beta launch of new troubleshooting endpoint for batch queries</li>
 </ul>
 ]]></content:encoded>


### PR DESCRIPTION
The community link `/community` is still broken because the page seems
to be missing.
