### PR TITLE
Add google site verification tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ yarn changelog:new
 
 The site automatically generates API documentation from OpenAPI specifications located in the `openapi/` directory.
 
+## Environment Variables
+
+The build optionally includes a Google verification meta tag. Set the
+`GOOGLE_SITE_VERIFICATION` environment variable with your verification token if
+you want this tag injected at build time:
+
+```bash
+export GOOGLE_SITE_VERIFICATION=your-token
+yarn build
+```
+
+If the variable is not set, the tag is omitted.
+
 ## 🧪 Testing
 
 Run the build command to test for any issues:

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,6 +7,8 @@ import { customApiMdGenerator } from './scripts/generator/customMdGenerators';
 
 // Environment variable to control API docs generation
 const shouldGenerateApiDocs = process.env.GENERATE_API_DOCS !== 'false';
+// Optional environment variable for Google site verification
+const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION;
 
 const config: Config = {
   title: 'Glean Developer',
@@ -124,6 +126,17 @@ const config: Config = {
           href: '/changelog.xml',
         },
       },
+      ...(googleSiteVerification
+        ? [
+            {
+              tagName: 'meta',
+              attributes: {
+                name: 'google-site-verification',
+                content: googleSiteVerification,
+              },
+            },
+          ]
+        : []),
     ],
     languageTabs: [
       {


### PR DESCRIPTION
This pull request introduces support for adding a Google site verification meta tag to the build process, controlled by an optional environment variable. The changes include updates to documentation and configuration files to implement and document this feature.

### Documentation Updates:
* Added a new section in `README.md` to explain the usage of the `GOOGLE_SITE_VERIFICATION` environment variable for injecting a Google verification meta tag during the build process.

### Configuration Updates:
* Introduced a new variable, `googleSiteVerification`, in `docusaurus.config.ts` to read the `GOOGLE_SITE_VERIFICATION` environment variable.
* Updated the `meta` tags configuration in `docusaurus.config.ts` to conditionally include the Google site verification meta tag if the `GOOGLE_SITE_VERIFICATION` variable is set.