### PR TITLE
fix: correct API Token Creator permissions for Indexing API

### DIFF
--- a/docs/api-info/indexing/authentication/overview.mdx
+++ b/docs/api-info/indexing/authentication/overview.mdx
@@ -58,7 +58,7 @@ Authorization: Bearer <indexing_api_token>
 
 <Steps>
   <Step title="Admin Access Required">
-    Only **Super Admins** can create Indexing API tokens
+    **Super Admins** can create Indexing API tokens with global permissions. **API Token Creators** can create tokens scoped to themselves only.
   </Step>
   
   <Step title="Navigate to Token Management">
@@ -80,7 +80,7 @@ Authorization: Bearer <indexing_api_token>
 
 ### Prerequisites
 
-- **Super Admin access** to Glean's admin console
+- **Super Admin** or **API Token Creator** access to Glean's admin console
 - **Datasource configured** in Glean (for document indexing)
 - **IP ranges identified** (if using IP restrictions)
 

--- a/docs/api-info/indexing/getting-started/overview.mdx
+++ b/docs/api-info/indexing/getting-started/overview.mdx
@@ -128,9 +128,9 @@ Here's how to create a datasource and index your first document:
 
 The Indexing API uses Glean-issued tokens for authentication. Only users with appropriate permissions can create and manage indexing tokens:
 
-- **Super Admins**: Can create Indexing API tokens (always global permissions)
+- **Super Admins**: Can create Indexing API tokens with global permissions
 - **Admins**: Cannot create Indexing API tokens
-- **API Token Creators**: Cannot create Indexing API tokens
+- **API Token Creators**: Can create Indexing API tokens (self-scoped only, no global permissions)
 
 Learn more in our [Authentication Guide](../authentication/overview).
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -119,7 +119,7 @@ Understanding who can create what type of authentication tokens:
 |------|------------------|-------------------|---------------------|
 | **Super Admin** | Configure for all | Create any token | Create any token |
 | **Admin** | Configure for all | Create for self only | Cannot create |
-| **API Token Creator** | Cannot configure | Create for self only | Cannot create |
+| **API Token Creator** | Cannot configure | Create for self only | Create for self only |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes incorrect documentation stating API Token Creators cannot create Indexing API tokens
- Per the design spec and actual product behavior, API Token Creators CAN create Indexing API tokens (self-scoped only, no global permissions)

## Test plan
- [ ] Verify permissions table at `/get-started/authentication` shows "Create for self only" for API Token Creator
- [ ] Verify Indexing API overview correctly lists API Token Creator capabilities
- [ ] Verify Indexing API authentication overview reflects updated permissions

## References
- Design spec: [API Token Creator/Developer Role](https://docs.google.com/document/d/1Tc21yOllTHrnaOEhaZTQ_pFm9DcDuk_Bmfxg5WrYSPc)
- Escalation: EE-21356

🤖 Generated with [Claude Code](https://claude.com/claude-code)