### PR TITLE
chore(changelog): 2026-02-21

### DIFF
--- a/changelog/entries/2026-02-20-api-client-go-0-11-28.md
+++ b/changelog/entries/2026-02-20-api-client-go-0-11-28.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.28'
+categories: ['API Clients']
+---
+
+Updated to change the field. - behavior or structure has been modified in
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.28

--- a/changelog/entries/2026-02-20-api-client-java-0-12-23.md
+++ b/changelog/entries/2026-02-20-api-client-java-0-12-23.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.23'
+categories: ['API Clients']
+---
+
+Updated so that has changed in the API client. - Category: API Clients - Package: - Change: in response marked as changed
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.23

--- a/changelog/entries/2026-02-20-api-client-python-0-12-8.md
+++ b/changelog/entries/2026-02-20-api-client-python-0-12-8.md
@@ -1,0 +1,11 @@
+---
+title: 'api-client-python v0.12.8'
+categories: ['API Clients']
+---
+
+- : **Changed**.
+- : **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8

--- a/changelog/entries/2026-02-20-api-client-typescript-0-14-7.md
+++ b/changelog/entries/2026-02-20-api-client-typescript-0-14-7.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.7'
+categories: ['API Clients']
+---
+
+Updated to change the field. - Category: API Clients - Affected method: - Changed response field:
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.7


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-02-21.

Files:
- changelog/entries/2026-02-20-api-client-java-0-12-23.md
- changelog/entries/2026-02-20-api-client-python-0-12-8.md
- changelog/entries/2026-02-20-api-client-typescript-0-14-7.md
- changelog/entries/2026-02-20-api-client-go-0-11-28.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}