### PR TITLE
feat(guides): add deep linked citations migration guide

### DIFF
--- a/changelog/entries/2025-12-16-deep-linked-citations-guide.md
+++ b/changelog/entries/2025-12-16-deep-linked-citations-guide.md
@@ -17,4 +17,4 @@ The guide covers:
 
 The change is additive and backward compatible—no action required unless you want to render the richer citation experience.
 
-Visit the [Deep Linked Citations guide](/docs/guides/chat/deep-linked-citations) for more information.
+Visit the [Deep Linked Citations guide](../guides/chat/deep-linked-citations) for more information.

--- a/changelog/entries/2025-12-16-deep-linked-citations-guide.md
+++ b/changelog/entries/2025-12-16-deep-linked-citations-guide.md
@@ -1,0 +1,20 @@
+---
+title: "Deep Linked Citations Migration Guide"
+categories: ["API", "Documentation"]
+---
+
+Added a migration guide for custom chat frontends to adopt deep-linked citations in the `/chat` API response.
+
+{/* truncate */}
+
+Deep-linked citations upgrade Glean Chat's citations from document-level to text-level—the response now includes exact quoted snippets from source documents via the new `referenceRanges[].snippets[]` field.
+
+The guide covers:
+- New response format and fields
+- Minimal vs full migration paths
+- Code examples (TypeScript/React)
+- Fetching document content for contextual previews
+
+The change is additive and backward compatible—no action required unless you want to render the richer citation experience.
+
+Visit the [Deep Linked Citations guide](/docs/guides/chat/deep-linked-citations) for more information.

--- a/docs/guides/chat/deep-linked-citations.mdx
+++ b/docs/guides/chat/deep-linked-citations.mdx
@@ -13,6 +13,8 @@ import TabItem from '@theme/TabItem';
 
 This guide explains how to update a custom chat frontend that uses Glean's `/chat` REST API to take advantage of **deep-linked (direct-quote) citations**, while remaining backward compatible with existing responses.
 
+Deep-linked citations are available starting Q4 2025. REST API support is currently in Beta.
+
 ## Overview
 
 Deep-linked citations upgrade Glean Chat's citations from **document-level** to **text-level**:
@@ -30,10 +32,12 @@ Deep-linked citations are available when all of the following are true:
 
 <CardGroup cols={2}>
   <Card title="Agentic Loop Runtime" icon="Cpu">
-    The `/chat` request must be running on Agentic Loop (the same runtime used by the Glean UI)
+    Your `/chat` request must use Agentic Loop. Set `agentConfig.agent` to `"FAST"` or `"ADVANCED"` in your request.
+    If omitted, requests default to Chat V2 which does not support deep-linked citations.
   </Card>
-  <Card title="Supported LLM Configuration" icon="Brain">
-    The deployment must use a supported LLM configuration for Agentic Loop
+  <Card title="Supported LLM Models" icon="Brain">
+    Deep-linked citations are supported with OpenAI (GPT) and Anthropic (Claude) models.
+    Gemini is not currently supported.
   </Card>
 </CardGroup>
 
@@ -84,33 +88,40 @@ When deep-linked citations are available for a given citation, the fragment's `c
 
 ```json
 {
-  "citation": {
-    "sourceDocument": {
-      "id": "GMAILNATIVE_THREAD_197cc5e9c51a13e1",
-      "datasource": "gmailnative",
-      "connectorType": "FEDERATED_SEARCH",
-      "title": "Request to get added to ChatGPT Teams to try Codex",
-      "url": "https://mail.google.com/mail/u/#inbox/197cc5e9c51a13e1"
-    },
-    "referenceRanges": [
-      {
-        "textRange": {
-          "startIndex": 50,
-          "endIndex": 120,
-          "type": "LINK"
-        },
-        "snippets": [
-          {
-            "text": "I'd like to try out Codex for engineering tasks — is it possible to get added",
-            "pageNumber": 1
-          },
-          {
-            "text": "to the ChatGPT Teams account?"
+  "messages": [
+    {
+      // ...
+      "fragments": [
+        // ...
+        {
+          "citation": {
+            "sourceDocument": { /* ... */ },
+            // highlight-start
+            "referenceRanges": [
+              {
+                "textRange": {
+                  "startIndex": 50,
+                  "endIndex": 120,
+                  "type": "LINK"
+                },
+                "snippets": [
+                  {
+                    "text": "I'd like to try out Codex for engineering tasks...",
+                    "pageNumber": 1
+                  },
+                  {
+                    "text": "to the ChatGPT Teams account?"
+                  }
+                ]
+              }
+            ]
+            // highlight-end
           }
-        ]
-      }
-    ]
-  }
+        }
+      ],
+      "citations": [ /* ... */ ]
+    }
+  ]
 }
 ```
 
