### PR TITLE
chore(changelog): 2026-01-08

### DIFF
--- a/changelog/entries/2026-01-07-configure-mcp-server-3-0-0.md
+++ b/changelog/entries/2026-01-07-configure-mcp-server-3-0-0.md
@@ -1,0 +1,10 @@
+---
+title: 'configure-mcp-server v3.0.0'
+categories: ['MCP']
+---
+
+The minimum supported Node.js version is now 22 LTS, and internal dependencies and documentation have been updated. - Breaking: Node.js 22 LTS is now required - Documentation: Added GA stability badge to README - Internal: Migrated to bintastic and updated config package dependencies
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.0.0


### PR DESCRIPTION
Adds 1 changelog entries generated on 2026-01-08.

Files:
- changelog/entries/2026-01-07-configure-mcp-server-3-0-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}