### PR TITLE
fix: Excludes npm from the link checker (npm blocks bots)

### DIFF
--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -175,6 +175,7 @@ lychee_cmd+=(
   --exclude "^https://langchain-ai\.github\.io/"   # LangChain docs (flaky)
   --exclude "^https://picsum\.photos/"             # Random image service
   --exclude "^https://docs\.lumapps\.com/"        # LumApps docs (auth)
+  --exclude "^https://www\.npmjs\.com/"           # npm.com blocks automated requests (403)
 )
 
 # Add exclusions for GitHub URLs (will be handled separately if needed)


### PR DESCRIPTION
Fixes link checker to exclude blocked URLs.

### Code changes:
* The script now excludes the npm website from the link checker to prevent automated requests from being blocked with a 403 error. This is achieved by adding the line `--exclude "^https://www\.npmjs\.com/"`.
