### PR TITLE
chore(changelog): 2026-01-06

### DIFF
--- a/changelog/entries/2026-01-05-mcp-config-schema-3-0-0-beta-0.md
+++ b/changelog/entries/2026-01-05-mcp-config-schema-3-0-0-beta-0.md
@@ -1,0 +1,12 @@
+---
+title: 'mcp-config-schema v3.0.0-beta.0'
+categories: ['MCP']
+---
+
+mcp-config-schema v3.0.0-beta.0.
+
+- mcp-config-schema v3.0.0-beta.0.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config-schema/releases/tag/v3.0.0-beta.0

--- a/changelog/entries/2026-01-06-mcp-config-schema-3-0-0.md
+++ b/changelog/entries/2026-01-06-mcp-config-schema-3-0-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v3.0.0'
+categories: ['MCP']
+---
+
+Server naming and CLI configuration are now vendor-neutral, with updated terminology and improved type safety in config builders. - Introduced serverNameBuilder and commandBuilder callbacks for vendor neutrality - Updated scripts to use stdio/http terminology and added markdown helpers - Added...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config-schema/releases/tag/v3.0.0


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-01-06.

Files:
- changelog/entries/2026-01-06-mcp-config-schema-3-0-0.md
- changelog/entries/2026-01-05-mcp-config-schema-3-0-0-beta-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}