### PR TITLE
chore(changelog): 2026-02-11

### DIFF
--- a/changelog/entries/2026-02-10-api-client-go-0-11-25.md
+++ b/changelog/entries/2026-02-10-api-client-go-0-11-25.md
@@ -1,0 +1,11 @@
+---
+title: 'api-client-go v0.11.25'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25

--- a/changelog/entries/2026-02-10-api-client-java-0-12-20.md
+++ b/changelog/entries/2026-02-10-api-client-java-0-12-20.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.20'
+categories: ['API Clients']
+---
+
+Added a new feedbackTimeSaved enum value to the feedback request event in glean.client.activity.feedback(). - Added request.feedback1.event.enum(feedbackTimeSaved) to glean.client.activity.feedback()
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.20

--- a/changelog/entries/2026-02-10-api-client-python-0-12-5.md
+++ b/changelog/entries/2026-02-10-api-client-python-0-12-5.md
@@ -1,0 +1,11 @@
+---
+title: 'api-client-python v0.12.5'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5

--- a/changelog/entries/2026-02-10-api-client-typescript-0-14-4.md
+++ b/changelog/entries/2026-02-10-api-client-typescript-0-14-4.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.4'
+categories: ['API Clients']
+---
+
+Added support for the enum value in the activity feedback API request. - now accepts
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.4


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-02-11.

Files:
- changelog/entries/2026-02-10-api-client-java-0-12-20.md
- changelog/entries/2026-02-10-api-client-python-0-12-5.md
- changelog/entries/2026-02-10-api-client-typescript-0-14-4.md
- changelog/entries/2026-02-10-api-client-go-0-11-25.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}