### PR TITLE
internal: Renames feature flag methods for clarity

### DIFF
--- a/FEATURE_FLAGS.md
+++ b/FEATURE_FLAGS.md
@@ -91,9 +91,9 @@ import { useContext } from 'react';
 import { FeatureFlagsContext } from '@site/src/theme/Root';
 
 function Component() {
-  const { booleans } = useContext(FeatureFlagsContext);
+  const { isEnabled } = useContext(FeatureFlagsContext);
   
-  if (booleans['new-ui']) {
+  if (isEnabled('new-ui')) {
     return <NewUI />;
   }
   return <OldUI />;
@@ -199,8 +199,8 @@ FLAGS_DEBUG=true
 The `metadata` field can store arbitrary configuration values that can be accessed in components:
 
 ```typescript
-const { raw } = useContext(FeatureFlagsContext);
-const version = raw['mcp-cli-version']?.metadata?.version as string | undefined;
+const { flagConfigs } = useContext(FeatureFlagsContext);
+const version = flagConfigs['mcp-cli-version']?.metadata?.version as string | undefined;
 ```
 
 ## Debug Mode
@@ -279,7 +279,7 @@ Alice will always see "new-search" but never "beta-ui" unless the percentages ch
 ### Feature Deprecation
 
 1. Add flag with `enabled: true`
-2. Wrap old feature in `!booleans['new-feature']`
+2. Wrap old feature in `!isEnabled('new-feature')`
 3. After migration, remove flag and old code
 
 ## Troubleshooting

--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -10,8 +10,8 @@ import { FeatureFlagsContext } from '@site/src/theme/Root';
 
 export const CompatibilityTable = () => {
   const registry = useMemo(() => new MCPConfigRegistry(), []);
-  const { booleans } = useContext(FeatureFlagsContext);
-  const showClaudeTeams = booleans['show-claude-teams'] || false;
+  const { isEnabled } = useContext(FeatureFlagsContext);
+  const showClaudeTeams = isEnabled('show-claude-teams');
 
   const compatibilityData = useMemo(() => {
     if (!registry) return [];

--- a/src/components/FeatureFlag.tsx
+++ b/src/components/FeatureFlag.tsx
@@ -12,11 +12,11 @@ export default function FeatureFlag({
   children,
   fallback = null,
 }: FeatureFlagProps) {
-  const { booleans } = useContext(FeatureFlagsContext);
+  const { isEnabled } = useContext(FeatureFlagsContext);
 
   const enabled = useMemo(() => {
-    return !!booleans[flag];
-  }, [booleans, flag]);
+    return isEnabled(flag);
+  }, [isEnabled, flag]);
 
   return enabled ? <>{children}</> : <>{fallback}</>;
 }

--- a/src/components/MCPConfigurator/index.tsx
+++ b/src/components/MCPConfigurator/index.tsx
@@ -57,10 +57,10 @@ function getConfigPath(
 
 export default function MCPConfigurator() {
   const registry = useMemo(() => new MCPConfigRegistry(), []);
-  const { booleans, raw } = useContext(FeatureFlagsContext);
-  const showClaudeTeams = booleans['show-claude-teams'] || false;
+  const { isEnabled, flagConfigs } = useContext(FeatureFlagsContext);
+  const showClaudeTeams = isEnabled('show-claude-teams');
 
-  const cliPackageVersion = raw['mcp-cli-version']?.metadata?.version as
+  const cliPackageVersion = flagConfigs['mcp-cli-version']?.metadata?.version as
     | string
     | undefined;
 


### PR DESCRIPTION
### Code changes:
* Updated references from `booleans` to `isEnabled` and `raw` to `flagConfigs`, enhancing code clarity by improving method names for checking feature flag statuses. This change logically focuses on transitioning to a more intuitive API for feature flag management, making the code easier to read and maintain.
