### PR TITLE
docs: Adding information on how to retrieve your Glean instance name

### DIFF
--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -117,6 +117,8 @@ X-Glean-ActAs: user@company.com
 
 ### Quick Test Commands
 
+Replace `<instance>` with your Glean instance name ([how to find](/get-started/authentication#finding-your-glean-instance)):
+
 <Tabs>
 <TabItem value="oauth" label="OAuth">
 

--- a/docs/api-info/indexing/authentication/overview.mdx
+++ b/docs/api-info/indexing/authentication/overview.mdx
@@ -238,6 +238,8 @@ Authorization: Bearer <indexing_api_token>
 
 ### Example Requests
 
+Replace `instance` with your Glean instance name ([how to find](/get-started/authentication#finding-your-glean-instance)):
+
 <Tabs>
 <TabItem value="index-document" label="Index Document">
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -16,6 +16,31 @@ Glean provides two main authentication methods to access its APIs, each with dif
 
 ---
 
+## Finding Your Glean Instance
+
+All Glean API requests require specifying your organization's specific Glean instance. The instance identifier is used in API endpoints and API Client/SDK configuration.
+
+### How to Find Your Instance
+
+1. **Navigate to the About Page**: Visit [https://app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) in your Glean admin console
+2. **Locate Server Instance**: Find the **"Server instance (QE)"** field
+3. **Extract Instance Name**: Use the portion before `-be.glean.com`
+
+### Example
+
+If your Server instance shows: `https://acme-prod-be.glean.com/`  
+Your instance name is: **`acme-prod`**
+
+### Usage in APIs
+
+Your instance name is used in:
+- **API Base URLs**: 
+  - Client API: `https://{instance}-be.glean.com/rest/api/v1/`
+  - Indexing API: `https://{instance}-be.glean.com/api/index/v1/`
+- **API Client/SDK Configuration**: Set as `GLEAN_INSTANCE` environment variable
+
+---
+
 ## API Types and Implementation Guides
 
 Glean offers two distinct APIs with different authentication capabilities. Choose your API type to get started:

--- a/docs/guides/actions/authentication.mdx
+++ b/docs/guides/actions/authentication.mdx
@@ -57,7 +57,7 @@ Your OAuth App must be configured to allow redirects (Callback URL) to:
 https://{your-glean-instance}-be.glean.com/tools/oauth/verify_code/{toolName}
 ```
 
-You can find your instance name in the admin console at [about Glean](https://app.glean.com/admin/about-glean), under **Server instance (QE):**. Use the part before `-be.glean.com`.
+You can find your instance name using our [instance lookup guide](/get-started/authentication#finding-your-glean-instance).
 
 Without this, the OAuth integration may fail or show invalid redirect URI errors.
 :::
@@ -90,8 +90,7 @@ import requests
 
 # Fill your glean instance here.
 YOUR_GLEAN_INSTANCE=''
-# Find this value in the admin console under [about Glean](https://app.glean.com/admin/about-glean)
-# at **Server instance (QE):**. Remove the `-be.glean.com` suffix from the URL.
+# Find this value using our instance lookup guide: /get-started/authentication#finding-your-glean-instance
 
 # Use this function as is in your code (once you have filled out YOUR_GLEAN_INSTANCE).
 # Pass the header value for Glean-Actions-Signature as the 'token' in this function.

--- a/docs/guides/agents/langchain.mdx
+++ b/docs/guides/agents/langchain.mdx
@@ -64,7 +64,7 @@ export GLEAN_API_TOKEN="your-glean-api-token"
 export GLEAN_ACT_AS="user@example.com"  # Optional: Email to act as when making requests
 ```
 
-To determine your `GLEAN_INSTANCE` value, open [about Glean](https://app.glean.com/admin/about-glean) in the admin console and locate the **Server instance (QE):** field. The instance name is the subdomain portion before `-be.glean.com`. For example, if the field shows `https://example-instance-be.glean.com/`, then your instance is `example-instance`.
+To determine your `GLEAN_INSTANCE` value, see our [instance lookup guide](/get-started/authentication#finding-your-glean-instance) for detailed instructions.
 
 ### Usage Examples
 

--- a/docs/guides/mcp/mcp.mdx
+++ b/docs/guides/mcp/mcp.mdx
@@ -125,6 +125,10 @@ Then follow the instructions for your IDE integration or Application Integration
 
 To use API tokens you'll need a [user-scoped API token](/api-info/client/authentication/overview). API Tokens require the following scopes: `chat`, `search`, `documents`. You should speak to your Glean administrator to provision these tokens.
 
+##### Instance Name
+
+For all configuration methods, you'll need your Glean instance name. See our [instance lookup guide](/get-started/authentication#finding-your-glean-instance) for detailed instructions on finding this value.
+
 #### IDE Integrations
 
 <details>


### PR DESCRIPTION
This pull request introduces a new "Instance Lookup Guide" to improve the clarity and consistency of instructions for finding and using the Glean instance name across various documentation files. The changes include adding a dedicated section for the guide and updating references in related documentation to point to it.

### Addition of Instance Lookup Guide:
* [`docs/get-started/authentication.mdx`](diffhunk://#diff-daa5abe43496aa62bad7dabf9262d71b554da3a35280e8d30797a446f29ee0ceR19-R43): Added a new section, "Finding Your Glean Instance," providing step-by-step instructions on identifying the Glean instance name and its usage in API endpoints and configuration.

Example:

<img width="1630" height="1228" alt="Screenshot 2025-07-15 at 4 16 41 PM" src="https://github.com/user-attachments/assets/9cf57fb9-4224-4bab-b7d6-c86ea32ab537" />

### Updates to Documentation References:
* [`docs/api-info/client/authentication/overview.mdx`](diffhunk://#diff-d06f4b18824da3ca9122c38a9671b55ca1f567717a8b0ef7a93f748f95d412b7R120-R121): Updated the quick test commands to include instructions for replacing `<instance>` with the Glean instance name, linking to the new guide.
* [`docs/api-info/indexing/authentication/overview.mdx`](diffhunk://#diff-d65af16c586cda15f6e1d1c46babe51b10595d226c0d90747c238fea1bb1ade6R241-R242): Added similar instructions for replacing `instance` in indexing API examples, with a link to the guide.
* [`docs/guides/actions/authentication.mdx`](diffhunk://#diff-ec61c7cc9ebcac10edbe2d45e36d230f63a0348650975a1bbf499a47c6fb6fa3L60-R60): Replaced inline instructions for finding the Glean instance name with a reference to the new guide in two locations. [[1]](diffhunk://#diff-ec61c7cc9ebcac10edbe2d45e36d230f63a0348650975a1bbf499a47c6fb6fa3L60-R60) [[2]](diffhunk://#diff-ec61c7cc9ebcac10edbe2d45e36d230f63a0348650975a1bbf499a47c6fb6fa3L93-R93)
* [`docs/guides/agents/langchain.mdx`](diffhunk://#diff-f0ecc5b98abe5b6f9deb7565a650deac0d27378b0f76c6846297bedeaf75a8aeL67-R67): Updated the instructions for determining the `GLEAN_INSTANCE` value to reference the new guide.
* [`docs/guides/mcp/mcp.mdx`](diffhunk://#diff-d0226dd41446a68d5b45b21d20d981b2ba135eeb8a296f3d6bdbac2867c506c9R128-R131): Added a new subsection linking to the instance lookup guide for finding the Glean instance name.