### PR TITLE
feat(deploy): Use GitHub App

### DIFF
--- a/.github/workflows/trigger-redeploy.yml
+++ b/.github/workflows/trigger-redeploy.yml
@@ -26,11 +26,18 @@ jobs:
       has_changes: ${{ steps.check-generated.outputs.has_changes }}
 
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up mise
         uses: jdx/mise-action@v2
@@ -65,7 +72,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: regenerate OpenAPI documentation'
           title: '[Manual] Regenerate OpenAPI Documentation'
           body: |
@@ -98,7 +105,7 @@ jobs:
         if: steps.check-generated.outputs.has_changes == 'true'
         uses: peter-evans/enable-pull-request-automerge@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash
 


### PR DESCRIPTION
Our pipeline right now uses a mix of random PATs and GITHUB_TOKEN.  The
end result is things are misattributed and don't work.

Replace these tokens with a GitHub App token.  The primary motivation is
so we can have a deployment pipeline that starts from the generate
clients cron job in @gleanwork/open-api and goes all the way to
generating a pr for redeploying the site in this repo.

Prior to this commit, the deployment PR would never run the CI check
because it was generated via GITHUB_TOKEN.
