### PR TITLE
docs: add ActAs header strategy for managing rate limits

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@ build
 *.mdx
 yarn.lock
 package-lock.json
+pnpm-lock.yaml
 *.min.js
 *.min.css
 coverage
@@ -32,4 +33,5 @@ public
 static
 docs/api
 openapi
-changelog 
+changelog
+src/data/changelog.json

--- a/docs/get-started/rate-limits.mdx
+++ b/docs/get-started/rate-limits.mdx
@@ -44,4 +44,7 @@ Glean uses token bucket rate limiters for user and endpoint-level enforcement. T
 ### Handling Rate Limits
 
 If you send too many requests in a short period, the API will respond with an HTTP 429 "Too Many Requests" error. To handle this gracefully, watch for 429 status codes and implement a retry mechanism with exponential backoff to gradually reduce request volume.
+
+For applications that need to make many requests, consider using a global token with the [X-Glean-ActAs](../api-info/client/authentication/glean-issued#authentication-headers) header to distribute requests across different users' rate limit quotas. Since requests with the ActAs header are counted towards the impersonated user's quota rather than the token creator's, this approach can help avoid hitting rate limits for a single user.
+
 If your application requires higher rate limits, please contact your Glean account team to see if the rate limits can be adjusted.

--- a/src/theme/Schema/index.tsx
+++ b/src/theme/Schema/index.tsx
@@ -1254,10 +1254,11 @@ const SchemaNode: React.FC<SchemaProps> = ({
 };
 function isEmpty(value: any): boolean {
   if (value == null) return true;
-  if (typeof value === 'string' || Array.isArray(value)) return value.length === 0;
+  if (typeof value === 'string' || Array.isArray(value))
+    return value.length === 0;
   if (value instanceof Map || value instanceof Set) return value.size === 0;
   if (typeof value === 'object') return Object.keys(value).length === 0;
   return false;
-};
+}
 
 export default SchemaNode;


### PR DESCRIPTION
Updates the rate limits documentation to mention using the X-Glean-ActAs header with global tokens as a strategy for distributing API requests across different users' rate limit quotas.

This helps developers understand that they can avoid hitting a single user's rate limit by impersonating different users with the ActAs header.

Also fixes prettier formatting issues and updates .prettierignore to exclude auto-generated files (pnpm-lock.yaml and changelog.json).