### PR TITLE
Add a section for `country`

### DIFF
--- a/docs/api-info/indexing/datasource/custom-properties.mdx
+++ b/docs/api-info/indexing/datasource/custom-properties.mdx
@@ -260,3 +260,14 @@ To propagate this update quicker - it is recommended to re-upload the documents 
 All custom properties are automatically used to enrich the document in the index - thereby improving searchability and ranking.
 
 For example, if we have a ticketing datasource and include a ticket ID as a custom property - we can then search by the ticket ID to fetch the relevant ticket (without requiring it to be in the title or the body!).
+
+### Special property: `country`
+
+In addition to general ranking improvements, a custom property named `country` has special behavior.
+
+:::info
+If you set a custom property with `name: "country"`, its value is used as a ranking signal to personalize results based on the searcher's location.
+
+- Acceptable values: ISO 3166-1 two-letter (alpha-2) or three-letter (alpha-3) country codes (for example, `US` or `USA`). Country names are also accepted, but ISO codes are preferred.
+- Usage: add `{"name": "country", "value": "<ISO code or country name>"}` to a document's `customProperties`.
+:::


### PR DESCRIPTION
Add information about how to explicitly tag documents with location (country) using the indexing API.