### PR TITLE
feat: restore GitHub edit functionality to developer site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -46,6 +46,7 @@ const config: Config = {
           sidebarPath: './sidebars.ts',
           routeBasePath: '/',
           docItemComponent: '@theme/ApiItem',
+          editUrl: 'https://github.com/gleanwork/glean-developer-site/edit/main/',
         },
         theme: {
           customCss: './src/css/custom.css',


### PR DESCRIPTION
- Add editUrl field to Docusaurus docs configuration
- Points to correct gleanwork/glean-developer-site repository
- Enables 'Edit this page' links on documentation pages
- Allows users to submit PRs and raise issues for documentation improvements

Resolves request from developer platform team to re-enable community contributions.