### PR TITLE
feat: Remove feature flags around deprecations

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -67,7 +67,6 @@ const baseSidebars: SidebarsConfig = {
           customProps: {
             icon: 'AlertTriangle',
             iconSet: 'feather',
-            flag: 'x-glean-deprecated',
           },
           items: [
             {

--- a/src/theme/ApiDeprecations/index.tsx
+++ b/src/theme/ApiDeprecations/index.tsx
@@ -1,7 +1,5 @@
 import type React from 'react';
-import { useContext } from 'react';
 import Link from '@docusaurus/Link';
-import { FeatureFlagsContext } from '../Root';
 import type { DeprecationItem } from '../../types/deprecations';
 import DeprecationEntry from '../../components/Deprecations/DeprecationEntry';
 import styles from './styles.module.css';
@@ -13,12 +11,6 @@ interface ApiDeprecationsProps {
 export default function ApiDeprecations({
   deprecations,
 }: ApiDeprecationsProps): React.ReactElement | null {
-  const { isEnabled } = useContext(FeatureFlagsContext);
-
-  if (!isEnabled('x-glean-deprecated')) {
-    return null;
-  }
-
   if (!deprecations || deprecations.length === 0) {
     return null;
   }


### PR DESCRIPTION
Removing the feature flags that were guarding the deprecations page(s)

<img width="2542" height="2560" alt="2026-01-15 at 13 52 56 2@2x" src="https://github.com/user-attachments/assets/09ed40fc-9f05-4b55-8b48-2f88e71794c0" />
