### PR TITLE
chore: Adds vercel analytics

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -187,6 +187,13 @@ const config: Config = {
         enableAnonymousAuth: true,
       },
     ],
+    [
+      'vercel-analytics',
+      {
+        debug: true,
+        mode: 'auto',
+      },
+    ],
     // Conditionally include OpenAPI docs plugin
     ...(shouldGenerateApiDocs ? [[
       'docusaurus-plugin-openapi-docs',

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -116,13 +116,6 @@ const config: Config = {
     },
     headTags: [
       {
-        tagName: 'script',
-        attributes: {
-          defer: true,
-          src: 'https://app.glean.com/embedded-search-latest.min.js',
-        },
-      },
-      {
         tagName: 'link',
         attributes: {
           rel: 'alternate',
@@ -181,7 +174,7 @@ const config: Config = {
         searchOptions: {
           backend: 'https://glean-public-external-be.glean.com',
           webAppUrl: 'https://glean-public-external.glean.com',
-          datasourcesFilter: ['webc7bwoqqgleandeveloperdocsnew'],
+          datasourcesFilter: ['webxtp3t2lgleandeveloperdocs'],
         },
         chatOptions: false,
         enableAnonymousAuth: true,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@docusaurus/core": "^3.8.1",
     "@docusaurus/plugin-client-redirects": "^3.8.1",
     "@docusaurus/plugin-content-docs": "^3.8.1",
+    "@docusaurus/plugin-vercel-analytics": "^3.8.1",
     "@docusaurus/preset-classic": "^3.8.1",
     "@docusaurus/theme-classic": "^3.8.1",
     "@docusaurus/theme-common": "^3.8.1",

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -229,6 +229,6 @@
     "SDK",
     "Website"
   ],
-  "generatedAt": "2025-07-03T16:48:28.549Z",
+  "generatedAt": "2025-07-03T22:42:59.067Z",
   "totalEntries": 17
 }

--- a/static/changelog.xml
+++ b/static/changelog.xml
@@ -4,7 +4,7 @@
         <title>Glean Developer Changelog</title>
         <link>https://glean-developer-site.vercel.app</link>
         <description>Updates and changes to the Glean Developer Platform</description>
-        <lastBuildDate>Thu, 03 Jul 2025 16:48:28 GMT</lastBuildDate>
+        <lastBuildDate>Thu, 03 Jul 2025 22:42:59 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Glean Developer Site</generator>
         <language>en</language>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "all"
+        }
+      ]
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2508,6 +2508,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@docusaurus/plugin-vercel-analytics@npm:^3.8.1":
+  version: 3.8.1
+  resolution: "@docusaurus/plugin-vercel-analytics@npm:3.8.1"
+  dependencies:
+    "@docusaurus/core": "npm:3.8.1"
+    "@docusaurus/logger": "npm:3.8.1"
+    "@docusaurus/types": "npm:3.8.1"
+    "@docusaurus/utils": "npm:3.8.1"
+    "@docusaurus/utils-validation": "npm:3.8.1"
+    "@vercel/analytics": "npm:^1.1.1"
+    tslib: "npm:^2.6.0"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  checksum: 10/282d083bf1d170435198aa9bac2e0c49ca2195a45f26a52eccd8eeb17867e2001b15785a8de03149fdefaff9bf88bbd944aa2d8672316ef94f65c9a3f0cc9f4a
+  languageName: node
+  linkType: hard
+
 "@docusaurus/preset-classic@npm:^3.8.1":
   version: 3.8.1
   resolution: "@docusaurus/preset-classic@npm:3.8.1"
@@ -5164,6 +5182,36 @@ __metadata:
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 10/80d6910946f2b1552a2406650051c91bbd1f24a6bf854354203d84fe2714b3e8ce4618f49cc3410494173a1c1e8e9777372fe68dce74bd45faf0a7a1a6ccf448
+  languageName: node
+  linkType: hard
+
+"@vercel/analytics@npm:^1.1.1":
+  version: 1.5.0
+  resolution: "@vercel/analytics@npm:1.5.0"
+  peerDependencies:
+    "@remix-run/react": ^2
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@remix-run/react":
+      optional: true
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10/ae13f10585ffd458e2e00b7e3711f62fc5806447b119e3a6bc19cb1e8a1971527b434343e63207155bef5e4a170b7be6b83822ab94f4716df243cbc2a3fff3b4
   languageName: node
   linkType: hard
 
@@ -8835,6 +8883,7 @@ __metadata:
     "@docusaurus/module-type-aliases": "npm:^3.8.1"
     "@docusaurus/plugin-client-redirects": "npm:^3.8.1"
     "@docusaurus/plugin-content-docs": "npm:^3.8.1"
+    "@docusaurus/plugin-vercel-analytics": "npm:^3.8.1"
     "@docusaurus/preset-classic": "npm:^3.8.1"
     "@docusaurus/theme-classic": "npm:^3.8.1"
     "@docusaurus/theme-common": "npm:^3.8.1"


### PR DESCRIPTION
This pull request introduces the Vercel Analytics plugin to the Docusaurus configuration and updates metadata timestamps in changelog files. The most significant changes include adding the plugin configuration and its dependency, as well as updating the `generatedAt` and `lastBuildDate` fields in the changelog data.

### Plugin Integration:
* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R190-R196): Added the Vercel Analytics plugin with `debug` mode enabled and `auto` mode configuration.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29): Added `@docusaurus/plugin-vercel-analytics` as a dependency.

### Metadata Updates:
* [`src/data/changelog.json`](diffhunk://#diff-45ef3d6390d0313f05c212afba64a6dc7bf86a88c2774c3838c959cbcd897b46L232-R232): Updated the `generatedAt` timestamp to reflect the latest build time.
* [`static/changelog.xml`](diffhunk://#diff-fd374faa325b3f83441210d60139226daa972bb421144b123ee8e40225aa401bL7-R7): Updated the `lastBuildDate` field to match the new build timestamp.