### PR TITLE
Update light theme warning color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -139,13 +139,13 @@
   --ifm-color-success-lighter: #5c62f1;
   --ifm-color-success-lightest: #8488f4;
 
-  --ifm-color-warning: #d8fd49; /* Indexing API - Glean green */
-  --ifm-color-warning-dark: #d0fc25;
-  --ifm-color-warning-darker: #ccfc12;
-  --ifm-color-warning-darkest: #a9d805;
-  --ifm-color-warning-light: #e0fd6d;
-  --ifm-color-warning-lighter: #e4fd80;
-  --ifm-color-warning-lightest: #edfdab;
+  --ifm-color-warning: #8a6a00; /* Indexing API - gold */
+  --ifm-color-warning-dark: #725700;
+  --ifm-color-warning-darker: #5c4600;
+  --ifm-color-warning-darkest: #3d2e00;
+  --ifm-color-warning-light: #d4b106;
+  --ifm-color-warning-lighter: #fadb14;
+  --ifm-color-warning-lightest: #fff566;
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
Warning color is a neon green/yellow that's impossible to read on a white background

# 🙈 
<img width="757" height="93" alt="Screenshot 2026-01-09 at 10 50 26 AM" src="https://github.com/user-attachments/assets/7d358e41-6aa6-4582-937d-8b2b072d1ca7" />

# 🤩 
<img width="730" height="33" alt="Screenshot 2026-01-09 at 10 59 59 AM" src="https://github.com/user-attachments/assets/0622521e-4a13-4a05-af74-ce82f30da697" />

# 🕶️ 
<img width="738" height="35" alt="Screenshot 2026-01-09 at 11 00 19 AM" src="https://github.com/user-attachments/assets/1762ef4a-fdd5-4d67-9230-efd9163884cd" />

## All new colors
<img width="451" height="132" alt="Screenshot 2026-01-09 at 10 59 52 AM" src="https://github.com/user-attachments/assets/0024d23c-19dd-44de-8483-9428dc99581f" />
