### PR TITLE
Clarify rate-limits with global tokens

### DIFF
--- a/docs/get-started/rate-limits.mdx
+++ b/docs/get-started/rate-limits.mdx
@@ -16,6 +16,10 @@ Applied across all incoming API traffic:
 
 - **30 requests per second** per user-scoped API token
 
+:::note
+  Global tokens with an [X-Glean-ActAs](../api-info/client/authentication/glean-issued#authentication-headers) header are counted towards the impersonated users's quota and not the token creator's.
+:::
+
 ### Endpoint Rate Limits
 
 Rate limits for specific endpoints per user-scoped API token are as follows:


### PR DESCRIPTION
Explain that rate limits are counted towards the impersonated user's 30 rps rate limit and not the token creator's

<img width="1030" height="551" alt="image" src="https://github.com/user-attachments/assets/cf4e6d2c-0829-4a52-acf7-9502d08d9092" />
