### PR TITLE
chore(changelog): 2026-02-05

### DIFF
--- a/changelog/entries/2026-02-05-glean-indexing-sdk-0-3-0.md
+++ b/changelog/entries/2026-02-05-glean-indexing-sdk-0-3-0.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-indexing-sdk v0.3.0'
+categories: ['Glean Indexing SDK']
+---
+
+Introduces a guided release process, standardizes async class and file naming, and improves Python version management for the Glean Indexing SDK. - Adds /release command for guided releases - Renames async classes with Base prefix and streaming files to base\_\* convention - Uses mise use for Python...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-indexing-sdk/releases/tag/v0.3.0

--- a/changelog/entries/2026-02-05-glean-indexing-sdk-0-3-1.md
+++ b/changelog/entries/2026-02-05-glean-indexing-sdk-0-3-1.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-indexing-sdk v0.3.1'
+categories: ['Glean Indexing SDK']
+---
+
+Added a guided release process, standardized async class and file naming, and improved release commit contents. - Introduced /release command for guided releases - Renamed async classes with Base prefix and files to base\_\* convention - Included CHANGELOG.md and uv.lock in release commits
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-indexing-sdk/releases/tag/v0.3.1


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-02-05.

Files:
- changelog/entries/2026-02-05-glean-indexing-sdk-0-3-1.md
- changelog/entries/2026-02-05-glean-indexing-sdk-0-3-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}