### PR TITLE
fix(ci): remove verify-build job from trigger-redeploy workflow

### DIFF
--- a/.github/workflows/trigger-redeploy.yml
+++ b/.github/workflows/trigger-redeploy.yml
@@ -102,27 +102,6 @@ jobs:
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash
 
-  verify-build:
-    if: needs.trigger-redeploy.outputs.has_changes == 'true'
-    needs: trigger-redeploy
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up mise
-        uses: jdx/mise-action@v2
-        with:
-          cache: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Verify Build
-        run: pnpm build
-
   summary:
     runs-on: ubuntu-latest
     needs: trigger-redeploy


### PR DESCRIPTION
The verify-build job was redundant because:

- The PR is made regardless of the result of verify-build
- The CI workflow for the PR should be running tests when the PR is created