### PR TITLE
[docs][NI] Update agents API scope requirements

### DIFF
--- a/docs/api-info/client/getting-started/basic-usage.mdx
+++ b/docs/api-info/client/getting-started/basic-usage.mdx
@@ -146,6 +146,8 @@ curl -X POST https://your-instance-be.glean.com/rest/api/v1/search \
 
 Execute specialized AI agents built in Glean's Agent Builder for complex workflows.
 
+**Required Scopes:** `agents`, `chat`
+
 **Request Format:**
 ```bash showLineNumbers
 curl -X POST https://your-instance-be.glean.com/rest/api/v1/agents/runs/wait \

--- a/docs/guides/agents/langchain.mdx
+++ b/docs/guides/agents/langchain.mdx
@@ -52,7 +52,7 @@ Glean's official LangChain integration enables you to build powerful AI agents t
 
 #### API Tokens
 
-You'll need Glean [API credentials](/get-started/authentication), and specifically a [user-scoped API token](/api-info/client/authentication/glean-issued#available-scopes). API Tokens require the following scopes: `chat`, `search`. You should speak to your Glean administrator to provision these tokens.
+You'll need Glean [API credentials](/get-started/authentication), and specifically a [user-scoped API token](/api-info/client/authentication/glean-issued#available-scopes). API Tokens require the following scopes: `chat`, `search`, and `agents` (if using the Agents API). You should speak to your Glean administrator to provision these tokens.
 
 #### Configure Environment Variables
 

--- a/docs/guides/agents/overview.mdx
+++ b/docs/guides/agents/overview.mdx
@@ -79,7 +79,7 @@ Glean provides multiple ways to build AI agents that can search and reason over 
 All approaches require Glean API credentials:
 
 1. **Get API Token**: Request a [user-scoped API token](/api-info/client/authentication/glean-issued#available-scopes)
-2. **Required Scopes**: `chat`, `search`, `agents` (depending on usage)
+2. **Required Scopes**: `agents` and `chat` are required for agent execution; `search` may be needed depending on your agent's configuration
 3. **Environment Setup**: Configure your Glean instance and token
 
 ## Need a No-Code Solution?


### PR DESCRIPTION
## Summary
Updates agent API documentation to clarify that both `agents` and `chat` scopes are required for agent run endpoints.

## Background
Internal report (Slack thread) identified that the documentation was incomplete - it only mentioned the `agents` scope, but in practice both `agents` and `chat` scopes are required for the agent execution endpoints:
- `/rest/api/v1/agents/runs/stream`
- `/rest/api/v1/agents/runs/wait`

## Changes
- **guides/agents/overview.mdx**: Clarified that `agents` and `chat` scopes are required for agent execution
- **guides/agents/langchain.mdx**: Added `agents` scope to the list of required scopes
- **api-info/client/getting-started/basic-usage.mdx**: Added scope requirements note to the Agents API example

## Testing
- ✅ Linting passed
- ✅ Formatting passed
- ✅ No build errors

## Notes
- Marked as [NI] (No QA needed) - documentation-only change
- Does not affect functionality, only clarifies existing scope requirements