### PR TITLE
fix: add redirect for the old scopes page

### DIFF
--- a/redirects.json
+++ b/redirects.json
@@ -316,6 +316,10 @@
     "to": "/guides/search/filtering-results"
   },
   {
+    "from": "/docs/client_api/client_api_scopes",
+    "to": "/api-info/client/authentication/glean-issued#available-scopes"
+  },
+  {
     "from": "/indexing/overview",
     "to": "/api-info/indexing/getting-started/overview"
   },


### PR DESCRIPTION
Glean's admin -> Client API Tokens -> OAuth card has a "learn more" link that goes to `/docs/client_api/client_api_scopes`.  Add a redirect from that to the Glean-issued tokens scopes section.
