### PR TITLE
Fix missing dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@mdx-js/react": "^3.0.0",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.1.0",
     "@vercel/edge-config": "^1.1.0",
+    "allof-merge": "^0.6.7",
     "clsx": "^2.1.1",
     "docusaurus-plugin-openapi-docs": "^4.4.0",
     "docusaurus-plugin-search-glean": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@vercel/edge-config':
         specifier: ^1.1.0
         version: 1.4.0
+      allof-merge:
+        specifier: ^0.6.7
+        version: 0.6.7
       clsx:
         specifier: ^2.1.1
         version: 2.1.1

--- a/src/theme/Schema/index.tsx
+++ b/src/theme/Schema/index.tsx
@@ -15,7 +15,6 @@ import {
   getSchemaName,
 } from 'docusaurus-plugin-openapi-docs/lib/markdown/schema';
 import { SchemaObject } from 'docusaurus-plugin-openapi-docs/lib/openapi/types';
-import isEmpty from 'lodash/isEmpty';
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 // const jsonSchemaMergeAllOf = require("json-schema-merge-allof");
@@ -1252,6 +1251,13 @@ const SchemaNode: React.FC<SchemaProps> = ({
   }
 
   return renderChildren(schema, schemaType, parentPath);
+};
+function isEmpty(value: any): boolean {
+  if (value == null) return true;
+  if (typeof value === 'string' || Array.isArray(value)) return value.length === 0;
+  if (value instanceof Map || value instanceof Set) return value.size === 0;
+  if (typeof value === 'object') return Object.keys(value).length === 0;
+  return false;
 };
 
 export default SchemaNode;


### PR DESCRIPTION
We had two dependencies that we were relying on but were not declared:

- `allof-merge`
- `lodash`


I added the missing `allof-merge` dependency.

For `lodash`, we were only using `isEmpty` in one spot (and nothing else) so I just went ahead and used a small utility method in it's place (instead of adding the dependency).

