### PR TITLE
chore(changelog): 2026-01-17

### DIFF
--- a/changelog/entries/2026-01-16-api-client-go-0-11-20.md
+++ b/changelog/entries/2026-01-16-api-client-go-0-11-20.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.20'
+categories: ['API Clients']
+---
+
+Go API client updated to version 0.11.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.686.0 (2.796.1). - Generated Go client v0.11.20 - Release includes updates from OpenAPI Doc 0.9.0 - Built using Speakeasy CLI 1.686.0 (2.796.1)
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.20

--- a/changelog/entries/2026-01-16-api-client-java-0-12-14.md
+++ b/changelog/entries/2026-01-16-api-client-java-0-12-14.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.14'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.14 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.686.0 (2.796.1). - Java client v0.12.14 released - Maven Central v0.12.14 published
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.14

--- a/changelog/entries/2026-01-16-api-client-python-0-11-27.md
+++ b/changelog/entries/2026-01-16-api-client-python-0-11-27.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.11.27'
+categories: ['API Clients']
+---
+
+Python API client updated to version 0.11.27 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.686.0 (2.796.1). - Generated python v0.11.27 - Released on PyPI v0.11.27
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.11.27

--- a/changelog/entries/2026-01-16-api-client-typescript-0-13-20.md
+++ b/changelog/entries/2026-01-16-api-client-typescript-0-13-20.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.13.20'
+categories: ['API Clients']
+---
+
+Updated TypeScript API client to version 0.13.20 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.686.0 (2.796.1).
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.13.20


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-01-17.

Files:
- changelog/entries/2026-01-16-api-client-java-0-12-14.md
- changelog/entries/2026-01-16-api-client-python-0-11-27.md
- changelog/entries/2026-01-16-api-client-typescript-0-13-20.md
- changelog/entries/2026-01-16-api-client-go-0-11-20.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}