### PR TITLE
chore(changelog): 2026-02-19

### DIFF
--- a/changelog/entries/2026-02-18-api-client-go-0-11-26.md
+++ b/changelog/entries/2026-02-18-api-client-go-0-11-26.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.26'
+categories: ['API Clients']
+---
+
+api-client-go 0.11.26 updates chat message type fields and adds UnauthorizedDatasourceInstances error details across messages and search APIs, including several breaking response changes. - Updated MessageType in Glean.Client.Chat.Create(), Retrieve(), and CreateStream(), including breaking...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.26

--- a/changelog/entries/2026-02-18-api-client-java-0-12-21.md
+++ b/changelog/entries/2026-02-18-api-client-java-0-12-21.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.21'
+categories: ['API Clients']
+---
+
+This release updates chat messageType fields and introduces unauthorizedDatasourceInstances error details across search and messages APIs, including breaking changes to chat create and retrieve responses. - Updated messageType in request.chatRequest.messages[] for glean.client.chat.create() and...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.21

--- a/changelog/entries/2026-02-18-api-client-python-0-12-6.md
+++ b/changelog/entries/2026-02-18-api-client-python-0-12-6.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.6'
+categories: ['API Clients']
+---
+
+glean-api-client 0.12.6 changes chat message type fields and adds unauthorized datasource error details across search APIs. - Changed in for and , and in for (breaking). - Changed for (breaking). - Added (and ) to , , , , and .
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.6

--- a/changelog/entries/2026-02-18-api-client-typescript-0-14-5.md
+++ b/changelog/entries/2026-02-18-api-client-typescript-0-14-5.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-typescript v0.14.5'
+categories: ['API Clients']
+---
+
+- : - **Changed**.
+- : - **Changed**
+- **Changed** (Breaking ⚠️)
+- : **Changed** (Breaking ⚠️)
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-02-19.

Files:
- changelog/entries/2026-02-18-api-client-java-0-12-21.md
- changelog/entries/2026-02-18-api-client-python-0-12-6.md
- changelog/entries/2026-02-18-api-client-typescript-0-14-5.md
- changelog/entries/2026-02-18-api-client-go-0-11-26.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}