### PR TITLE
feat: Runtime feature flags for sidebar visibility

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1,12 +1,6 @@
 import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
-import { getBuildTimeFlags } from './src/utils/buildTimeFlags';
-import { flagsSnapshotToBooleans } from './src/lib/featureFlags';
-import { filterByFeatureFlags } from './src/utils/filtering';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
-
-const rawFlags = getBuildTimeFlags();
-const boolFlags = flagsSnapshotToBooleans(rawFlags, {});
 
 const baseSidebars: SidebarsConfig = {
   docSidebar: [
@@ -67,6 +61,7 @@ const baseSidebars: SidebarsConfig = {
           customProps: {
             icon: 'AlertTriangle',
             iconSet: 'feather',
+            flag: 'x-glean-deprecated',
           },
           items: [
             {
@@ -1555,6 +1550,4 @@ const baseSidebars: SidebarsConfig = {
   ],
 };
 
-const sidebars = filterByFeatureFlags(baseSidebars, boolFlags);
-
-export default sidebars;
+export default baseSidebars;

--- a/src/theme/ApiDeprecations/index.tsx
+++ b/src/theme/ApiDeprecations/index.tsx
@@ -1,5 +1,7 @@
 import type React from 'react';
+import { useContext } from 'react';
 import Link from '@docusaurus/Link';
+import { FeatureFlagsContext } from '../Root';
 import type { DeprecationItem } from '../../types/deprecations';
 import DeprecationEntry from '../../components/Deprecations/DeprecationEntry';
 import styles from './styles.module.css';
@@ -11,6 +13,12 @@ interface ApiDeprecationsProps {
 export default function ApiDeprecations({
   deprecations,
 }: ApiDeprecationsProps): React.ReactElement | null {
+  const { isEnabled } = useContext(FeatureFlagsContext);
+
+  if (!isEnabled('x-glean-deprecated')) {
+    return null;
+  }
+
   if (!deprecations || deprecations.length === 0) {
     return null;
   }

--- a/src/theme/DocSidebarItems/index.tsx
+++ b/src/theme/DocSidebarItems/index.tsx
@@ -1,0 +1,57 @@
+import React, { memo, useContext, useMemo, type ReactNode } from 'react';
+import {
+  DocSidebarItemsExpandedStateProvider,
+  useVisibleSidebarItems,
+} from '@docusaurus/plugin-content-docs/client';
+import DocSidebarItem from '@theme/DocSidebarItem';
+import { FeatureFlagsContext } from '@site/src/theme/Root';
+import type { Props } from '@theme/DocSidebarItems';
+
+function filterItemsByFlags(
+  items: Props['items'],
+  isEnabled: (flag: string) => boolean
+): Props['items'] {
+  return items
+    .filter((item) => {
+      const flag = (item as any).customProps?.flag;
+      if (typeof flag === 'string') {
+        return isEnabled(flag);
+      }
+      return true;
+    })
+    .map((item) => {
+      if (item.type === 'category' && item.items) {
+        return {
+          ...item,
+          items: [...filterItemsByFlags(item.items, isEnabled)],
+        };
+      }
+      return item;
+    })
+    .filter((item) => {
+      // Remove empty categories (all children were hidden)
+      if (item.type === 'category') {
+        return item.items && item.items.length > 0;
+      }
+      return true;
+    });
+}
+
+function DocSidebarItems({ items, ...props }: Props): ReactNode {
+  const { isEnabled } = useContext(FeatureFlagsContext);
+  const flagFilteredItems = useMemo(
+    () => filterItemsByFlags(items, isEnabled),
+    [items, isEnabled]
+  );
+  const visibleItems = useVisibleSidebarItems(flagFilteredItems, props.activePath);
+
+  return (
+    <DocSidebarItemsExpandedStateProvider>
+      {visibleItems.map((item, index) => (
+        <DocSidebarItem key={index} item={item} index={index} {...props} />
+      ))}
+    </DocSidebarItemsExpandedStateProvider>
+  );
+}
+
+export default memo(DocSidebarItems);


### PR DESCRIPTION
## Summary

- Switches sidebar link visibility from build-time to runtime feature flags
- Enables flag changes without rebuilding the site
- Adds URL override support for testing (e.g., `?ff_x-glean-deprecated=true`)
- Enables per-user targeting via rollout percentages

## Changes

- **`src/theme/DocSidebarItems/index.tsx`** (new): Swizzled Docusaurus component that filters sidebar items based on `FeatureFlagsContext` at runtime
- **`sidebars.ts`**: Removed build-time filtering, exports `baseSidebars` directly
- **`src/theme/ApiDeprecations/index.tsx`**: Updated to respect runtime flags for the deprecations component

## Implementation Details

The new `DocSidebarItems` component:
1. Reads flags from `FeatureFlagsContext` using `isEnabled()`
2. Recursively filters items with `customProps.flag` 
3. Removes empty categories when all children are hidden
4. Uses `useMemo` for performance optimization

## Test plan

- [ ] Build and run locally: `npm run build && npm run serve`
- [ ] Verify "Deprecations" sidebar item is hidden by default (flag disabled)
- [ ] Verify URL override works: visit with `?ff_x-glean-deprecated=true` and confirm "Deprecations" appears
- [ ] Verify flag toggle via Edge Config updates sidebar without rebuild
- [ ] Verify nested categories with all children hidden are themselves hidden