### PR TITLE
chore(changelog): 2025-12-11

### DIFF
--- a/changelog/entries/2025-12-10-api-client-go-0-11-15.md
+++ b/changelog/entries/2025-12-10-api-client-go-0-11-15.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.15'
+categories: ['API Clients']
+---
+
+New governance findings export endpoints were added, and multiple request and response fields were changed across Announcements, Answers, Chat, Collections, Documents, Pins, Search, Entities, Shortcuts, and Verification APIs. - Added: Glean.Governance.Createfindingsexport, Listfindingsexports,...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.15

--- a/changelog/entries/2025-12-10-api-client-go-0-11-16.md
+++ b/changelog/entries/2025-12-10-api-client-go-0-11-16.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.16'
+categories: ['API Clients']
+---
+
+Updated Go API client to version 0.11.16 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.675.2 (2.778.5). - No additional details or breaking changes were specified in the release notes.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.16

--- a/changelog/entries/2025-12-10-api-client-java-0-12-10.md
+++ b/changelog/entries/2025-12-10-api-client-java-0-12-10.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.10'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.10 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.675.2. - Java client v0.12.10 generated - Released to Maven Central v0.12.10
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.10

--- a/changelog/entries/2025-12-10-api-client-java-0-12-9.md
+++ b/changelog/entries/2025-12-10-api-client-java-0-12-9.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.9'
+categories: ['API Clients']
+---
+
+Added new findings export endpoints and introduced or changed multiple request and response fields across governance, announcements, answers, chat, collections, documents, insights, messages, pins, search, entities, shortcuts, and verification APIs. - Added: glean.governance.createfindingsexport(),...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.9

--- a/changelog/entries/2025-12-10-api-client-python-0-11-23.md
+++ b/changelog/entries/2025-12-10-api-client-python-0-11-23.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.11.23'
+categories: ['API Clients']
+---
+
+New governance findings export endpoints were added and multiple request/response fields were changed across announcements, answers, chat, collections, documents, pins, search, entities, shortcuts, verification, and governance data policies APIs. - Added: glean.governance.createfindingsexport(),...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.11.23

--- a/changelog/entries/2025-12-10-api-client-typescript-0-13-15.md
+++ b/changelog/entries/2025-12-10-api-client-typescript-0-13-15.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.13.15'
+categories: ['API Clients']
+---
+
+New governance findings export endpoints were added, and multiple existing endpoints changed request and response fields related to authorship, roles, attribution, and sensitive content options. - Added: glean.governance.createfindingsexport(), listfindingsexports(), downloadfindingsexport(),...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.15

--- a/changelog/entries/2025-12-10-api-client-typescript-0-13-16.md
+++ b/changelog/entries/2025-12-10-api-client-typescript-0-13-16.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.13.16'
+categories: ['API Clients']
+---
+
+Updated TypeScript API client to version 0.13.16 based on OpenAPI Doc 0.9.0.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.16


### PR DESCRIPTION
Adds 7 changelog entries generated on 2025-12-11.

Files:
- changelog/entries/2025-12-10-api-client-java-0-12-10.md
- changelog/entries/2025-12-10-api-client-java-0-12-9.md
- changelog/entries/2025-12-10-api-client-python-0-11-23.md
- changelog/entries/2025-12-10-api-client-typescript-0-13-16.md
- changelog/entries/2025-12-10-api-client-typescript-0-13-15.md
- changelog/entries/2025-12-10-api-client-go-0-11-16.md
- changelog/entries/2025-12-10-api-client-go-0-11-15.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}