### PR TITLE
fix: have configure commands scroll

### DIFF
--- a/src/components/Steps/styles.module.css
+++ b/src/components/Steps/styles.module.css
@@ -49,6 +49,8 @@
 .step__content {
   flex: 1;
   padding-top: 0.25rem;
+  min-width: 0; /* Allow flex item to shrink below content width */
+  overflow-x: auto; /* Enable horizontal scrolling when needed */
 }
 
 .step__title {
@@ -80,4 +82,42 @@
   align-items: center;
   margin-right: 0.5rem;
   color: var(--ifm-color-content-secondary);
+}
+
+/* Code block handling within steps */
+.step__content pre,
+.step__body pre {
+  overflow-x: auto;
+  white-space: pre;
+  word-wrap: normal;
+  max-width: 100%;
+}
+
+.step__content code,
+.step__body code {
+  white-space: pre;
+  word-wrap: normal;
+}
+
+/* Custom scrollbar for code blocks in steps */
+.step__content pre::-webkit-scrollbar,
+.step__body pre::-webkit-scrollbar {
+  height: 6px;
+}
+
+.step__content pre::-webkit-scrollbar-track,
+.step__body pre::-webkit-scrollbar-track {
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 3px;
+}
+
+.step__content pre::-webkit-scrollbar-thumb,
+.step__body pre::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-400);
+  border-radius: 3px;
+}
+
+.step__content pre::-webkit-scrollbar-thumb:hover,
+.step__body pre::-webkit-scrollbar-thumb:hover {
+  background: var(--ifm-color-emphasis-500);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -896,3 +896,41 @@ html {
     background-size: 16px 16px;
   }
 }
+
+/* TabItem overflow handling for Docusaurus tabs */
+.tabs-container [role="tabpanel"] {
+  min-width: 0; /* Allow tab content to shrink */
+  overflow-x: auto; /* Enable horizontal scrolling when needed */
+}
+
+/* Code blocks within TabItem components */
+.tabs-container [role="tabpanel"] pre {
+  overflow-x: auto;
+  white-space: pre;
+  word-wrap: normal;
+  max-width: 100%;
+}
+
+.tabs-container [role="tabpanel"] code {
+  white-space: pre;
+  word-wrap: normal;
+}
+
+/* Custom scrollbar for code blocks in tabs */
+.tabs-container [role="tabpanel"] pre::-webkit-scrollbar {
+  height: 6px;
+}
+
+.tabs-container [role="tabpanel"] pre::-webkit-scrollbar-track {
+  background: var(--ifm-color-emphasis-200);
+  border-radius: 3px;
+}
+
+.tabs-container [role="tabpanel"] pre::-webkit-scrollbar-thumb {
+  background: var(--ifm-color-emphasis-400);
+  border-radius: 3px;
+}
+
+.tabs-container [role="tabpanel"] pre::-webkit-scrollbar-thumb:hover {
+  background: var(--ifm-color-emphasis-500);
+}


### PR DESCRIPTION
Long MCP configure commands, e.g. for windsurf, would overflow the surrounding tabs list rather than scroll.

This is because they were rendered with

```css
display: flex;
min-width: auto;
```

Setting `min-width: 0` allows the tab content to shrink (and then `overflow-x: auto` enables scrolling).


![screen](https://github.com/user-attachments/assets/34e02c66-c858-471e-bf6d-15bd073c3385)

