### PR TITLE
fix: Use deep link to ChatGPT settings

### DIFF
--- a/src/components/MCPConfigurator/InstallButton.tsx
+++ b/src/components/MCPConfigurator/InstallButton.tsx
@@ -96,7 +96,7 @@ export function InstallButton({
     if (client.isAdminRequired) {
       const docUrl =
         client.id === CLIENT.CHATGPT
-          ? 'https://platform.openai.com/docs/mcp#connect-in-chatgpt'
+          ? 'https://chatgpt.com/#settings/Connectors'
           : client.id === CLIENT.CLAUDE_TEAMS_ENTERPRISE
             ? 'https://support.anthropic.com/en/articles/11724452-browsing-and-connecting-to-tools-from-the-directory'
             : 'https://developers.glean.com/docs/guides/mcp';


### PR DESCRIPTION
### Code changes:
* The URL for the ChatGPT documentation was changed from a general OpenAI documentation link to a direct deep link for ChatGPT settings. This improves user accessibility by directing them to the correct settings page for integrations.
