### PR TITLE
chore: Add token rotation doc to sidebar

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1072,6 +1072,11 @@ const sidebars: SidebarsConfig = {
                     id: 'api/client-api/authentication/createauthtoken',
                     label: 'Create authentication token',
                   },
+                  {
+                    type: 'doc',
+                    id: 'api-info/indexing/authentication/token-rotation',
+                    label: 'Token Rotation',
+                  },
                 ],
               },
               {


### PR DESCRIPTION
### Code changes:
* A new entry for "Token Rotation" has been added to the sidebar configuration in `sidebars.ts`, allowing users to access documentation related to token rotation.

I realized we accidentally left this page out of the sidebar while indexing (I saw 4 documents with an unknown classification)