### PR TITLE
fix: improve deprecation notices on API pages

### DIFF
--- a/scripts/generator/customMdGenerators.ts
+++ b/scripts/generator/customMdGenerators.ts
@@ -2,7 +2,6 @@ import fs from 'fs';
 import path from 'path';
 import { createAuthorization } from 'docusaurus-plugin-openapi-docs/lib/markdown/createAuthorization';
 import { createCallbacks } from 'docusaurus-plugin-openapi-docs/lib/markdown/createCallbacks';
-import { createDeprecationNotice } from 'docusaurus-plugin-openapi-docs/lib/markdown/createDeprecationNotice';
 import { createDescription } from 'docusaurus-plugin-openapi-docs/lib/markdown/createDescription';
 import { createHeading } from 'docusaurus-plugin-openapi-docs/lib/markdown/createHeading';
 import { createMethodEndpoint } from 'docusaurus-plugin-openapi-docs/lib/markdown/createMethodEndpoint';
@@ -20,7 +19,6 @@ import {
 import type { ApiPageMetadata } from 'docusaurus-plugin-openapi-docs/lib/types';
 import type {
   DeprecationItem,
-  EndpointGroup,
   DeprecationsData,
 } from '../../src/types/deprecations';
 
@@ -139,7 +137,6 @@ export function customApiMdGenerator({
   frontMatter,
 }: ApiPageMetadata) {
   const {
-    deprecated,
     'x-deprecated-description': deprecatedDescription,
     'x-visibility': xVisibility,
     'x-beta': xBeta,
@@ -169,12 +166,11 @@ export function customApiMdGenerator({
       : '\n',
     createHeading(title),
     createMethodEndpoint(method, endpointPath),
-    deprecationsMarkdown,
     infoPath && createAuthorization(infoPath),
     frontMatter.show_extensions
       ? createVendorExtensions(extensions)
       : undefined,
-    createDeprecationNotice({ deprecated, description: deprecatedDescription }),
+    deprecationsMarkdown,
     createPreviewNotice({ xVisibility, xBeta }),
     createDescription(description),
     requestBody || parameters ? createRequestHeader('Request') : undefined,

--- a/src/components/Deprecations/DeprecationEntry.tsx
+++ b/src/components/Deprecations/DeprecationEntry.tsx
@@ -58,7 +58,7 @@ export default function DeprecationEntry({
             <>
               <span className={styles.dateSeparator}>|</span>
               <span className={styles.dateLabel}>
-                {isPast ? 'Removed on' : 'Will be removed on'}{' '}
+                {isPast ? 'Removed on' : 'Will be removed after'}{' '}
                 <time className={styles.removalDate}>{entry.removal}</time>
               </span>
             </>

--- a/src/theme/ApiDeprecations/styles.module.css
+++ b/src/theme/ApiDeprecations/styles.module.css
@@ -47,9 +47,7 @@ details[open] .deprecationsSummary::before {
 }
 
 .viewAllContainer {
-  margin-top: 1rem;
-  padding-top: 0.75rem;
-  border-top: 1px solid var(--ifm-color-emphasis-200);
+  margin-top: 0.75rem;
   text-align: right;
 }
 


### PR DESCRIPTION
## Summary
- Replace `createDeprecationNotice` with the unified `deprecationsMarkdown` component for consistent deprecation display
- Update removal date text from "Will be removed on" to "Will be removed after" for clarity
- Simplify view all container styling by removing unnecessary border

<img width="3680" height="2390" alt="2026-01-21 at 21 36 30 2@2x" src="https://github.com/user-attachments/assets/b1718953-9e9a-46cb-a45f-6724c3daf44d" />