### PR TITLE
fix: Remove manifest sections from Actions docs

### DIFF
--- a/docs/guides/actions/examples/google-docs-update.mdx
+++ b/docs/guides/actions/examples/google-docs-update.mdx
@@ -26,7 +26,7 @@ Before proceeding, ensure you have:
 ## Implementation Guide
 
 <Steps>
-  <Step title="Action Manifest Configuration">
+  <Step title="Basic Configuration">
     <p>Navigate to <a href="https://app.glean.com/admin/platform/tools">Admin console > Platform > Actions</a> and create a new action from scratch.</p>
 
     <h4>Basic Information Configuration</h4>

--- a/docs/guides/actions/examples/jira-issue-creation-redirect.mdx
+++ b/docs/guides/actions/examples/jira-issue-creation-redirect.mdx
@@ -27,27 +27,6 @@ Before proceeding, ensure you have:
 ## Implementation Guide
 
 <Steps>
-  <Step title="Action Manifest Implementation">
-    <p>The action manifest defines the fundamental properties of your Jira redirect action. This configuration establishes how the action behaves within the Glean ecosystem.</p>
-
-    <details>
-      <summary>Click to expand the action manifest configuration</summary>
-
-    ```json
-    {
-      "type": "ACTION",
-      "name": "JiraCreateTicket",
-      "description": "This action allows you to create a new issue in Jira. You can specify the project, issue type, and other details.",
-      "enablePreview": true,
-      "actionType": "REDIRECT"
-    }
-    ```
-
-    </details>
-
-    <p>The manifest configuration is intentionally simpler than that of execution actions because redirect actions don't require OAuth authentication or complex server implementations. This simplicity reduces implementation overhead while maintaining functionality.</p>
-  </Step>
-
   <Step title="API Specification Development">
     <p>The OpenAPI specification serves as the blueprint for how Glean Assistant interacts with your redirect action. This specification must clearly define all parameters and their behaviors to ensure accurate field population.</p>
 

--- a/docs/guides/actions/examples/jira-issue-creation.mdx
+++ b/docs/guides/actions/examples/jira-issue-creation.mdx
@@ -27,37 +27,15 @@ Before beginning this implementation, ensure you have:
 ## Implementation Guide
 
 <Steps>
-  <Step title="Action Manifest Configuration">
-    <p>The first step involves creating an action manifest that defines the core properties of your Jira integration. This manifest establishes the fundamental characteristics and authentication requirements of your action.</p>
-
-    <details>
-      <summary>Click to expand the action manifest configuration</summary>
-
-    ```json
-    {
-      "type": "ACTION",
-      "name": "CreateJiraIssue",
-      "displayName": "Create Jira Issue Action",
-      "description": "This action allows you to create a new issue in Jira. You can specify the project, issue type, and other details.",
-      "enablePreview": true,
-      "actionType": "EXECUTION",
-      "logoUrl": "path/to/your/logo.png",
-      "auth": {
-        "type": "OAUTH_ADMIN",
-        "client_url": "https://auth.atlassian.com/authorize?audience={ATLASSIAN-DOMAIN}.atlassian.net&prompt=consent",
-        "scopes": ["write:jira-work", "offline_access", "read:me"],
-        "authorization_url": "https://auth.atlassian.com/oauth/token"
-      }
-    }
-    ```
-
-    </details>
-
-    <p>We use the <code>OAUTH_ADMIN</code> authentication type because Jira's cloud API supports using admin tokens to create issues on behalf of other users. This approach simplifies the authentication flow while maintaining proper user attribution.</p>
-  </Step>
-
   <Step title="Server Implementation">
     <p>The server implementation handles requests from Glean's actions backend and manages the creation of Jira issues. This implementation includes proper security measures and ensures accurate user attribution.</p>
+    
+    <p>Note: This example uses OAuth authentication configured through the Glean Admin UI. When setting up your action, you'll configure OAuth with the following settings:</p>
+    <ul>
+      <li>Client URL: <code>https://auth.atlassian.com/authorize?audience={`{ATLASSIAN-DOMAIN}`}.atlassian.net&prompt=consent</code></li>
+      <li>Authorization URL: <code>https://auth.atlassian.com/oauth/token</code></li>
+      <li>Scopes: <code>write:jira-work</code>, <code>offline_access</code>, <code>read:me</code></li>
+    </ul>
 
     <details>
       <summary>Click to expand the complete Python server implementation</summary>

--- a/docs/guides/actions/examples/zendesk-ticket-redirection.mdx
+++ b/docs/guides/actions/examples/zendesk-ticket-redirection.mdx
@@ -27,28 +27,6 @@ Before implementing this action, ensure you have:
 ## Implementation Guide
 
 <Steps>
-  <Step title="Action Manifest Configuration">
-    <p>The action manifest defines the essential properties for your Zendesk redirect action. This configuration establishes the action's identity and behavior within the Glean ecosystem.</p>
-
-    <details>
-      <summary>Click to expand the action manifest configuration</summary>
-
-    ```json
-    {
-      "type": "ACTION",
-      "name": "CreateZendeskTicket",
-      "displayName": "Create Zendesk Ticket",
-      "description": "Creates a new support ticket in Zendesk with specified details including subject, description, priority, and requester information.",
-      "enablePreview": true,
-      "actionType": "REDIRECT"
-    }
-    ```
-
-    </details>
-
-    <p>The simplicity of this manifest reflects the streamlined nature of redirect actions. Unlike execution actions, redirect actions don't require complex authentication schemes or server implementations, making them easier to deploy and maintain.</p>
-  </Step>
-
   <Step title="OpenAPI Specification Design">
     <p>The OpenAPI specification serves as the blueprint for parameter handling and URL construction. This specification must accurately reflect Zendesk's parameter structure and validation requirements.</p>
 


### PR DESCRIPTION
This pull request updates several action integration guides to streamline and clarify the implementation steps. The main focus is on simplifying the documentation by removing redundant or overly detailed "Action Manifest Configuration" sections and instead referencing OAuth and configuration details where necessary. This makes the guides more concise and easier to follow.

**Documentation simplification and streamlining:**

* Removed the detailed "Action Manifest Configuration" step from the Jira Issue Creation guide and replaced it with a brief note on OAuth configuration, providing only the essential URLs and scopes needed for setup.
* Removed the "Action Manifest Implementation" step, including the manifest code block, from the Jira Issue Creation Redirect guide to reduce redundancy and complexity.
* Removed the "Action Manifest Configuration" step, including the manifest code block, from the Zendesk Ticket Redirection guide to streamline the instructions and focus on the OpenAPI specification.

**Minor improvements to guide structure:**

* Renamed the "Action Manifest Configuration" step to "Basic Configuration" in the Google Docs Update guide for better clarity and consistency.