### PR TITLE
chore: add community datasource

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -228,7 +228,7 @@ const config: Config = {
         searchOptions: {
           backend: 'https://glean-public-external-be.glean.com',
           webAppUrl: 'https://glean-public-external.glean.com',
-          datasourcesFilter: ['devdocs', 'gleandocs'],
+          datasourcesFilter: ['devdocs', 'gleandocs', 'webjjldruagleancommunity'],
           disableAssistant: true,
         },
         chatOptions: false,


### PR DESCRIPTION
### Code changes:
* The change adds 'webjjldruagleancommunity' to the `datasourcesFilter` array in the `docusaurus.config.ts`, indicating that this new datasource is now included in the search options, alongside 'devdocs' and 'gleandocs'.
