### PR TITLE
chore(changelog): 2026-02-06

### DIFF
--- a/changelog/entries/2026-02-06-api-client-go-0-11-22.md
+++ b/changelog/entries/2026-02-06-api-client-go-0-11-22.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.22'
+categories: ['API Clients']
+---
+
+Updated Go API client to version 0.11.22 based on OpenAPI Doc 0.9.0. - No additional details or breaking changes were specified in this release.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.22

--- a/changelog/entries/2026-02-06-api-client-java-0-12-16.md
+++ b/changelog/entries/2026-02-06-api-client-java-0-12-16.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.16'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.16 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.706.1 (2.809.2). - Java client v0.12.16 released to Maven Central
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.16

--- a/changelog/entries/2026-02-06-api-client-python-0-12-1.md
+++ b/changelog/entries/2026-02-06-api-client-python-0-12-1.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.1'
+categories: ['API Clients']
+---
+
+Updated Python API client to version 0.12.1 based on OpenAPI Doc 0.9.0. - Python client generated at v0.12.1 - Released on PyPI as v0.12.1
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.1

--- a/changelog/entries/2026-02-06-api-client-typescript-0-14-1.md
+++ b/changelog/entries/2026-02-06-api-client-typescript-0-14-1.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.1'
+categories: ['API Clients']
+---
+
+Updated the TypeScript API client to version 0.14.1 based on OpenAPI Doc 0.9.0. - Generated TypeScript client v0.14.1 - Aligned with OpenAPI Doc 0.9.0 - Release available as NPM package v0.14.1
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.1


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-02-06.

Files:
- changelog/entries/2026-02-06-api-client-java-0-12-16.md
- changelog/entries/2026-02-06-api-client-python-0-12-1.md
- changelog/entries/2026-02-06-api-client-typescript-0-14-1.md
- changelog/entries/2026-02-06-api-client-go-0-11-22.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}