### PR TITLE
chore(changelog): 2025-12-13

### DIFF
--- a/changelog/entries/2025-12-12-api-client-go-0-11-18.md
+++ b/changelog/entries/2025-12-12-api-client-go-0-11-18.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.18'
+categories: ['API Clients']
+---
+
+Added ExportSize to the response of Glean.Governance.Createfindingsexport() and to each export in Glean.Governance.Listfindingsexports(). - Glean.Governance.Createfindingsexport(): response.ExportSize added - Glean.Governance.Listfindingsexports(): response.Exports.[].ExportSize added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.18

--- a/changelog/entries/2025-12-12-api-client-java-0-12-12.md
+++ b/changelog/entries/2025-12-12-api-client-java-0-12-12.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.12'
+categories: ['API Clients']
+---
+
+Added export size fields to findings export APIs. - glean.governance.createfindingsexport(): response.exportsize added - glean.governance.listfindingsexports(): response.exports.[].exportSize added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.12

--- a/changelog/entries/2025-12-12-api-client-python-0-11-25.md
+++ b/changelog/entries/2025-12-12-api-client-python-0-11-25.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.11.25'
+categories: ['API Clients']
+---
+
+Added export_size to the response of glean.governance.createfindingsexport() and to each export in glean.governance.listfindingsexports(). - glean.governance.createfindingsexport(): response.export_size added - glean.governance.listfindingsexports(): response.exports.[].export_size added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.11.25

--- a/changelog/entries/2025-12-12-api-client-typescript-0-13-18.md
+++ b/changelog/entries/2025-12-12-api-client-typescript-0-13-18.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.13.18'
+categories: ['API Clients']
+---
+
+Added export size fields to findings export APIs. - glean.governance.createfindingsexport(): response.exportsize added - glean.governance.listfindingsexports(): response.exports.[].exportSize added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.18


### PR DESCRIPTION
Adds 4 changelog entries generated on 2025-12-13.

Files:
- changelog/entries/2025-12-12-api-client-java-0-12-12.md
- changelog/entries/2025-12-12-api-client-python-0-11-25.md
- changelog/entries/2025-12-12-api-client-typescript-0-13-18.md
- changelog/entries/2025-12-12-api-client-go-0-11-18.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}