### PR TITLE
bug: remove test data that was being included

### DIFF
--- a/scripts/generate-deprecations.ts
+++ b/scripts/generate-deprecations.ts
@@ -142,7 +142,7 @@ async function main() {
       './openapi/indexing/indexing-capitalized.yaml',
     ],
     './src/data/deprecations.json',
-    testExtraEndpoints,
+    [], // pass in testExtraEndpoints for example deprecations
   );
 }
 

--- a/src/data/deprecations.json
+++ b/src/data/deprecations.json
@@ -2,112 +2,6 @@
   "endpoints": [
     {
       "method": "POST",
-      "path": "/api/index/v1/indexdocument",
-      "deprecations": [
-        {
-          "id": "indexdocument-version-dep",
-          "type": "field",
-          "name": "version",
-          "message": "The version field is deprecated. Use document.metadata.version for optimistic concurrency control.",
-          "introduced": "2026-02-15",
-          "removal": "2026-10-15",
-          "docs": "https://developers.glean.com/docs/migrations/document-versioning"
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "path": "/api/index/v1/indexdocuments",
-      "deprecations": [
-        {
-          "id": "indexdocuments-uploadid-dep",
-          "type": "field",
-          "name": "uploadId",
-          "message": "The uploadId field is deprecated. Use batchId for tracking bulk uploads.",
-          "introduced": "2026-04-10",
-          "removal": "2027-04-15"
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/autocomplete",
-      "deprecations": [
-        {
-          "id": "autocomplete-tracking-token-dep",
-          "type": "field",
-          "name": "trackingToken",
-          "message": "The trackingToken field is deprecated. Use requestId instead for request tracking.",
-          "introduced": "2026-04-01",
-          "removal": "2027-04-15",
-          "docs": "https://developers.glean.com/docs/migrations/request-tracking"
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/chat",
-      "deprecations": [
-        {
-          "id": "chat-save-chat-dep",
-          "type": "field",
-          "name": "saveChat",
-          "message": "The saveChat field is deprecated. Use chatPersistence instead.",
-          "introduced": "2026-03-01",
-          "removal": "2027-01-15",
-          "docs": "https://developers.glean.com/docs/migrations/chat-persistence"
-        },
-        {
-          "id": "chat-timeout-millis-dep",
-          "type": "field",
-          "name": "timeoutMillis",
-          "message": "The timeoutMillis field is deprecated. Use requestOptions.timeout instead.",
-          "introduced": "2026-03-15",
-          "removal": "2027-01-15"
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/feed",
-      "deprecations": [
-        {
-          "id": "feed-category-all-dep",
-          "type": "enum-value",
-          "name": "category",
-          "enumValue": "ALL",
-          "message": "The ALL category is deprecated. Use MIXED to retrieve all feed types.",
-          "introduced": "2026-03-20",
-          "removal": "2027-01-15"
-        }
-      ]
-    },
-    {
-      "method": "POST",
-      "path": "/api/v1/search",
-      "deprecations": [
-        {
-          "id": "search-disable-spellcheck-dep",
-          "type": "field",
-          "name": "disableSpellcheck",
-          "message": "The disableSpellcheck field is deprecated. Use requestOptions.spellcheckMode instead.",
-          "introduced": "2026-01-15",
-          "removal": "2026-07-15",
-          "docs": "https://developers.glean.com/docs/migrations/spellcheck-options"
-        },
-        {
-          "id": "search-cluster-type-none-dep",
-          "type": "enum-value",
-          "name": "clusterType",
-          "enumValue": "NONE",
-          "message": "The NONE cluster type is deprecated. Omit the clusterType field instead.",
-          "introduced": "2026-02-01",
-          "removal": "2026-10-15"
-        }
-      ]
-    },
-    {
-      "method": "POST",
       "path": "/rest/api/v1/listanswers",
       "deprecations": [
         {
@@ -121,6 +15,6 @@
       ]
     }
   ],
-  "generatedAt": "2026-01-21T20:35:54.234Z",
-  "totalCount": 9
+  "generatedAt": "2026-01-21T23:06:59.487Z",
+  "totalCount": 1
 }


### PR DESCRIPTION
## Summary
- Remove test data (`testExtraEndpoints`) from the deprecations generation script that was accidentally being included in the output

## Test plan
- [ ] Verify the generated `deprecations.json` file no longer contains test endpoint data
- [ ] Run `npm run generate:deprecations` and confirm it completes successfully