### PR TITLE
fix: remove IDE integration Tab headers

### DIFF
--- a/docs/guides/mcp/mcp.mdx
+++ b/docs/guides/mcp/mcp.mdx
@@ -134,8 +134,6 @@ For all configuration methods, you'll need your Glean instance name. See our [in
 <details>
 <summary>Cursor</summary>
 
-### Configure Cursor
-
 <Tabs>
   <TabItem value="configure-using-the-cli-oauth" label="Configure using the CLI (OAuth)">
 
@@ -259,8 +257,6 @@ For all configuration methods, you'll need your Glean instance name. See our [in
 <details>
 <summary>Windsurf</summary>
 
-### Configure Windsurf
-
 <Tabs>
   <TabItem value="configure-using-the-cli" label="Configure using the CLI">
 
@@ -355,8 +351,6 @@ For all configuration methods, you'll need your Glean instance name. See our [in
 
 <details>
 <summary>VS Code</summary>
-
-### Configure VS Code
 
 <Tabs>
   <TabItem value="global-configuration" label="Global configuration">
@@ -568,8 +562,6 @@ VS Code supports workspace-specific MCP server configuration stored in `.vscode/
 
 <details>
 <summary>Claude Desktop</summary>
-
-### Configure Claude Desktop
 
 <Tabs>
   <TabItem value="configure-using-the-cli" label="Configure using the CLI">


### PR DESCRIPTION
The headers were within `details > summary`.  Docusaurus automatically created right-hand-side links, but those links would not work when the summary was collapsed.
