### PR TITLE
chore(changelog): 2025-12-12

### DIFF
--- a/changelog/entries/2025-12-11-api-client-go-0-11-17.md
+++ b/changelog/entries/2025-12-11-api-client-go-0-11-17.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.17'
+categories: ['API Clients']
+---
+
+Updated Go API client to version 0.11.17 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.675.4 (2.779.2). - No additional details about new endpoints, parameters, or breaking changes were provided in these release notes.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.17

--- a/changelog/entries/2025-12-11-api-client-java-0-12-11.md
+++ b/changelog/entries/2025-12-11-api-client-java-0-12-11.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.11'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.11 based on OpenAPI Doc 0.9.0. - Java client generated at v0.12.11 - Released to Maven Central v0.12.11
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.11

--- a/changelog/entries/2025-12-11-api-client-python-0-11-24.md
+++ b/changelog/entries/2025-12-11-api-client-python-0-11-24.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.11.24'
+categories: ['API Clients']
+---
+
+Updated Python API client to version 0.11.24 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.675.4 (2.779.2). - Python client generated at v0.11.24 - Released on PyPI as v0.11.24
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.11.24

--- a/changelog/entries/2025-12-11-api-client-typescript-0-13-17.md
+++ b/changelog/entries/2025-12-11-api-client-typescript-0-13-17.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.13.17'
+categories: ['API Clients']
+---
+
+Updated TypeScript API client to version 0.13.17 based on OpenAPI Doc 0.9.0. - Reflects changes from OpenAPI Doc 0.9.0 - TypeScript client generated at v0.13.17 - NPM package released at v0.13.17
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.17


### PR DESCRIPTION
Adds 4 changelog entries generated on 2025-12-12.

Files:
- changelog/entries/2025-12-11-api-client-java-0-12-11.md
- changelog/entries/2025-12-11-api-client-python-0-11-24.md
- changelog/entries/2025-12-11-api-client-typescript-0-13-17.md
- changelog/entries/2025-12-11-api-client-go-0-11-17.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}