### PR TITLE
fix(ci): regenerate site pr

### DIFF
--- a/.github/workflows/trigger-redeploy.yml
+++ b/.github/workflows/trigger-redeploy.yml
@@ -74,11 +74,9 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           commit-message: 'chore: regenerate OpenAPI documentation'
-          title: '[Manual] Regenerate OpenAPI Documentation'
+          title: 'Regenerate OpenAPI Documentation'
           body: |
-            ## 🔄 Manual OpenAPI Documentation Regeneration
-
-            This PR was manually triggered to regenerate the OpenAPI documentation.
+            ## 🔄 OpenAPI Documentation Regeneration
 
             **Trigger reason**: ${{ github.event.inputs.reason }}
             **Triggered by**: ${{ github.actor }}
@@ -98,7 +96,7 @@ jobs:
             - `docs/api/indexing-api/` - Regenerated indexing API docs
 
             Please review the changes if needed, otherwise the PR will auto-merge when checks pass.
-          branch: manual-regenerate-openapi-docs
+          branch: ci/regenerate-openapi-docs
           delete-branch: true
 
       - name: Enable Auto-Merge


### PR DESCRIPTION
Fix `.github/workflows/trigger-redeploy.yml` to have a better
description and not inaccurately describe the automatically generated PR
as having been created manually.


See https://github.com/gleanwork/glean-developer-site/pull/265 for an example pr.
