### PR TITLE
chore(changelog): 2026-01-09

### DIFF
--- a/changelog/entries/2026-01-08-mcp-config-schema-3-1-0.md
+++ b/changelog/entries/2026-01-08-mcp-config-schema-3-1-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v3.1.0'
+categories: ['MCP']
+---
+
+This release adds native HTTP transport support for JetBrains (2025.2+), deprecates getNormalizedServersConfig for future removal, corrects the Junie config path, and introduces config validation for Claude Code commands. - Added native HTTP transport support for JetBrains (2025.2+) - Deprecated...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config-schema/releases/tag/v3.1.0


### PR DESCRIPTION
Adds 1 changelog entries generated on 2026-01-09.

Files:
- changelog/entries/2026-01-08-mcp-config-schema-3-1-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}