### PR TITLE
docs: add MCP server configuration instructions link

### DIFF
--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -170,6 +170,8 @@ During the public beta, we're providing access to two specialized MCP servers:
   </TabItem>
 </Tabs>
 
+To configure the Glean MCP server, following instructions on https://docs.glean.com/administration/platform/mcp/connecting-to-glean-mcp-server
+
 ## Core Capabilities
 
 The remote MCP server exposes a curated set of Glean capabilities as MCP tools. Administrators can enable defaults and optionally add more.


### PR DESCRIPTION
## Summary
- Added reference to Glean MCP server configuration documentation
- Link placed at the bottom of the "Available Servers" section in RemoteMCPContent.mdx
- Directs users to: https://docs.glean.com/administration/platform/mcp/connecting-to-glean-mcp-server

## Changes
- Updated `docs/guides/mcp/RemoteMCPContent.mdx` to include configuration instructions link

## Testing
No testing required - documentation only change

cc: @andriy-mysyk-glean for review

🤖 Generated with [Claude Code](https://claude.ai/code)