### PR TITLE
chore(changelog): 2025-12-02

### DIFF
--- a/changelog/entries/2025-12-01-mcp-server-0-9-1.md
+++ b/changelog/entries/2025-12-01-mcp-server-0-9-1.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-server v0.9.1'
+categories: ['MCP']
+---
+
+v0.9.0 was re-released with no additional protocol-level or config schema changes.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-server/releases/tag/v0.9.1


### PR DESCRIPTION
Adds 1 changelog entries generated on 2025-12-02.

Files:
- changelog/entries/2025-12-01-mcp-server-0-9-1.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}