### PR TITLE
Remove support email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for incorrect support email
         run: |
           echo "Checking for usage of support@glean.com..."
-          if grep -r --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=build --exclude-dir=dist --exclude-dir=.next --exclude="*.lock" --exclude="yarn.lock" --exclude="package-lock.json" --exclude=".github/workflows/ci.yml" "support@glean.com" .; then
+          if grep -r --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=build --exclude-dir=dist --exclude-dir=.next --exclude="*.lock" --exclude="yarn.lock" --exclude="package-lock.json" --exclude="ci.yml" "support@glean.com" .; then
             echo "Found usage of incorrect email 'support@glean.com'"
             echo "Please replace with the correct support email address"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check for incorrect support email
         run: |
           echo "Checking for usage of support@glean.com..."
-          if grep -r --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=build --exclude-dir=dist --exclude-dir=.next --exclude="*.lock" --exclude="yarn.lock" --exclude="package-lock.json" "support@glean.com" .; then
+          if grep -r --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=build --exclude-dir=dist --exclude-dir=.next --exclude="*.lock" --exclude="yarn.lock" --exclude="package-lock.json" --exclude=".github/workflows/ci.yml" "support@glean.com" .; then
             echo "Found usage of incorrect email 'support@glean.com'"
             echo "Please replace with the correct support email address"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,16 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
+      - name: Check for incorrect support email
+        run: |
+          echo "Checking for usage of support@glean.com..."
+          if grep -r --exclude-dir=node_modules --exclude-dir=.git --exclude-dir=build --exclude-dir=dist --exclude-dir=.next --exclude="*.lock" --exclude="yarn.lock" --exclude="package-lock.json" "support@glean.com" .; then
+            echo "Found usage of incorrect email 'support@glean.com'"
+            echo "Please replace with the correct support email address"
+            exit 1
+          else
+            echo "No usage of support@glean.com found"
+          fi
+
       - name: Test build website
         run: yarn build 

--- a/docs/guides/mcp/mcp.mdx
+++ b/docs/guides/mcp/mcp.mdx
@@ -709,7 +709,7 @@ To join the Remote MCP Server private beta:
   title="Request Beta Access"
   icon="Mail"
 >
-  [Contact your Glean account representative](mailto:support@glean.com?subject=Remote%20MCP%20Server%20Beta%20Access) to request access.
+  Contact your Glean account representative to request access.
 </Card>
 
 **What to Include in Your Request:**


### PR DESCRIPTION
This pull request introduces a check for incorrect usage of the outdated support email address and removes its usage from the documentation. These changes help ensure consistency and accuracy in communication.

### Continuous Integration Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR28-R38): Added a CI step to check for occurrences of the outdated email address `support@glean.com` in the codebase, excluding specific directories and files. If found, the CI process will fail with a message prompting correction.

### Documentation Updates:
* [`docs/guides/mcp/mcp.mdx`](diffhunk://#diff-d0226dd41446a68d5b45b21d20d981b2ba135eeb8a296f3d6bdbac2867c506c9L712-R712): Removed the outdated email address `support@glean.com` from the documentation to prevent its use in contacting the Glean account representative.