### PR TITLE
fix(ci): No spurious redeploys

### DIFF
--- a/.github/workflows/trigger-redeploy.yml
+++ b/.github/workflows/trigger-redeploy.yml
@@ -59,7 +59,10 @@ jobs:
       - name: Check for generated changes
         id: check-generated
         run: |
-          if [[ -n $(git status --porcelain) ]]; then
+          # Ignore src/data and static/deprecations because they will both
+          # include timestamps that generate false positives to the question:
+          # "are there differences to deploy".
+          if [[ -n $(git status --porcelain -- ':!src/data/**' ':!static/deprecations.xml') ]]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
             echo "📝 Changes detected in generated documentation"
           else


### PR DESCRIPTION
.github/workflows/trigger-redeploy.yml attempts to avoid pointless
redeploys by checking if there's actually a diff.

Enhance this check to ignore files that contain generation timestamps,
as these timestamps will always differ.

[test run](https://github.com/gleanwork/glean-developer-site/actions/runs/21192110924)