@@ -119,10 +130,10 @@ When deep-linked citations are available for a given citation, the fragment's `c
 | Field | Description |
 |-------|-------------|
 | `referenceRanges[]` | Optional array. Many citations will continue to be document-level only. |
-| `textRange` | Describes which part of the assistant response the citation is attached to (existing behavior). |
-| `snippets[]` | **New**: An array of direct-quote snippets from the source document that support the statement. |
-| `snippet.text` | The quoted text from the source document. |
-| `snippet.pageNumber` | Optional page number where the snippet appears. |
+| `referenceRanges[].textRange` | Describes which part of the assistant response the citation is attached to (existing behavior). |
+| `referenceRanges[].snippets[]` | **New**: An array of direct-quote snippets from the source document that support the statement. |
+| `referenceRanges[].snippets[].text` | The quoted text from the source document. |
+| `referenceRanges[].snippets[].pageNumber` | Optional page number where the snippet appears. |
 
 Each `snippet` is a `SearchResultSnippet` object from the public search/documents API, shared with other Glean surfaces. At minimum it has `text: string`, but may also include `pageNumber: number` and other metadata such as snippet identifiers.
 
@@ -153,7 +164,7 @@ If you only want to stay compatible without changing your UI:
 
 ### Full Migration
 
-The goal is to mirror the Glean UI behavior: hovering a citation shows the **direct quote** that backs the statement, plus surrounding context and (where available) a **page number** and preview.
+If your goal is to mirror the Glean UI behavior, you'll render hover cards that show the **direct quote** backing each statement, plus surrounding context and (where available) a **page number** and preview.
 
 **High-level flow for each assistant message:**
 
