### PR TITLE
docs: Remove deprecated tools and link to ChatGPT docs

### DIFF
--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -153,7 +153,7 @@ During the public beta, we're providing access to two specialized MCP servers:
       <strong>Key Features:</strong>
     </p>
     <ul>
-      <li>Conforms to OpenAI's MCP Connector spec</li>
+      <li>Conforms to OpenAI's MCP [Connector spec](https://platform.openai.com/docs/mcp)</li>
       <li>Optimized response formatting for ChatGPT</li>
       <li>Automatic citation handling</li>
       <li>Token-efficient responses</li>
@@ -183,11 +183,9 @@ The remote MCP server exposes a curated set of Glean capabilities as MCP tools. 
 
 - **`code_search`** (Code Search) - Search your codebase and repositories
 - **`employee_search`** (Employee Search) - Find people and expertise in your organization
-- **`gemini_web_search`** (Gemini Web Search) - Search the web with Gemini
 - **`gmail_search`** (Gmail Search) - Search Gmail messages and threads
 - **`meeting_lookup`** (Meeting Lookup) - Find meeting recordings and notes
 - **`outlook_search`** (Outlook Search) - Search Outlook emails and calendar
-- **`web_browser`** (Web Browser) - Browse and extract content from web pages
 
 ---
 


### PR DESCRIPTION
### Code changes:
* The diff shows that the link to OpenAI's MCP Connector spec was added, while references to `gemini_web_search` and `web_browser` tools were removed from the document. This reflects a shift towards up-to-date resources and optimization of tool references, enhancing clarity and relevance in the documentation.
