### PR TITLE
docs: add SDK configuration for deprecation testing header

### DIFF
--- a/docs/deprecations/overview.mdx
+++ b/docs/deprecations/overview.mdx
@@ -112,6 +112,15 @@ X-Glean-Exclude-Deprecated-After: 2027-01-15
 
 This header simulates how the API will behave after the deprecation date, helping you verify your code handles the changes correctly.
 
+### Using the SDKs
+
+Glean's official SDKs can be configured to automatically include this header on all requests through constructor options or environment variables. See the documentation for your SDK:
+
+- [TypeScript](https://github.com/gleanwork/api-client-typescript#experimental-features-and-deprecation-testing)
+- [Python](https://github.com/gleanwork/api-client-python#experimental-features-and-deprecation-testing)
+- [Go](https://github.com/gleanwork/api-client-go#experimental-features-and-deprecation-testing)
+- [Java](https://github.com/gleanwork/api-client-java#experimental-features-and-deprecation-testing)
+
 ---
 
 ## After Removal


### PR DESCRIPTION
## Summary

- Add documentation for how Glean's official SDKs can be configured to automatically include the `X-Glean-Exclude-Deprecated-After` header
- Link to each SDK's documentation for TypeScript, Python, Go, and Java

Related: https://github.com/gleanwork/api-client-typescript/pull/95

## Test plan

- [ ] Verify the deprecations overview page renders correctly
- [ ] Verify all SDK links resolve to the correct section