### PR TITLE
chore(changelog): 2026-01-22

### DIFF
--- a/changelog/entries/2026-01-21-langchain-glean-0-3-4.md
+++ b/changelog/entries/2026-01-21-langchain-glean-0-3-4.md
@@ -1,0 +1,10 @@
+---
+title: 'langchain-glean v0.3.4'
+categories: ['langchain-glean']
+---
+
+Updated SDK to use vars() for Speakeasy models and removed unused parameters, with improved environment variable propagation. - Switched from model_dump() to vars() for Speakeasy SDK models - Updated SDK method calls for glean-api-client 0.11.x - Removed unused stream parameter from...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/langchain-glean/releases/tag/v0.3.4

--- a/changelog/entries/2026-01-22-mcp-config-schema-4-1-0.md
+++ b/changelog/entries/2026-01-22-mcp-config-schema-4-1-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v4.1.0'
+categories: ['MCP']
+---
+
+This release updates the MCP config schema with enhancements to client support, API behavior, and authentication options. - Added Cursor Agent to clients - Updated clientNeedsMcpRemote in the API - Introduced new authentication configurations
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v4.1.0


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-01-22.

Files:
- changelog/entries/2026-01-22-mcp-config-schema-4-1-0.md
- changelog/entries/2026-01-21-langchain-glean-0-3-4.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}