### PR TITLE
chore(changelog): 2026-02-20

### DIFF
--- a/changelog/entries/2026-02-19-api-client-go-0-11-27.md
+++ b/changelog/entries/2026-02-19-api-client-go-0-11-27.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.27'
+categories: ['API Clients']
+---
+
+Added the method to the Go API client. - Added to support datasource authentication checks
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.27

--- a/changelog/entries/2026-02-19-api-client-java-0-12-22.md
+++ b/changelog/entries/2026-02-19-api-client-java-0-12-22.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.22'
+categories: ['API Clients']
+---
+
+Added the method to the API client for authentication checks. - New function added to the client
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.22

--- a/changelog/entries/2026-02-19-api-client-python-0-12-7.md
+++ b/changelog/entries/2026-02-19-api-client-python-0-12-7.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.7'
+categories: ['API Clients']
+---
+
+Added a new authentication helper for checking data source authorization in glean-api-client 0.12.7. - Added for data source auth checks.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.7

--- a/changelog/entries/2026-02-19-api-client-typescript-0-14-6.md
+++ b/changelog/entries/2026-02-19-api-client-typescript-0-14-6.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.6'
+categories: ['API Clients']
+---
+
+Added the method to the package in version 0.14.6. - Category: API Clients - New:
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.6

--- a/changelog/entries/2026-02-19-rest-api-changes-open-api.md
+++ b/changelog/entries/2026-02-19-rest-api-changes-open-api.md
@@ -1,0 +1,10 @@
+---
+title: 'REST API: changes (endpoints) 2026-02-19'
+categories: ['API']
+---
+
+1 endpoint added
+
+{/* truncate */}
+
+Added endpoint: /checkdatasourceauth


### PR DESCRIPTION
Adds 5 changelog entries generated on 2026-02-20.

Files:
- changelog/entries/2026-02-19-api-client-java-0-12-22.md
- changelog/entries/2026-02-19-api-client-python-0-12-7.md
- changelog/entries/2026-02-19-api-client-typescript-0-14-6.md
- changelog/entries/2026-02-19-api-client-go-0-11-27.md
- changelog/entries/2026-02-19-rest-api-changes-open-api.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}