### PR TITLE
add gleandocs datasource

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -193,7 +193,7 @@ const config: Config = {
         searchOptions: {
           backend: 'https://glean-public-external-be.glean.com',
           webAppUrl: 'https://glean-public-external.glean.com',
-          datasourcesFilter: ['devdocs'],
+          datasourcesFilter: ['devdocs', 'gleandocs'],
         },
         chatOptions: false,
         enableAnonymousAuth: true,


### PR DESCRIPTION
### Code changes:
* The change modifies the `datasourcesFilter` in the `docusaurus.config.ts` file to include 'gleandocs' alongside 'devdocs', enabling the application to recognize and utilize the 'gleandocs' datasource for search functionalities. This expands the range of documents accessible through the search backend.
