### PR TITLE
chore(changelog): 2026-01-14

### DIFF
--- a/changelog/entries/2026-01-14-mcp-config-schema-4-0-0.md
+++ b/changelog/entries/2026-01-14-mcp-config-schema-4-0-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v4.0.0'
+categories: ['MCP']
+---
+
+Tooling configuration consolidated at the monorepo root and converted to an npm workspaces monorepo. - Affects: mcp-config-glean, mcp-config-schema - Refactored configuration structure for improved maintainability - Transitioned to npm workspaces for streamlined dependency management
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v4.0.0

--- a/changelog/entries/2026-01-14-mcp-config-schema-4-0-1.md
+++ b/changelog/entries/2026-01-14-mcp-config-schema-4-0-1.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v4.0.1'
+categories: ['MCP']
+---
+
+Added --bearer-token-env-var flag to Codex CLI for API token authentication and improved CLAUDE.md documentation with architecture and vendor-neutrality details. - Codex CLI now supports API token authentication via environment variable - CLAUDE.md updated for clearer architecture and...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v4.0.1


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-01-14.

Files:
- changelog/entries/2026-01-14-mcp-config-schema-4-0-1.md
- changelog/entries/2026-01-14-mcp-config-schema-4-0-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}