### PR TITLE
fix(changelog): Removes repetitive dates when entries are for the same day

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -257,6 +257,7 @@ const config: Config = {
               config: {
                 indexing: {
                   specPath: './openapi/indexing/indexing-capitalized.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/indexing-api',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -267,6 +268,7 @@ const config: Config = {
                 activity: {
                   // ok
                   specPath: './openapi/client/split-apis/activity-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/activity',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -278,6 +280,7 @@ const config: Config = {
                   // circular
                   specPath:
                     './openapi/client/split-apis/announcements-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/announcements',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -288,6 +291,7 @@ const config: Config = {
                 answers: {
                   // ok
                   specPath: './openapi/client/split-apis/answers-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/answers',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -299,6 +303,7 @@ const config: Config = {
                   // ok
                   specPath:
                     './openapi/client/split-apis/authentication-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/authentication',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -309,6 +314,7 @@ const config: Config = {
                 chat: {
                   // circular
                   specPath: './openapi/client/split-apis/chat-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/chat',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -319,6 +325,7 @@ const config: Config = {
                 agents: {
                   // ok
                   specPath: './openapi/client/split-apis/agents-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/agents',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -329,6 +336,7 @@ const config: Config = {
                 collections: {
                   // circular
                   specPath: './openapi/client/split-apis/collections-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/collections',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -339,6 +347,7 @@ const config: Config = {
                 documents: {
                   // circular
                   specPath: './openapi/client/split-apis/documents-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/documents',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -349,6 +358,7 @@ const config: Config = {
                 insights: {
                   // circular
                   specPath: './openapi/client/split-apis/insights-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/insights',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -359,6 +369,7 @@ const config: Config = {
                 messages: {
                   // circular
                   specPath: './openapi/client/split-apis/messages-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/messages',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -369,6 +380,7 @@ const config: Config = {
                 pins: {
                   // circular
                   specPath: './openapi/client/split-apis/pins-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/pins',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -379,6 +391,7 @@ const config: Config = {
                 search: {
                   // circular
                   specPath: './openapi/client/split-apis/search-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/search',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -389,6 +402,7 @@ const config: Config = {
                 entities: {
                   // circular
                   specPath: './openapi/client/split-apis/entities-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/entities',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -399,6 +413,7 @@ const config: Config = {
                 shortcuts: {
                   // circular
                   specPath: './openapi/client/split-apis/shortcuts-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/shortcuts',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -409,6 +424,7 @@ const config: Config = {
                 summarize: {
                   // ok
                   specPath: './openapi/client/split-apis/summarize-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/summarize',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -419,6 +435,7 @@ const config: Config = {
                 verification: {
                   // circular
                   specPath: './openapi/client/split-apis/verification-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/verification',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -429,6 +446,7 @@ const config: Config = {
                 tools: {
                   // ok
                   specPath: './openapi/client/split-apis/tools-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/tools',
                   sidebarOptions: {
                     groupPathsBy: 'tag',
@@ -439,6 +457,7 @@ const config: Config = {
                 governance: {
                   // ok
                   specPath: './openapi/client/split-apis/governance-api.yaml',
+                  showSchemas: false,
                   outputDir: 'docs/api/client-api/governance',
                   sidebarOptions: {
                     groupPathsBy: 'tag',

--- a/src/components/Changelog/ChangelogEntries.tsx
+++ b/src/components/Changelog/ChangelogEntries.tsx
@@ -20,9 +20,18 @@ export default function ChangelogEntries({
 
   return (
     <div className={styles.changelogEntries}>
-      {entries.map((entry) => (
-        <ChangelogEntryComponent key={entry.id} entry={entry} />
-      ))}
+      {entries.map((entry, index) => {
+        const previousEntry = index > 0 ? entries[index - 1] : null;
+        const showDate = !previousEntry || previousEntry.date !== entry.date;
+        
+        return (
+          <ChangelogEntryComponent 
+            key={entry.id} 
+            entry={entry} 
+            showDate={showDate}
+          />
+        );
+      })}
     </div>
   );
 } 

--- a/src/components/Changelog/ChangelogEntry.tsx
+++ b/src/components/Changelog/ChangelogEntry.tsx
@@ -5,6 +5,7 @@ import styles from './ChangelogEntry.module.css';
 
 interface ChangelogEntryProps {
   entry: ChangelogEntry;
+  showDate?: boolean;
 }
 
 interface CategoryBadgeProps {
@@ -31,7 +32,8 @@ function CategoryBadge({ category }: CategoryBadgeProps): React.ReactElement {
 }
 
 export default function ChangelogEntry({ 
-  entry 
+  entry,
+  showDate = true 
 }: ChangelogEntryProps): React.ReactElement {
   const stripHtml = (html: string) => html.replace(/<[^>]*>/g, '').trim();
   const summaryText = stripHtml(entry.summary);
@@ -44,13 +46,15 @@ export default function ChangelogEntry({
   return (
     <div className={styles.changelogEntry}>
       <div className={styles.entryDate}>
-        <time>
-          <div className={styles.monthDay}>{monthDay}</div>
-          <div className={styles.year}>{year}</div>
-        </time>
+        {showDate ? (
+          <time>
+            <div className={styles.monthDay}>{monthDay}</div>
+            <div className={styles.year}>{year}</div>
+          </time>
+        ) : null}
       </div>
       <div className={styles.contentWrapper}>
-        <div className={styles.entryDot}></div>
+        {showDate && <div className={styles.entryDot}></div>}
         <div className={styles.entryContent}>
           <header className={styles.entryHeader}>
             <h2>{entry.title}</h2>


### PR DESCRIPTION
This pull request improves the changelog display and updates API documentation settings in the Docusaurus configuration. The most notable changes are the enhancement of the changelog UI to avoid repeating dates for consecutive entries on the same day, and the disabling of schema display for all OpenAPI-generated API docs.

**Changelog UI Improvements:**

* Updated `ChangelogEntries` to only show the date for the first entry of each day, reducing redundant date displays for consecutive entries with the same date (`src/components/Changelog/ChangelogEntries.tsx`).
* Modified `ChangelogEntry` to accept a `showDate` prop and conditionally render the date and entry dot based on this prop, supporting the new grouped date display (`src/components/Changelog/ChangelogEntry.tsx`) [[1]](diffhunk://#diff-92765eb69bdc5c18da044fdfdde68480d5ef2ab3d1d4a2919bffce99ec4ff5ddR8) [[2]](diffhunk://#diff-92765eb69bdc5c18da044fdfdde68480d5ef2ab3d1d4a2919bffce99ec4ff5ddL34-R36) [[3]](diffhunk://#diff-92765eb69bdc5c18da044fdfdde68480d5ef2ab3d1d4a2919bffce99ec4ff5ddR49-R57).

**API Documentation Configuration:**

* Set `showSchemas: false` for all OpenAPI plugin configurations in `docusaurus.config.ts`, which hides the schemas section from the generated API documentation (`docusaurus.config.ts`) [[1]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R260) [[2]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R271) [[3]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R283) [[4]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R294) [[5]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R306) [[6]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R317) [[7]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R328) [[8]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R339) [[9]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R350) [[10]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R361) [[11]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R372) [[12]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R383) [[13]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R394) [[14]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R405) [[15]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R416) [[16]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R427) [[17]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R438) [[18]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R449) [[19]](diffhunk://#diff-cc8abb6104e21d495dc8f64639c7b03419226d920d1c545df51be9b0b73b2784R460).