### PR TITLE
feat(agents): clarify run QPM

### DIFF
--- a/docs/get-started/rate-limits.mdx
+++ b/docs/get-started/rate-limits.mdx
@@ -26,7 +26,14 @@ Rate limits for specific endpoints per user-scoped API token are as follows:
 
 | Endpoint             | Rate Limit                              |
 | -------------------- | --------------------------------------- |
-| /agents/runs         | 0.5 requests per second                 |
+| /agents/runs         | 0.5 requests per second ([see details](#agent-rate-limits)) |
+
+:::info
+30 qpm is the limit for initiating agent runs. Depending on your deployment size and depending on how long-running and compute intensive the agent is, agent performance may degrade if run at max qpm.
+:::
+
+| Endpoint             | Rate Limit                              |
+| -------------------- | --------------------------------------- |
 | /autocomplete        | 10 requests per second                  |
 | /chat                | 0.5 requests per second                 |
 | /feed                | 7 requests per second                   |


### PR DESCRIPTION
Add a note explaining that the rate limit for agents is just about initiating agent runs and does not mean that agents can always run at max performance at the max qpm.

<img width="1335" height="957" alt="image" src="https://github.com/user-attachments/assets/36b492f5-6475-4a68-ab26-8e3f7f0de23e" />