@@ -321,23 +332,6 @@ function CitationPopover({ citation }: { citation: any }) {
 | **Coverage** | Deep-linked citations are not provided for world-knowledge or web-search-only answers. Some citations may intentionally fall back to document-level when matching is uncertain, to avoid misleading users |
 
 Design your UI to gracefully fall back to document-level behavior when no `referenceRanges` / `snippets` are present.
-
-## Backward Compatibility
-
-The `/chat` response format change is **additive**:
-
-- No existing fields are removed or renamed
-- New fields are optional and can be ignored safely
-
-:::note
-The migration from Chat V2 to Agentic Loop for the REST API is logically separate from deep-linked citations. However, deep-linked citations are only available on Agentic Loop. Customers may notice response quality differences when switching from Chat V2 to Agentic Loop, independent of citation changes.
-:::
-
-**Key points for API clients:**
-
-- **No immediate changes are required**—you only need to update your UI if you want to surface direct-quote snippets
-- Regenerate from the latest OpenAPI spec for `/chat` and `/getdocuments`
-- Handle unknown/extra fields defensively to accommodate future enhancements (e.g., more snippet metadata, richer deep-link URLs)
 
 ## Migration Checklist
 

--- a/docs/guides/chat/deep-linked-citations.mdx
+++ b/docs/guides/chat/deep-linked-citations.mdx
@@ -1,0 +1,389 @@
+---
+title: Deep Linked Citations
+description: Upgrade your custom chat frontend to display rich citation previews with highlighted snippets from source documents
+---
+
+import Card from '@site/src/components/Card';
+import CardGroup from '@site/src/components/CardGroup';
+import { Steps } from '@site/src/components/Steps';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Deep Linked Citations
+
+This guide explains how to update a custom chat frontend that uses Glean's `/chat` REST API to take advantage of **deep-linked (direct-quote) citations**, while remaining backward compatible with existing responses.
+
+## Overview
+
+Deep-linked citations upgrade Glean Chat's citations from **document-level** to **text-level**:
+
+- Citations can now include **exact snippets** from the source document that support the preceding statement, rather than just pointing to the document as a whole.
+- In the `/chat` response, this appears as a new optional `referenceRanges[].snippets[]` array attached to each inline `citation` fragment.
+
+:::tip Backward Compatible
+If your integration ignores these new fields, everything continues to work. The change is **additive and backward compatible**. This guide is about how to opt in and render the richer experience.
+:::
+
+## Prerequisites
+
+Deep-linked citations are available when all of the following are true:
+
+<CardGroup cols={2}>
+  <Card title="Agentic Loop Runtime" icon="Cpu">
+    The `/chat` request must be running on Agentic Loop (the same runtime used by the Glean UI)
+  </Card>
+  <Card title="Supported LLM Configuration" icon="Brain">
+    The deployment must use a supported LLM configuration for Agentic Loop
+  </Card>
+</CardGroup>
+
+:::note
+Deep-linked citations are provided for answers grounded in **enterprise content** (company documents, email, etc.), not for pure world-knowledge or web search answers. If these conditions are not met, your existing citation UI continues to function as today.
+:::
+
+## Response Format
+
+### Baseline Structure (Unchanged)
+
+Each chat response message still looks like:
+
+```json
+{
+  "messages": [
+    {
+      "author": "GLEAN_AI",
+      "fragments": [
+        { "text": "Some generated text. " },
+        {
+          "citation": {
+            "sourceDocument": {
+              "id": "DOC_ID",
+              "datasource": "gdrive",
+              "title": "Document title",
+              "url": "https://docs.google.com/..."
+            }
+          }
+        }
+      ],
+      "citations": [ /* existing top-level citations, unchanged */ ]
+    }
+  ]
+}
+```
+
+Your existing integration likely uses:
+
+- `fragments[].text` to render the assistant answer
+- `fragments[].citation.sourceDocument` and/or `citations[]` to render citation pills
+
+All of that remains valid.
+
+### New `referenceRanges` Field
+
+When deep-linked citations are available for a given citation, the fragment's `citation` now also includes **reference ranges** with **snippets**:
+
+```json
+{
+  "citation": {
+    "sourceDocument": {
+      "id": "GMAILNATIVE_THREAD_197cc5e9c51a13e1",
+      "datasource": "gmailnative",
+      "connectorType": "FEDERATED_SEARCH",
+      "title": "Request to get added to ChatGPT Teams to try Codex",
+      "url": "https://mail.google.com/mail/u/#inbox/197cc5e9c51a13e1"
+    },
+    "referenceRanges": [
+      {
+        "textRange": {
+          "startIndex": 50,
+          "endIndex": 120,
+          "type": "LINK"
+        },
+        "snippets": [
+          {
+            "text": "I'd like to try out Codex for engineering tasks — is it possible to get added",
+            "pageNumber": 1
+          },
+          {
+            "text": "to the ChatGPT Teams account?"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Key points:**
+
+| Field | Description |
+|-------|-------------|
+| `referenceRanges[]` | Optional array. Many citations will continue to be document-level only. |
+| `textRange` | Describes which part of the assistant response the citation is attached to (existing behavior). |
+| `snippets[]` | **New**: An array of direct-quote snippets from the source document that support the statement. |
+| `snippet.text` | The quoted text from the source document. |
+| `snippet.pageNumber` | Optional page number where the snippet appears. |
+
+Each `snippet` is a `SearchResultSnippet` object from the public search/documents API, shared with other Glean surfaces. At minimum it has `text: string`, but may also include `pageNumber: number` and other metadata such as snippet identifiers.
+
+:::note
+Top-level `citations[]` on the message remain unchanged and still hold document-level info. They are not required to implement deep-linking but may be useful for your existing UI logic.
+:::
+
+## Migration Options
+
+<CardGroup cols={2}>
+  <Card title="Minimal Migration" icon="Shield">
+    Stay compatible without UI changes—just update your types to tolerate the new fields
+  </Card>
+  <Card title="Full Migration" icon="Sparkles">
+    Render deep-linked citations with hover previews showing direct quotes
+  </Card>
+</CardGroup>
+
+### Minimal Migration
+
+If you only want to stay compatible without changing your UI:
+
+1. **Update your deserialization model** to tolerate the new fields:
+   - The `citation` object now may contain a `referenceRanges` array with nested `snippets`
+   - If you are using a generated client or strict type definitions, regenerate from the latest OpenAPI spec so these fields are known but optional
+
+2. **Ignore `referenceRanges` / `snippets` for now.** The behavior will match pre-deep-linked citations. This is a good first step while you plan UI updates.
+
+### Full Migration
+
+The goal is to mirror the Glean UI behavior: hovering a citation shows the **direct quote** that backs the statement, plus surrounding context and (where available) a **page number** and preview.
+
+**High-level flow for each assistant message:**
+
+1. Render `fragments[].text` as you do today
+2. For each `fragments[].citation`:
+   - Always show the document-level citation pill (title, datasource, icon, etc.) based on `sourceDocument`—this is unchanged
+   - If `referenceRanges[].snippets[]` is present, use those snippets to populate the **hover card / popover** with direct quotes and surrounding context
+   - Optionally show the `pageNumber` when present
+3. Clicking the citation can continue to open `sourceDocument.url`
+
+## Fetching Document Content
+
+To display **surrounding text** around each snippet, fetch the full document text via `/getdocuments` using the cited document IDs:
+
+```json
+POST /rest/api/v1/getdocuments
+
+{
+  "documentSpecs": [{ "id": "DOC_ID" }],
+  "includeFields": ["DOCUMENT_CONTENT"]
+}
+```
+
+The response includes `content.fullTextList` which you can join to get the full document text, then search for each snippet's `text` within that string to derive preceding and following context.
+
+## Code Examples
+
+<Tabs>
+  <TabItem value="typescript" label="TypeScript/React">
+
+```tsx
+type Snippet = { text: string; pageNumber?: number }
+
+async function loadDocumentContent(docId: string): Promise<string> {
+  const resp = await fetch("/rest/api/v1/getdocuments", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      documentSpecs: [{ id: docId }],
+      includeFields: ["DOCUMENT_CONTENT"],
+    }),
+  })
+  const data = await resp.json()
+  const doc = Object.values(data.documents)[0] as any
+  return (doc?.content?.fullTextList || []).join("\n\n")
+}
+
+function findSurroundingText(
+  fullText: string,
+  snippetText: string,
+  windowChars = 200,
+): { preceding: string; cited: string; following: string } {
+  const idx = fullText.indexOf(snippetText)
+  if (idx === -1) {
+    return { preceding: "", cited: snippetText, following: "" }
+  }
+  const start = Math.max(0, idx - windowChars)
+  const end = Math.min(fullText.length, idx + snippetText.length + windowChars)
+  return {
+    preceding: fullText.slice(start, idx),
+    cited: fullText.slice(idx, idx + snippetText.length),
+    following: fullText.slice(idx + snippetText.length, end),
+  }
+}
+
+function CitationPopover({ citation }: { citation: any }) {
+  const [docContent, setDocContent] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (citation.sourceDocument?.id) {
+      loadDocumentContent(citation.sourceDocument.id).then(setDocContent)
+    }
+  }, [citation.sourceDocument?.id])
+
+  const ranges = citation.referenceRanges ?? []
+
+  if (!ranges.length) {
+    // Fallback: document-level citation only
+    return <div>{citation.sourceDocument?.title}</div>
+  }
+
+  return (
+    <div className="citation-popover">
+      <div className="citation-header">
+        <strong>{citation.sourceDocument?.title}</strong>
+        {ranges[0]?.snippets?.[0]?.pageNumber != null && (
+          <span> · Page {ranges[0].snippets[0].pageNumber}</span>
+        )}
+      </div>
+      <div className="snippet-context">
+        {ranges.flatMap((range, idx) =>
+          (range.snippets || []).map((s, j) => {
+            if (!docContent) {
+              return <div key={`${idx}-${j}`}>{s.text}</div>
+            }
+            const { preceding, cited, following } = findSurroundingText(
+              docContent,
+              s.text,
+            )
+            // Fallback if snippet text couldn't be matched in document
+            if (!preceding && !following) {
+              return <div key={`${idx}-${j}`}>{s.text}</div>
+            }
+            return (
+              <p key={`${idx}-${j}`}>
+                {preceding && <span className="muted">...{preceding}</span>}
+                <mark>{cited}</mark>
+                {following && <span className="muted">{following}...</span>}
+              </p>
+            )
+          }),
+        )}
+      </div>
+    </div>
+  )
+}
+```
+
+  </TabItem>
+  <TabItem value="pseudocode" label="Pseudocode">
+
+```
+# For each citation with referenceRanges:
+
+1. Extract document ID from citation.sourceDocument.id
+
+2. Fetch document content:
+   POST /getdocuments
+   Body: { documentSpecs: [{ id: docId }], includeFields: ["DOCUMENT_CONTENT"] }
+
+3. Join fullTextList to get complete document text
+
+4. For each snippet in referenceRanges[].snippets[]:
+   a. Find snippet.text within the full document text
+   b. Extract ~200 chars before and after for context
+   c. Render with:
+      - Preceding context (muted/gray)
+      - Snippet text (highlighted)
+      - Following context (muted/gray)
+      - Page number if available
+
+5. Show in hover popover when user hovers citation pill
+```
+
+  </TabItem>
+</Tabs>
+
+## UX Guidelines
+
+### When Users See Deep-Linked Snippets
+
+- Not every citation pill will have snippet highlights—deep-linking only appears when the LLM confidently matches a snippet
+- When present, the hover popover should:
+  - Highlight the **cited snippet** with emphasis (e.g., background color or bold)
+  - Show a few lines before and after for context
+  - Optionally show **page number** if provided
+  - Optionally offer an **"Expand"** button for a larger preview
+
+### Limitations
+
+| Limitation | Description |
+|------------|-------------|
+| **Complex formatting** | Tables, spreadsheets, code blocks, and heavy HTML may render as plain text in the snippet preview, which can look noisy or hard to read |
+| **Source navigation** | Clicking a citation opens the underlying document. Jumping directly to the exact page/offset is not guaranteed for all sources—it's supported only in some cases (e.g., slide number for certain PPT sources, some page-number support for PDFs) and is still being expanded |
+| **Coverage** | Deep-linked citations are not provided for world-knowledge or web-search-only answers. Some citations may intentionally fall back to document-level when matching is uncertain, to avoid misleading users |
+
+Design your UI to gracefully fall back to document-level behavior when no `referenceRanges` / `snippets` are present.
+
+## Backward Compatibility
+
+The `/chat` response format change is **additive**:
+
+- No existing fields are removed or renamed
+- New fields are optional and can be ignored safely
+
+:::note
+The migration from Chat V2 to Agentic Loop for the REST API is logically separate from deep-linked citations. However, deep-linked citations are only available on Agentic Loop. Customers may notice response quality differences when switching from Chat V2 to Agentic Loop, independent of citation changes.
+:::
+
+**Key points for API clients:**
+
+- **No immediate changes are required**—you only need to update your UI if you want to surface direct-quote snippets
+- Regenerate from the latest OpenAPI spec for `/chat` and `/getdocuments`
+- Handle unknown/extra fields defensively to accommodate future enhancements (e.g., more snippet metadata, richer deep-link URLs)
+
+## Migration Checklist
+
+<Steps>
+  <div>
+    <h3>Verify Server Configuration</h3>
+    <p>Ensure your <code>/chat</code> requests are using <strong>Agentic Loop</strong> and an LLM configuration that supports deep-linked citations.</p>
+  </div>
+
+  <div>
+    <h3>Update API Types</h3>
+    <p>Regenerate your client types from the latest OpenAPI spec so <code>ChatMessageCitation.referenceRanges[].snippets[]</code> and <code>SearchResultSnippet.pageNumber</code> are present but optional.</p>
+  </div>
+
+  <div>
+    <h3>Handle New Fields Defensively</h3>
+    <p>Ensure your deserialization tolerates the new fields. Handle unknown/extra fields defensively to accommodate future enhancements.</p>
+  </div>
+
+  <div>
+    <h3>Update Citation UI</h3>
+    <p>Keep your existing document-level citation pills (title, icon, click → <code>sourceDocument.url</code>). If <code>referenceRanges[].snippets[]</code> exists, show snippet text in your hover/detail view with optional page number.</p>
+  </div>
+
+  <div>
+    <h3>Add Contextual Preview (Recommended)</h3>
+    <p>On hover or "expand", call <code>/getdocuments</code> with the cited document IDs and <code>includeFields: ["DOCUMENT_CONTENT"]</code>. Use the returned <code>fullTextList</code> to compute surrounding context and highlight each snippet.</p>
+  </div>
+</Steps>
+
+## Related Documentation
+
+<CardGroup cols={2}>
+  <Card
+    title="Chat API Reference"
+    icon="chat"
+    iconSet="glean"
+    href="/api/client-api/chat/overview"
+  >
+    Complete reference for the /chat endpoint
+  </Card>
+  <Card
+    title="Read Documents API"
+    icon="FileText"
+    href="/api/client-api/documents/getdocuments"
+  >
+    Fetch document content with includeFields options
+  </Card>
+</CardGroup>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -108,11 +108,6 @@ const baseSidebars: SidebarsConfig = {
               id: 'guides/chat/chatbot-example',
               label: 'Chatbot Example',
             },
-            {
-              type: 'doc',
-              id: 'guides/chat/deep-linked-citations',
-              label: 'Deep Linked Citations',
-            },
           ],
         },
         {
@@ -254,6 +249,21 @@ const baseSidebars: SidebarsConfig = {
             icon: 'mcp',
             iconSet: 'glean',
           },
+        },
+        {
+          type: 'category',
+          label: 'Migration Guides',
+          customProps: {
+            icon: 'RefreshCw',
+            iconSet: 'feather',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'guides/chat/deep-linked-citations',
+              label: 'Deep Linked Citations',
+            },
+          ],
         },
       ],
     },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -108,6 +108,11 @@ const baseSidebars: SidebarsConfig = {
               id: 'guides/chat/chatbot-example',
               label: 'Chatbot Example',
             },
+            {
+              type: 'doc',
+              id: 'guides/chat/deep-linked-citations',
+              label: 'Deep Linked Citations',
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary

- Adds a new migration guide for customers using custom frontends to adopt deep-linked (direct-quote) citations in their Chat API implementations
- Updates sidebar navigation to include the new guide under Guides > Chat

## Content Overview

The guide covers:
- **Overview**: What deep-linked citations are and backward compatibility
- **Prerequisites**: Agentic Loop runtime and supported LLM configurations
- **Response Format**: Baseline structure and new `referenceRanges[].snippets[]` field
- **Migration Options**: Minimal (just update types) vs Full (render hover previews)
- **Code Examples**: TypeScript/React implementation with pseudocode alternative
- **UX Guidelines**: When users see snippets, limitations, graceful fallback
- **Backward Compatibility**: Chat V2 → Agentic Loop migration context
- **Migration Checklist**: Step-by-step adoption guide

## Test plan

- [ ] Run `pnpm start` and verify the page loads at `/guides/chat/deep-linked-citations`
- [ ] Verify sidebar navigation shows "Deep Linked Citations" under Chat
- [ ] Review code examples for accuracy
- [ ] Verify all MDX components render correctly (Cards, Steps, Tabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)