### PR TITLE
Add query param to make the auth token tabs linkable

### DIFF
--- a/docs/libraries/web-sdk/authentication/server-to-server.mdx
+++ b/docs/libraries/web-sdk/authentication/server-to-server.mdx
@@ -39,7 +39,7 @@ Choose your implementation approach:
 
 This approach gives you complete control over token generation and refresh. Your application manages user authentication and fetches tokens from Glean's API.
 
-<Tabs>
+<Tabs queryString="tokenType">
 <TabItem value="api-key" label="API Key" default>
 
 <!-- Required for docusaurus styles to apply corectly 😬 -->


### PR DESCRIPTION
Fix formatting issues in server-to-server authentication documentation.