### PR TITLE
feat: Adds feature flag for configure CLI version

### DIFF
--- a/FEATURE_FLAGS.md
+++ b/FEATURE_FLAGS.md
@@ -20,6 +20,13 @@ This document describes the feature flag system implemented for the Glean Develo
     },
     "beta-tutorials": {
       "enabled": false
+    },
+    "mcp-cli-version": {
+      "enabled": true,
+      "metadata": {
+        "version": "1.0.0-beta.1"
+      },
+      "description": "Version to pin the @gleanwork/configure-mcp-server package to"
     }
   }
 }
@@ -174,6 +181,26 @@ FLAGS_DEBUG=true
 {
   "enabled": false
 }
+```
+
+**Using metadata for configuration values:**
+
+```json
+{
+  "enabled": true,
+  "metadata": {
+    "version": "1.0.0-beta.1",
+    "apiUrl": "https://api.example.com",
+    "maxRetries": 3
+  }
+}
+```
+
+The `metadata` field can store arbitrary configuration values that can be accessed in components:
+
+```typescript
+const { raw } = useContext(FeatureFlagsContext);
+const version = raw['mcp-cli-version']?.metadata?.version as string | undefined;
 ```
 
 ## Debug Mode

--- a/src/components/MCPConfigurator/index.tsx
+++ b/src/components/MCPConfigurator/index.tsx
@@ -57,8 +57,12 @@ function getConfigPath(
 
 export default function MCPConfigurator() {
   const registry = useMemo(() => new MCPConfigRegistry(), []);
-  const { booleans } = useContext(FeatureFlagsContext);
+  const { booleans, raw } = useContext(FeatureFlagsContext);
   const showClaudeTeams = booleans['show-claude-teams'] || false;
+
+  const cliPackageVersion = raw['mcp-cli-version']?.metadata?.version as
+    | string
+    | undefined;
 
   const allClients = useMemo(() => {
     if (!registry) return [];
@@ -449,10 +453,14 @@ export default function MCPConfigurator() {
                       <button
                         className={styles.copyConfigIcon}
                         onClick={() => {
+                          const packageName = cliPackageVersion
+                            ? `@gleanwork/configure-mcp-server@${cliPackageVersion}`
+                            : '@gleanwork/configure-mcp-server';
+
                           let cliCommand =
                             selectedClientId === CLIENT.CLAUDE_CODE
                               ? `claude mcp add ${fullServerName} ${serverUrl || 'https://[instance]-be.glean.com/mcp/[endpoint]'} --transport http`
-                              : `npx @gleanwork/configure-mcp-server remote --url ${serverUrl || 'https://[instance]-be.glean.com/mcp/[endpoint]'} --client ${selectedClientId}`;
+                              : `npx ${packageName} remote --url ${serverUrl || 'https://[instance]-be.glean.com/mcp/[endpoint]'} --client ${selectedClientId}`;
 
                           // Add bearer token to Claude Code command if present
                           if (
@@ -492,7 +500,7 @@ export default function MCPConfigurator() {
    --header "Authorization: Bearer ${authToken}"`
                                   : ''
                               }`
-                            : `npx @gleanwork/configure-mcp-server remote \\
+                            : `npx ${cliPackageVersion ? `@gleanwork/configure-mcp-server@${cliPackageVersion}` : '@gleanwork/configure-mcp-server'} remote \\
    --url ${serverUrl || 'https://[instance]-be.glean.com/mcp/[endpoint]'} \\
    --client ${selectedClientId}${
      authMethod === 'bearer' && authToken

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -89,8 +89,10 @@ export default function Root({ children }: { children: ReactNode }) {
 
   // Check for URL parameter overrides
   const { urlOverrides, timeOverride } = useMemo(() => {
-    if (typeof window === 'undefined')
+    if (typeof window === 'undefined') {
       return { urlOverrides: {}, timeOverride: undefined };
+    }
+
     const params = new URLSearchParams(window.location.search);
     const overrides: Record<string, boolean> = {};
     let timeOverride: string | undefined;

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -89,7 +89,8 @@ export default function Root({ children }: { children: ReactNode }) {
 
   // Check for URL parameter overrides
   const { urlOverrides, timeOverride } = useMemo(() => {
-    if (typeof window === 'undefined') return { urlOverrides: {}, timeOverride: undefined };
+    if (typeof window === 'undefined')
+      return { urlOverrides: {}, timeOverride: undefined };
     const params = new URLSearchParams(window.location.search);
     const overrides: Record<string, boolean> = {};
     let timeOverride: string | undefined;
@@ -109,9 +110,9 @@ export default function Root({ children }: { children: ReactNode }) {
   }, []);
 
   const booleans = useMemo(() => {
-    const context = { 
+    const context = {
       visitorId,
-      ...(timeOverride ? { currentTime: timeOverride } : {})
+      ...(timeOverride ? { currentTime: timeOverride } : {}),
     };
     const base = flagsSnapshotToBooleans(raw, context);
     // Apply URL overrides


### PR DESCRIPTION
### Code changes:
* A new feature flag called `mcp-cli-version` has been added to enable a specified version of the `@gleanwork/configure-mcp-server` package, allowing better control of CLI versioning. It includes a `metadata` field storing version information, which is utilized in the `MCPConfigurator` component to conditionally reference the package version in CLI commands.
