### PR TITLE
fix: Fixes OAS links

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -4,6 +4,14 @@
     "to": "/"
   },
   {
+    "from": "/oas/client",
+    "to": "https://gleanwork.github.io/open-api/specs/final/client_rest.yaml"
+  },
+  {
+    "from": "/oas/indexing",
+    "to": "https://gleanwork.github.io/open-api/specs/final/indexing.yaml"
+  },
+  {
     "from": "/actions/authentication",
     "to": "/get-started/authentication"
   },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -965,7 +965,7 @@ const sidebars: SidebarsConfig = {
               },
               {
                 type: 'link',
-                href: 'https://developers.glean.com/oas/indexing',
+                href: 'https://developers.glean.com/oas/client',
                 label: 'OpenAPI Spec',
               },
             ],


### PR DESCRIPTION
This pull request adds new redirects to the `redirects.json` file for OpenAPI specification files.

* `redirects.json`: Added two new redirects:
  * `/oas/client` now redirects to the OpenAPI specification for the client REST API.
  * `/oas/indexing` now redirects to the OpenAPI specification for indexing.