### PR TITLE
fix: Fixes connector for search to point to production site connector

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,7 +179,7 @@ const config: Config = {
         searchOptions: {
           backend: 'https://glean-public-external-be.glean.com',
           webAppUrl: 'https://glean-public-external.glean.com',
-          datasourcesFilter: ['webxtp3t2lgleandeveloperdocs'],
+          datasourcesFilter: ['webitwtmzigleandeveloperdocs'],
         },
         chatOptions: false,
         enableAnonymousAuth: true,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,7 +179,7 @@ const config: Config = {
         searchOptions: {
           backend: 'https://glean-public-external-be.glean.com',
           webAppUrl: 'https://glean-public-external.glean.com',
-          datasourcesFilter: ['webitwtmzigleandeveloperdocs'],
+          datasourcesFilter: ['webj88x6azgleandeveloperdocs'],
         },
         chatOptions: false,
         enableAnonymousAuth: true,


### PR DESCRIPTION
This pull request updates the `datasourcesFilter` configuration in the `docusaurus.config.ts` file.

* [`docusaurus.config.ts`](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784L182-R182): Changed the value of `datasourcesFilter` from `['webxtp3t2lgleandeveloperdocs']` to `['webitwtmzigleandeveloperdocs']` in the `searchOptions` object.