### PR TITLE
Add Context7 MCP server registration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/websites/developers_glean",
+  "public_key": "pk_IEuoTZ4biJkZC4eMY0VOF"
+}


### PR DESCRIPTION
## Summary
- Registers the Glean developer docs site with Context7 for LLM-accessible documentation
- Adds `context7.json` with the site URL and public key

## Test plan
- [ ] Verify `context7.json` contains correct URL and public key
- [ ] Confirm Context7 can discover and index the developer docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)