### PR TITLE
[docs] Fix /indexdocuments rate limit to 600 documents per minute

### DIFF
--- a/docs/get-started/rate-limits.mdx
+++ b/docs/get-started/rate-limits.mdx
@@ -38,7 +38,7 @@ Rate limits for specific endpoints per user-scoped API token are as follows:
 | /chat                | 0.5 requests per second                 |
 | /feed                | 7 requests per second                   |
 | /indexdocument       | 10 requests per second                  |
-| /indexdocuments      | 10 requests per second                  |
+| /indexdocuments      | 600 documents per minute                |
 | /people              | 5 requests per second                   |
 | /processalldocuments | 1 request every 3 hours per data source |
 | /recommendations     | 0.5 requests per second                 |


### PR DESCRIPTION
## Problem

Customers were receiving 429 errors from the `/indexdocuments` endpoint despite following the documented rate limit of "10 requests per second".

## Root Cause

The actual rate limit for `/indexdocuments` is **600 documents per minute**, not "10 requests per second" as previously documented. While these seem mathematically equivalent (600/60 = 10), the enforcement is based on total documents across all requests within a minute window.

## Solution

Updated the rate limit documentation in `docs/get-started/rate-limits.mdx` to accurately reflect:
- **Before:** `10 requests per second`
- **After:** `600 documents per minute`

This clarifies the actual enforcement mechanism and prevents future customer confusion.