### PR TITLE
feat: Adding GitHub Action for automatic publishing of server.json to MCP registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,47 @@
+name: Publish to MCP Registry
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - "server.json"
+    workflow_dispatch:
+
+jobs:
+    publish:
+        name: Publish to MCP Registry
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "20"
+
+            - name: Install MCP Publisher CLI
+              run: npm install -g @modelcontextprotocol/mcp-publisher
+
+            - name: Authenticate with MCP Registry
+              env:
+                  MCP_PRIVATE_KEY: ${{ secrets.MCP_PRIVATE_KEY }}
+              run: |
+                  echo "$MCP_PRIVATE_KEY" > key.pem
+                  chmod 600 key.pem
+
+                  EXTRACTED_KEY=$(openssl pkey -in key.pem -noout -text | grep -A3 "priv:" | tail -n +2 | tr -d ' :\n')
+
+                  mcp-publisher login dns \
+                    --domain glean.com \
+                    --private-key "$EXTRACTED_KEY"
+
+                  rm key.pem
+
+            - name: Publish to Registry
+              run: mcp-publisher publish
+
+            - name: Report Success
+              if: success()
+              run: |
+                  VERSION=$(jq -r '.version' server.json)
+                  echo "Successfully published Glean MCP Server version $VERSION to the registry"


### PR DESCRIPTION
### Code changes:
* A new GitHub Action workflow is added to automatically publish `server.json` to the MCP registry upon pushes to the `main` branch or via manual dispatch. The workflow includes steps for checking out the code, setting up Node.js, installing the MCP Publisher CLI, authenticating with the MCP registry using a private key, and publishing the server configuration.
