### PR TITLE
chore: Adding actions redirects

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -17,7 +17,7 @@
   },
   {
     "from": "/agents/mcp",
-    "to": "/guides/mcp/mcp"
+    "to": "/guides/mcp"
   },
   {
     "from": "/api-clients",

--- a/redirects.json
+++ b/redirects.json
@@ -16,10 +16,17 @@
     "to": "/guides/actions/authentication"
   },
   {
+    "from": "/agents/mcp",
+    "to": "/guides/mcp/mcp"
+  },
+  {
     "from": "/api-clients",
     "to": "/libraries/api-clients"
   },
-
+  {
+    "from": "/actions/create-actions",
+    "to": "/guides/actions/create-actions"
+  },
   {
     "from": "/client/api/activity/report-client-activity",
     "to": "/api/client-api/activity/activity"
@@ -307,6 +314,10 @@
   {
     "from": "/client/search/filtering-results",
     "to": "/guides/search/filtering-results"
+  },
+  {
+    "from": "/indexing/overview",
+    "to": "/api-info/indexing/getting-started/overview"
   },
   {
     "from": "/indexing/api/authentication/rotate-token",
@@ -599,5 +610,93 @@
   {
     "from": "/actions/examples/zendesk-ticket-redirection",
     "to": "/guides/actions/examples/zendesk-ticket-redirection"
+  },
+  {
+    "from": "/actions/examples/overview",
+    "to": "/guides/actions/examples/jira-issue-creation"
+  },
+  {
+    "from": "/actions/examples/index",
+    "to": "/guides/actions/examples/jira-issue-creation"
+  },
+  {
+    "from": "/actions/index",
+    "to": "/guides/actions/overview"
+  },
+  {
+    "from": "/actions/getting-started",
+    "to": "/guides/actions/overview"
+  },
+  {
+    "from": "/actions/guide",
+    "to": "/guides/actions/overview"
+  },
+  {
+    "from": "/actions/docs",
+    "to": "/guides/actions/overview"
+  },
+  {
+    "from": "/actions/examples/google-docs",
+    "to": "/guides/actions/examples/google-docs-update"
+  },
+  {
+    "from": "/actions/examples/google-docs-action",
+    "to": "/guides/actions/examples/google-docs-update"
+  },
+  {
+    "from": "/actions/examples/jira",
+    "to": "/guides/actions/examples/jira-issue-creation"
+  },
+  {
+    "from": "/actions/examples/jira-creation",
+    "to": "/guides/actions/examples/jira-issue-creation"
+  },
+  {
+    "from": "/actions/examples/jira-redirect",
+    "to": "/guides/actions/examples/jira-issue-creation-redirect"
+  },
+  {
+    "from": "/actions/examples/zendesk",
+    "to": "/guides/actions/examples/zendesk-ticket-redirection"
+  },
+  {
+    "from": "/actions/examples/zendesk-redirect",
+    "to": "/guides/actions/examples/zendesk-ticket-redirection"
+  },
+  {
+    "from": "/actions/examples/calendar",
+    "to": "/guides/actions/examples/google-calendar-events"
+  },
+  {
+    "from": "/actions/examples/google-calendar",
+    "to": "/guides/actions/examples/google-calendar-events"
+  },
+  {
+    "from": "/actions/setup",
+    "to": "/guides/actions/create-actions"
+  },
+  {
+    "from": "/actions/configuration",
+    "to": "/guides/actions/create-actions"
+  },
+  {
+    "from": "/actions/auth",
+    "to": "/guides/actions/authentication"
+  },
+  {
+    "from": "/actions/authentication-guide",
+    "to": "/guides/actions/authentication"
+  },
+  {
+    "from": "/actions/help",
+    "to": "/guides/actions/faq"
+  },
+  {
+    "from": "/actions/troubleshooting",
+    "to": "/guides/actions/faq"
+  },
+  {
+    "from": "/actions/questions",
+    "to": "/guides/actions/faq"
   }
 ]


### PR DESCRIPTION
This pull request updates the `redirects.json` file to add new URL redirects, primarily focusing on improving the organization and accessibility of documentation for actions, indexing, and guides. The changes ensure that outdated or less intuitive URLs are redirected to more structured and relevant paths.

### New Redirects for Documentation Organization:

* Added redirects for several `/actions` endpoints, consolidating them under `/guides/actions` to improve consistency and discoverability. Examples include redirects for `/actions/setup` to `/guides/actions/create-actions` and `/actions/auth` to `/guides/actions/authentication`.
* Introduced redirects for `/actions/examples` endpoints to specific guides, such as `/actions/examples/google-docs` to `/guides/actions/examples/google-docs-update` and `/actions/examples/jira` to `/guides/actions/examples/jira-issue-creation`.

### Indexing and API Redirects:

* Added a redirect for `/indexing/overview` to `/api-info/indexing/getting-started/overview`, aligning indexing documentation with the API structure.

### General Redirects for Guides:

* Included new redirects for pages like `/agents/mcp` to `/guides/mcp/mcp` and `/actions/create-actions` to `/guides/actions/create-actions`, ensuring all documentation is grouped under the `/guides` hierarchy.