### PR TITLE
chore(changelog): 2026-01-10

### DIFF
--- a/changelog/entries/2026-01-09-configure-mcp-server-3-0-1.md
+++ b/changelog/entries/2026-01-09-configure-mcp-server-3-0-1.md
@@ -1,0 +1,10 @@
+---
+title: 'configure-mcp-server v3.0.1'
+categories: ['MCP']
+---
+
+Removed the engines field from configuration and restored Node 20 CI testing. - Internal change only - No impact on external protocol or config schema - Change committed by Steve Calvert
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.0.1

--- a/changelog/entries/2026-01-10-mcp-config-schema-3-1-1.md
+++ b/changelog/entries/2026-01-10-mcp-config-schema-3-1-1.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v3.1.1'
+categories: ['MCP']
+---
+
+Clients without a configPath now receive null from buildCommand, preventing errors in protocol-level command construction. - Fixed buildCommand to return null for clients lacking configPath - Ensures protocol-level stability for clients with missing configuration - Committer: Steve Calvert
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config-schema/releases/tag/v3.1.1


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-01-10.

Files:
- changelog/entries/2026-01-10-mcp-config-schema-3-1-1.md
- changelog/entries/2026-01-09-configure-mcp-server-3-0-1.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}