### PR TITLE
Fix document-access examples to use userEmail

### DIFF
--- a/docs/api-info/indexing/debugging/document-access.mdx
+++ b/docs/api-info/indexing/debugging/document-access.mdx
@@ -22,7 +22,7 @@ curl -X POST https://customer-be.glean.com/api/index/v1/checkdocumentaccess
         "datasource": "gleantest",
         "objectType": "Article",
         "docId": "art123",
-        "email": "user1@example.com"
+        "userEmail": "user1@example.com"
       }'
 ```
 
@@ -40,7 +40,7 @@ check_document_access_request = CheckDocumentAccessRequest(
     datasource="gleantest",
     object_type="Article",
     doc_id="art123",
-    email="user1@example.com"
+    user_email="user1@example.com"
 )
 try:
     api_response = troubleshoot_api.checkdocumentaccess_post(check_document_access_request)


### PR DESCRIPTION
## Summary
- update the cURL request payload in the Document Access troubleshooting guide to use `userEmail`
- update the Python example to use `user_email` for `CheckDocumentAccessRequest`

## Why
The API schema for `checkdocumentaccess` requires `userEmail`; the existing example used `email`, which causes parsing errors.

Closes #145