### PR TITLE
chore(changelog): 2026-02-24

### DIFF
--- a/changelog/entries/2026-02-23-glean-indexing-sdk-1-0-0b0.md
+++ b/changelog/entries/2026-02-23-glean-indexing-sdk-1-0-0b0.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-indexing-sdk v1.0.0b0'
+categories: ['Glean Indexing SDK']
+---
+
+Introduces a custom exception hierarchy for the Glean Indexing SDK and improves release packaging and documentation references. - Add custom exception hierarchy to enable more robust and granular error handling - Fix broken documentation references by updating invalid URLs - Ensure release commits...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-indexing-sdk/releases/tag/v1.0.0b0

--- a/changelog/entries/2026-02-23-mcp-config-schema-4-2-0.md
+++ b/changelog/entries/2026-02-23-mcp-config-schema-4-2-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v4.2.0'
+categories: ['MCP']
+---
+
+No functional changes documented for mcp-config-schema v4.2.0 based on the provided release notes. - Version identifier updated to mcp-config-schema v4.2.0 for tracking and dependency alignment.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v4.2.0


### PR DESCRIPTION
Adds 2 changelog entries generated on 2026-02-24.

Files:
- changelog/entries/2026-02-23-mcp-config-schema-4-2-0.md
- changelog/entries/2026-02-23-glean-indexing-sdk-1-0-0b0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}