### PR TITLE
chore: Use generic changelog branch name to dedupe

### DIFF
--- a/.github/workflows/changelog-generator.yml
+++ b/.github/workflows/changelog-generator.yml
@@ -31,6 +31,7 @@ jobs:
               with:
                   fetch-depth: 0
                   path: pr-worktree
+                  token: ${{ secrets.CHANGELOG_PAT }}
 
             - name: Set up mise
               uses: jdx/mise-action@v2
@@ -54,7 +55,7 @@ jobs:
 
             - name: Run changelog generator
               env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.CHANGELOG_PAT }}
                   CHANGELOG_WORKTREE: pr-worktree
                   GLEAN_API_TOKEN: ${{ secrets.CHANGELOG_GLEAN_API_TOKEN }}
                   GLEAN_INSTANCE: ${{ secrets.CHANGELOG_GLEAN_INSTANCE }}

--- a/packages/changelog-generator/src/commands/compile-json.ts
+++ b/packages/changelog-generator/src/commands/compile-json.ts
@@ -31,12 +31,10 @@ function getDirectoryHash(dirPath: string): string | null {
 
   const fileHashes = files.map((file) => {
     const filePath = path.join(dirPath, file);
-    const stats = fs.statSync(filePath);
     const content = fs.readFileSync(filePath, 'utf-8');
     return {
       file,
       hash: crypto.createHash('md5').update(content).digest('hex'),
-      mtime: stats.mtime.toISOString(),
     };
   });
 

--- a/packages/changelog-generator/src/octo.ts
+++ b/packages/changelog-generator/src/octo.ts
@@ -38,7 +38,7 @@ export async function findExistingChangelogPR(
   params: {
     owner: string;
     repo: string;
-    branchPrefix: string;
+    branchName: string;
     baseBranch: string;
   },
 ): Promise<PullRequest | null> {
@@ -51,8 +51,8 @@ export async function findExistingChangelogPR(
       per_page: 100,
     });
 
-    const matchingPR = response.data.find((pr) =>
-      pr.head.ref.startsWith(params.branchPrefix),
+    const matchingPR = response.data.find(
+      (pr) => pr.head.ref === params.branchName,
     );
 
     return matchingPR || null;

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,6 +1,305 @@
 {
   "entries": [
     {
+      "id": "2025-11-26-rest-api-changes-open-api",
+      "slug": "rest-api-changes-open-api",
+      "title": "REST API: changes (endpoints) 2025-11-26",
+      "date": "2025-11-26",
+      "categories": [
+        "API"
+      ],
+      "summary": "<p>2 endpoints added</p>\n",
+      "fullContent": "<p>2 endpoints added</p>\n<p>Added endpoint: /custom-metadata/schema/{groupName}<br>Added endpoint: /document/{docId}/custom-metadata/{groupName}</p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-26-rest-api-changes-open-api.md"
+    },
+    {
+      "id": "2025-11-25-configure-mcp-server-2-1-0",
+      "slug": "configure-mcp-server-2-1-0",
+      "title": "configure-mcp-server v2.1.0",
+      "date": "2025-11-25",
+      "categories": [
+        "MCP"
+      ],
+      "summary": "<p>Upgraded mcp-config-schema to version 2.0.0. - Enhancement: Updated dependency to mcp-config-schema 2.0.0 - Internal: Added CLAUDE.md</p>\n",
+      "fullContent": "<p>Upgraded mcp-config-schema to version 2.0.0. - Enhancement: Updated dependency to mcp-config-schema 2.0.0 - Internal: Added CLAUDE.md</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/configure-mcp-server/releases/tag/v2.1.0\">https://github.com/gleanwork/configure-mcp-server/releases/tag/v2.1.0</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-25-configure-mcp-server-2-1-0.md"
+    },
+    {
+      "id": "2025-11-24-api-client-typescript-0-13-14",
+      "slug": "api-client-typescript-0-13-14",
+      "title": "api-client-typescript v0.13.14",
+      "date": "2025-11-24",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for possible breaking changes in this response structure.</p>\n",
+      "fullContent": "<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for possible breaking changes in this response structure.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.14\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.14</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-24-api-client-typescript-0-13-14.md"
+    },
+    {
+      "id": "2025-11-24-api-client-python-0-11-22",
+      "slug": "api-client-python-0-11-22",
+      "title": "api-client-python v0.11.22",
+      "date": "2025-11-24",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response.agents_response.agents_usage_by_department_insights array in glean.client.insights.retrieve() has changed. - Review integration for compatibility with updated response structure - May impact parsing or downstream processing of department insights - No new endpoints or parameters...</p>\n",
+      "fullContent": "<p>The response.agents_response.agents_usage_by_department_insights array in glean.client.insights.retrieve() has changed. - Review integration for compatibility with updated response structure - May impact parsing or downstream processing of department insights - No new endpoints or parameters...</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.11.22\">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.22</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-24-api-client-python-0-11-22.md"
+    },
+    {
+      "id": "2025-11-24-api-client-java-0-12-8",
+      "slug": "api-client-java-0-12-8",
+      "title": "api-client-java v0.12.8",
+      "date": "2025-11-24",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for potential breaking changes in this response structure.</p>\n",
+      "fullContent": "<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for potential breaking changes in this response structure.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.8\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.8</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-24-api-client-java-0-12-8.md"
+    },
+    {
+      "id": "2025-11-24-api-client-go-0-11-14",
+      "slug": "api-client-go-0-11-14",
+      "title": "api-client-go v0.11.14",
+      "date": "2025-11-24",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Changed the structure of response.AgentsResponse.AgentsUsageByDepartmentInsights[] in Glean.Client.Insights.Retrieve().</p>\n",
+      "fullContent": "<p>Changed the structure of response.AgentsResponse.AgentsUsageByDepartmentInsights[] in Glean.Client.Insights.Retrieve().</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.14\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.14</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-24-api-client-go-0-11-14.md"
+    },
+    {
+      "id": "2025-11-21-api-client-typescript-0-13-13",
+      "slug": "api-client-typescript-0-13-13",
+      "title": "api-client-typescript v0.13.13",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated TypeScript API client to version 0.13.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - TypeScript client generated at v0.13.13 - Release available as NPM package v0.13.13</p>\n",
+      "fullContent": "<p>Updated TypeScript API client to version 0.13.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - TypeScript client generated at v0.13.13 - Release available as NPM package v0.13.13</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.13\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.13</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-typescript-0-13-13.md"
+    },
+    {
+      "id": "2025-11-21-api-client-typescript-0-13-12",
+      "slug": "api-client-typescript-0-13-12",
+      "title": "api-client-typescript v0.13.12",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated TypeScript API client to version 0.13.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0.</p>\n",
+      "fullContent": "<p>Updated TypeScript API client to version 0.13.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.12\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.12</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-typescript-0-13-12.md"
+    },
+    {
+      "id": "2025-11-21-api-client-typescript-0-13-11",
+      "slug": "api-client-typescript-0-13-11",
+      "title": "api-client-typescript v0.13.11",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response structure of glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using glean.client.insights.retrieve() may require updates to handle the new response format.</p>\n",
+      "fullContent": "<p>The response structure of glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using glean.client.insights.retrieve() may require updates to handle the new response format.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.11\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.11</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-typescript-0-13-11.md"
+    },
+    {
+      "id": "2025-11-21-api-client-python-0-11-20",
+      "slug": "api-client-python-0-11-20",
+      "title": "api-client-python v0.11.20",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Python API client to version 0.11.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>\n",
+      "fullContent": "<p>Updated Python API client to version 0.11.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.11.20\">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.20</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-python-0-11-20.md"
+    },
+    {
+      "id": "2025-11-21-api-client-python-0-11-18",
+      "slug": "api-client-python-0-11-18",
+      "title": "api-client-python v0.11.18",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Python API client to version 0.11.18, based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0. - Python SDK generated at v0.11.18 - PyPI release published at v0.11.18 - Based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0</p>\n",
+      "fullContent": "<p>Updated Python API client to version 0.11.18, based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0. - Python SDK generated at v0.11.18 - PyPI release published at v0.11.18 - Based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.11.18\">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.18</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-python-0-11-18.md"
+    },
+    {
+      "id": "2025-11-21-api-client-python-0-11-16",
+      "slug": "api-client-python-0-11-16",
+      "title": "api-client-python v0.11.16",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response structure for glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using this method may require updates to handle the new response format.</p>\n",
+      "fullContent": "<p>The response structure for glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using this method may require updates to handle the new response format.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.11.16\">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.16</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-python-0-11-16.md"
+    },
+    {
+      "id": "2025-11-21-api-client-java-0-12-7",
+      "slug": "api-client-java-0-12-7",
+      "title": "api-client-java v0.12.7",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Java API client to version 0.12.7 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.7 - Released to Maven Central v0.12.7</p>\n",
+      "fullContent": "<p>Updated Java API client to version 0.12.7 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.7 - Released to Maven Central v0.12.7</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.7\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.7</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-java-0-12-7.md"
+    },
+    {
+      "id": "2025-11-21-api-client-java-0-12-6",
+      "slug": "api-client-java-0-12-6",
+      "title": "api-client-java v0.12.6",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Java API client to version 0.12.6 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.6 - Released to Maven Central v0.12.6</p>\n",
+      "fullContent": "<p>Updated Java API client to version 0.12.6 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.6 - Released to Maven Central v0.12.6</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.6\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.6</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-java-0-12-6.md"
+    },
+    {
+      "id": "2025-11-21-api-client-java-0-12-5",
+      "slug": "api-client-java-0-12-5",
+      "title": "api-client-java v0.12.5",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response object returned by glean.client.insights.retrieve() has changed in a breaking way. - This is a breaking change and may require updates to client code using this method.</p>\n",
+      "fullContent": "<p>The response object returned by glean.client.insights.retrieve() has changed in a breaking way. - This is a breaking change and may require updates to client code using this method.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.5\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.5</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-java-0-12-5.md"
+    },
+    {
+      "id": "2025-11-21-api-client-go-0-11-13",
+      "slug": "api-client-go-0-11-13",
+      "title": "api-client-go v0.11.13",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Go API client to version 0.11.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from recent Speakeasy CLI versions</p>\n",
+      "fullContent": "<p>Updated Go API client to version 0.11.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from recent Speakeasy CLI versions</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.13\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.13</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-go-0-11-13.md"
+    },
+    {
+      "id": "2025-11-21-api-client-go-0-11-12",
+      "slug": "api-client-go-0-11-12",
+      "title": "api-client-go v0.11.12",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Go API client to version 0.11.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from the latest Speakeasy CLI release</p>\n",
+      "fullContent": "<p>Updated Go API client to version 0.11.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from the latest Speakeasy CLI release</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.12\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.12</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-go-0-11-12.md"
+    },
+    {
+      "id": "2025-11-21-api-client-go-0-11-11",
+      "slug": "api-client-go-0-11-11",
+      "title": "api-client-go v0.11.11",
+      "date": "2025-11-21",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>The response object returned by Glean.Client.Insights.Retrieve() has changed in a breaking way. - Breaking change to the response structure - Review integration for compatibility before upgrading</p>\n",
+      "fullContent": "<p>The response object returned by Glean.Client.Insights.Retrieve() has changed in a breaking way. - Breaking change to the response structure - Review integration for compatibility before upgrading</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.11\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.11</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-21-api-client-go-0-11-11.md"
+    },
+    {
+      "id": "2025-11-18-mcp-config-schema-2-0-0",
+      "slug": "mcp-config-schema-2-0-0",
+      "title": "mcp-config-schema v2.0.0",
+      "date": "2025-11-18",
+      "categories": [
+        "MCP"
+      ],
+      "summary": "<p>Renamed components for improved semantic clarity, added support for Jetbrains IDEs and Codex, and updated documentation to reflect recent changes. - Breaking: Renamed for better semantic meaning - Enhancement: Added support for Jetbrains IDEs and Codex - Documentation: Updated README.md and...</p>\n",
+      "fullContent": "<p>Renamed components for improved semantic clarity, added support for Jetbrains IDEs and Codex, and updated documentation to reflect recent changes. - Breaking: Renamed for better semantic meaning - Enhancement: Added support for Jetbrains IDEs and Codex - Documentation: Updated README.md and...</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/mcp-config-schema/releases/tag/v2.0.0\">https://github.com/gleanwork/mcp-config-schema/releases/tag/v2.0.0</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-18-mcp-config-schema-2-0-0.md"
+    },
+    {
+      "id": "2025-11-17-api-client-typescript-0-13-10",
+      "slug": "api-client-typescript-0-13-10",
+      "title": "api-client-typescript v0.13.10",
+      "date": "2025-11-17",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated API client to typescript v0.13.10 based on OpenAPI Doc 0.9.0.</p>\n",
+      "fullContent": "<p>Updated API client to typescript v0.13.10 based on OpenAPI Doc 0.9.0.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.10\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.10</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-17-api-client-typescript-0-13-10.md"
+    },
+    {
+      "id": "2025-11-17-api-client-python-0-11-14",
+      "slug": "api-client-python-0-11-14",
+      "title": "api-client-python v0.11.14",
+      "date": "2025-11-17",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Python API client to version 0.11.14 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>\n",
+      "fullContent": "<p>Updated Python API client to version 0.11.14 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.11.14\">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.14</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-17-api-client-python-0-11-14.md"
+    },
+    {
+      "id": "2025-11-17-api-client-java-0-12-4",
+      "slug": "api-client-java-0-12-4",
+      "title": "api-client-java v0.12.4",
+      "date": "2025-11-17",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Java API client to version 0.12.4 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1. - Java client v0.12.4 generated - Released to Maven Central v0.12.4</p>\n",
+      "fullContent": "<p>Updated Java API client to version 0.12.4 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1. - Java client v0.12.4 generated - Released to Maven Central v0.12.4</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.4\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.4</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-17-api-client-java-0-12-4.md"
+    },
+    {
+      "id": "2025-11-17-api-client-go-0-11-10",
+      "slug": "api-client-go-0-11-10",
+      "title": "api-client-go v0.11.10",
+      "date": "2025-11-17",
+      "categories": [
+        "API Clients"
+      ],
+      "summary": "<p>Updated Go API client to v0.11.10 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1 (2.755.6). - Reflects changes from OpenAPI Doc 0.9.0 - Generated using Speakeasy CLI 1.658.1 (2.755.6) - Go API client version updated to v0.11.10</p>\n",
+      "fullContent": "<p>Updated Go API client to v0.11.10 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1 (2.755.6). - Reflects changes from OpenAPI Doc 0.9.0 - Generated using Speakeasy CLI 1.658.1 (2.755.6) - Go API client version updated to v0.11.10</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.10\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.10</a></p>\n",
+      "hasTruncation": true,
+      "fileName": "2025-11-17-api-client-go-0-11-10.md"
+    },
+    {
       "id": "2025-11-14-api-client-typescript-0-13-9",
       "slug": "api-client-typescript-0-13-9",
       "title": "api-client-typescript v0.13.9",
@@ -1962,6 +2261,6 @@
     "Website",
     "langchain-glean"
   ],
-  "generatedAt": "2025-11-14T00:00:00.000Z",
-  "totalEntries": 150
+  "generatedAt": "2025-11-26T00:00:00.000Z",
+  "totalEntries": 173
 }

--- a/static/changelog.xml
+++ b/static/changelog.xml
@@ -4,7 +4,7 @@
         <title>Glean Developer Changelog</title>
         <link>https://developers.glean.com</link>
         <description>Updates and changes to the Glean Developer Platform</description>
-        <lastBuildDate>Fri, 14 Nov 2025 00:00:00 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 26 Nov 2025 00:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Glean Developer Site</generator>
         <language>en</language>
@@ -14,6 +14,282 @@
             <link>https://developers.glean.com</link>
         </image>
         <copyright>Copyright © 2025 Glean</copyright>
+        <item>
+            <title><![CDATA[REST API: changes (endpoints) 2025-11-26]]></title>
+            <link>https://developers.glean.com/changelog#rest-api-changes-open-api</link>
+            <guid isPermaLink="false">2025-11-26-rest-api-changes-open-api</guid>
+            <pubDate>Wed, 26 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>2 endpoints added</p>
+]]></description>
+            <content:encoded><![CDATA[<p>2 endpoints added</p>
+<p>Added endpoint: /custom-metadata/schema/{groupName}<br>Added endpoint: /document/{docId}/custom-metadata/{groupName}</p>
+]]></content:encoded>
+            <category>API</category>
+        </item>
+        <item>
+            <title><![CDATA[configure-mcp-server v2.1.0]]></title>
+            <link>https://developers.glean.com/changelog#configure-mcp-server-2-1-0</link>
+            <guid isPermaLink="false">2025-11-25-configure-mcp-server-2-1-0</guid>
+            <pubDate>Tue, 25 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Upgraded mcp-config-schema to version 2.0.0. - Enhancement: Updated dependency to mcp-config-schema 2.0.0 - Internal: Added CLAUDE.md</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Upgraded mcp-config-schema to version 2.0.0. - Enhancement: Updated dependency to mcp-config-schema 2.0.0 - Internal: Added CLAUDE.md</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/configure-mcp-server/releases/tag/v2.1.0">https://github.com/gleanwork/configure-mcp-server/releases/tag/v2.1.0</a></p>
+]]></content:encoded>
+            <category>MCP</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.13.14]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-13-14</link>
+            <guid isPermaLink="false">2025-11-24-api-client-typescript-0-13-14</guid>
+            <pubDate>Mon, 24 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for possible breaking changes in this response structure.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for possible breaking changes in this response structure.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.14">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.14</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.11.22]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-11-22</link>
+            <guid isPermaLink="false">2025-11-24-api-client-python-0-11-22</guid>
+            <pubDate>Mon, 24 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response.agents_response.agents_usage_by_department_insights array in glean.client.insights.retrieve() has changed. - Review integration for compatibility with updated response structure - May impact parsing or downstream processing of department insights - No new endpoints or parameters...</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response.agents_response.agents_usage_by_department_insights array in glean.client.insights.retrieve() has changed. - Review integration for compatibility with updated response structure - May impact parsing or downstream processing of department insights - No new endpoints or parameters...</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.11.22">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.22</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.12.8]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-12-8</link>
+            <guid isPermaLink="false">2025-11-24-api-client-java-0-12-8</guid>
+            <pubDate>Mon, 24 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for potential breaking changes in this response structure.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response.agentsresponse.agentsUsageByDepartmentInsights array in glean.client.insights.retrieve() has changed. - Review integration for potential breaking changes in this response structure.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.8">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.8</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.11.14]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-11-14</link>
+            <guid isPermaLink="false">2025-11-24-api-client-go-0-11-14</guid>
+            <pubDate>Mon, 24 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Changed the structure of response.AgentsResponse.AgentsUsageByDepartmentInsights[] in Glean.Client.Insights.Retrieve().</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Changed the structure of response.AgentsResponse.AgentsUsageByDepartmentInsights[] in Glean.Client.Insights.Retrieve().</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.14">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.14</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.13.13]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-13-13</link>
+            <guid isPermaLink="false">2025-11-21-api-client-typescript-0-13-13</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated TypeScript API client to version 0.13.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - TypeScript client generated at v0.13.13 - Release available as NPM package v0.13.13</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated TypeScript API client to version 0.13.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - TypeScript client generated at v0.13.13 - Release available as NPM package v0.13.13</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.13">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.13</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.13.12]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-13-12</link>
+            <guid isPermaLink="false">2025-11-21-api-client-typescript-0-13-12</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated TypeScript API client to version 0.13.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated TypeScript API client to version 0.13.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.12">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.12</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.13.11]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-13-11</link>
+            <guid isPermaLink="false">2025-11-21-api-client-typescript-0-13-11</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response structure of glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using glean.client.insights.retrieve() may require updates to handle the new response format.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response structure of glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using glean.client.insights.retrieve() may require updates to handle the new response format.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.11">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.11</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.11.20]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-11-20</link>
+            <guid isPermaLink="false">2025-11-21-api-client-python-0-11-20</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Python API client to version 0.11.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Python API client to version 0.11.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.11.20">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.20</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.11.18]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-11-18</link>
+            <guid isPermaLink="false">2025-11-21-api-client-python-0-11-18</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Python API client to version 0.11.18, based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0. - Python SDK generated at v0.11.18 - PyPI release published at v0.11.18 - Based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Python API client to version 0.11.18, based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0. - Python SDK generated at v0.11.18 - PyPI release published at v0.11.18 - Based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.11.18">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.18</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.11.16]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-11-16</link>
+            <guid isPermaLink="false">2025-11-21-api-client-python-0-11-16</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response structure for glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using this method may require updates to handle the new response format.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response structure for glean.client.insights.retrieve() has changed in a breaking way. - Breaking change: applications using this method may require updates to handle the new response format.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.11.16">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.16</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.12.7]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-12-7</link>
+            <guid isPermaLink="false">2025-11-21-api-client-java-0-12-7</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Java API client to version 0.12.7 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.7 - Released to Maven Central v0.12.7</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Java API client to version 0.12.7 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.7 - Released to Maven Central v0.12.7</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.7">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.7</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.12.6]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-12-6</link>
+            <guid isPermaLink="false">2025-11-21-api-client-java-0-12-6</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Java API client to version 0.12.6 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.6 - Released to Maven Central v0.12.6</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Java API client to version 0.12.6 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0. - Java SDK generated at v0.12.6 - Released to Maven Central v0.12.6</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.6">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.6</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.12.5]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-12-5</link>
+            <guid isPermaLink="false">2025-11-21-api-client-java-0-12-5</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response object returned by glean.client.insights.retrieve() has changed in a breaking way. - This is a breaking change and may require updates to client code using this method.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response object returned by glean.client.insights.retrieve() has changed in a breaking way. - This is a breaking change and may require updates to client code using this method.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.5">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.5</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.11.13]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-11-13</link>
+            <guid isPermaLink="false">2025-11-21-api-client-go-0-11-13</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Go API client to version 0.11.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from recent Speakeasy CLI versions</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Go API client to version 0.11.13 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from recent Speakeasy CLI versions</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.13">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.13</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.11.12]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-11-12</link>
+            <guid isPermaLink="false">2025-11-21-api-client-go-0-11-12</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Go API client to version 0.11.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from the latest Speakeasy CLI release</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Go API client to version 0.11.12 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.660.0 (2.760.2). - Reflects changes from the latest OpenAPI specification - Incorporates updates from the latest Speakeasy CLI release</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.12">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.12</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.11.11]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-11-11</link>
+            <guid isPermaLink="false">2025-11-21-api-client-go-0-11-11</guid>
+            <pubDate>Fri, 21 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>The response object returned by Glean.Client.Insights.Retrieve() has changed in a breaking way. - Breaking change to the response structure - Review integration for compatibility before upgrading</p>
+]]></description>
+            <content:encoded><![CDATA[<p>The response object returned by Glean.Client.Insights.Retrieve() has changed in a breaking way. - Breaking change to the response structure - Review integration for compatibility before upgrading</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.11">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.11</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[mcp-config-schema v2.0.0]]></title>
+            <link>https://developers.glean.com/changelog#mcp-config-schema-2-0-0</link>
+            <guid isPermaLink="false">2025-11-18-mcp-config-schema-2-0-0</guid>
+            <pubDate>Tue, 18 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Renamed components for improved semantic clarity, added support for Jetbrains IDEs and Codex, and updated documentation to reflect recent changes. - Breaking: Renamed for better semantic meaning - Enhancement: Added support for Jetbrains IDEs and Codex - Documentation: Updated README.md and...</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Renamed components for improved semantic clarity, added support for Jetbrains IDEs and Codex, and updated documentation to reflect recent changes. - Breaking: Renamed for better semantic meaning - Enhancement: Added support for Jetbrains IDEs and Codex - Documentation: Updated README.md and...</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/mcp-config-schema/releases/tag/v2.0.0">https://github.com/gleanwork/mcp-config-schema/releases/tag/v2.0.0</a></p>
+]]></content:encoded>
+            <category>MCP</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.13.10]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-13-10</link>
+            <guid isPermaLink="false">2025-11-17-api-client-typescript-0-13-10</guid>
+            <pubDate>Mon, 17 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated API client to typescript v0.13.10 based on OpenAPI Doc 0.9.0.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated API client to typescript v0.13.10 based on OpenAPI Doc 0.9.0.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.10">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.10</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.11.14]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-11-14</link>
+            <guid isPermaLink="false">2025-11-17-api-client-python-0-11-14</guid>
+            <pubDate>Mon, 17 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Python API client to version 0.11.14 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Python API client to version 0.11.14 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.650.0.</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.11.14">https://github.com/gleanwork/api-client-python/releases/tag/v0.11.14</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.12.4]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-12-4</link>
+            <guid isPermaLink="false">2025-11-17-api-client-java-0-12-4</guid>
+            <pubDate>Mon, 17 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Java API client to version 0.12.4 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1. - Java client v0.12.4 generated - Released to Maven Central v0.12.4</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Java API client to version 0.12.4 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1. - Java client v0.12.4 generated - Released to Maven Central v0.12.4</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.4">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.4</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.11.10]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-11-10</link>
+            <guid isPermaLink="false">2025-11-17-api-client-go-0-11-10</guid>
+            <pubDate>Mon, 17 Nov 2025 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Updated Go API client to v0.11.10 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1 (2.755.6). - Reflects changes from OpenAPI Doc 0.9.0 - Generated using Speakeasy CLI 1.658.1 (2.755.6) - Go API client version updated to v0.11.10</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Updated Go API client to v0.11.10 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.658.1 (2.755.6). - Reflects changes from OpenAPI Doc 0.9.0 - Generated using Speakeasy CLI 1.658.1 (2.755.6) - Go API client version updated to v0.11.10</p>
+<p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.10">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.10</a></p>
+]]></content:encoded>
+            <category>API Clients</category>
+        </item>
         <item>
             <title><![CDATA[api-client-typescript v0.13.9]]></title>
             <link>https://developers.glean.com/changelog#api-client-typescript-0-13-9</link>


### PR DESCRIPTION
### Code changes:
* The changelog generator workflow was updated to use a fixed branch name (`chore/changelog`) instead of a dynamic branch prefix based on the date. Additionally, the GitHub token used for the changelog generation was changed to a new secret (`CHANGELOG_PAT`). This simplifies the branch management and ensures consistent naming for changelog pull requests.
