### PR TITLE
chore(deps): Group @docusaurus dependencies in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,8 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
       dev-dependencies:
         dependency-type: "development"


### PR DESCRIPTION
All @docusaurus packages must be on the exact same version (enforced at install time). Previously, the `devDependencies` group would update `@docusaurus` devDeps separately from `@docusaurus` deps, causing version mismatches and CI failures. By adding a docusaurus group before `devDependencies`, all `@docusaurus` packages now update together in a single PR.

Closes #176 #175 

Blocks #173 (once this lands, that will need rebasing)