### PR TITLE
chore(changelog): 2026-02-10

### DIFF
--- a/changelog/entries/2026-02-09-api-client-go-0-11-24.md
+++ b/changelog/entries/2026-02-09-api-client-go-0-11-24.md
@@ -1,0 +1,11 @@
+---
+title: 'api-client-go v0.11.24'
+categories: ['API Clients']
+---
+
+- : **Added**.
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24

--- a/changelog/entries/2026-02-09-api-client-java-0-12-19.md
+++ b/changelog/entries/2026-02-09-api-client-java-0-12-19.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.19'
+categories: ['API Clients']
+---
+
+The method now includes the field in its response. - Added to the response
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.19

--- a/changelog/entries/2026-02-09-api-client-python-0-12-3.md
+++ b/changelog/entries/2026-02-09-api-client-python-0-12-3.md
@@ -1,0 +1,11 @@
+---
+title: 'api-client-python v0.12.3'
+categories: ['API Clients']
+---
+
+- : **Added**.
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3

--- a/changelog/entries/2026-02-09-api-client-python-0-12-4.md
+++ b/changelog/entries/2026-02-09-api-client-python-0-12-4.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.4'
+categories: ['API Clients']
+---
+
+Released Python API client v0.12.4 generated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.709.1 (2.812.2). - Generated Python SDK version v0.12.4 - Published Python package release v0.12.4
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.4

--- a/changelog/entries/2026-02-09-api-client-typescript-0-14-3.md
+++ b/changelog/entries/2026-02-09-api-client-typescript-0-14-3.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.3'
+categories: ['API Clients']
+---
+
+Added the response.tools field to glean.client.agents.retrieveSchemas() in the @gleanwork/api-client 0.14.3 release. - Added response.tools to glean.client.agents.retrieveSchemas() output
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.3


### PR DESCRIPTION
Adds 5 changelog entries generated on 2026-02-10.

Files:
- changelog/entries/2026-02-09-api-client-java-0-12-19.md
- changelog/entries/2026-02-09-api-client-python-0-12-4.md
- changelog/entries/2026-02-09-api-client-python-0-12-3.md
- changelog/entries/2026-02-09-api-client-typescript-0-14-3.md
- changelog/entries/2026-02-09-api-client-go-0-11-24.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}