### PR TITLE
Fix link color inside Alerts

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -355,6 +355,10 @@ article li a:hover,
   border: none;
 }
 
+.alert a {
+  text-decoration-color: var(--ifm-color-content);
+}
+
 /* Grid Utility Classes */
 .grid {
   display: grid;


### PR DESCRIPTION
Current color is very hard to see/tell it's  link

**Current**
<img width="588" height="215" alt="Screenshot 2025-08-08 at 4 07 57 PM" src="https://github.com/user-attachments/assets/2534604c-c764-475a-995a-b62523d5df67" />
   
**Better**
<img width="540" height="190" alt="image" src="https://github.com/user-attachments/assets/d49d8144-8eed-46a7-9b85-8997c8bf8615" />

<img width="552" height="203" alt="Screenshot 2025-08-08 at 4 12 31 PM" src="https://github.com/user-attachments/assets/1db8f34a-05fa-4045-9f8e-fb1cdd0ac5e2" />
