### PR TITLE
docs: migrate from GLEAN_INSTANCE to GLEAN_SERVER_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 # Get this from your Glean admin settings
 GLEAN_API_TOKEN=your-api-token-here
 
-# Your Glean server URL (find at app.glean.com/admin/about-glean)
+# Your Glean server URL (find at https://app.glean.com/admin/about-glean)
 GLEAN_SERVER_URL=https://your-company-be.glean.com
-# Legacy instance name (still supported as fallback)
-# GLEAN_INSTANCE=glean
+# Deprecated: legacy instance name (still supported as fallback)
+# GLEAN_INSTANCE=your-company

--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,7 @@
 # Get this from your Glean admin settings
 GLEAN_API_TOKEN=your-api-token-here
 
-# Your Glean instance name (e.g., 'glean' for glean-be.glean.com)
-GLEAN_INSTANCE=glean
+# Your Glean server URL (find at app.glean.com/admin/about-glean)
+GLEAN_SERVER_URL=https://your-company-be.glean.com
+# Legacy instance name (still supported as fallback)
+# GLEAN_INSTANCE=glean

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@
 GLEAN_API_TOKEN=your-api-token-here
 
 # Your Glean server URL (find at https://app.glean.com/admin/about-glean)
-GLEAN_SERVER_URL=https://your-company-be.glean.com
+GLEAN_SERVER_URL=https://your-server-id-be.glean.com
 # Deprecated: legacy instance name (still supported as fallback)
 # GLEAN_INSTANCE=your-company

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,6 @@
 GLEAN_API_TOKEN=your-api-token-here
 
 # Your Glean server URL (find at https://app.glean.com/admin/about-glean)
-GLEAN_SERVER_URL=https://your-server-id-be.glean.com
+GLEAN_SERVER_URL=https://your-company-be.glean.com
 # Deprecated: legacy instance name (still supported as fallback)
 # GLEAN_INSTANCE=your-company

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The `scripts/indexing/` directory contains a Python-based Glean indexing pipelin
 
 ```bash
 mise run indexing:dry-run    # Test extraction without uploading
-mise run indexing:run        # Full indexing (requires GLEAN_INDEXING_API_TOKEN, GLEAN_INSTANCE)
+mise run indexing:run        # Full indexing (requires GLEAN_INDEXING_API_TOKEN, GLEAN_SERVER_URL)
 mise run indexing:setup      # Install deps and Playwright browsers
 ```
 

--- a/MCP_REGISTRY.md
+++ b/MCP_REGISTRY.md
@@ -131,7 +131,7 @@ To publish an updated version:
 Ensure the `websiteUrl` target (currently pointing to `docs.glean.com`) includes:
 
 - Clear setup instructions for getting organization-specific URLs
-- Environment variable requirements (GLEAN_INSTANCE, etc.)
+- Environment variable requirements (GLEAN_SERVER_URL, etc.)
 - Authentication setup (OAuth or API tokens)
 - Troubleshooting guide
 - Example use cases and prompts

--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -7,7 +7,7 @@
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token, not Indexing token)
  * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
- *   Falls back to GLEAN_INSTANCE if GLEAN_SERVER_URL is not set.
+ *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 
 import { Glean } from '@gleanwork/api-client';
@@ -31,7 +31,7 @@ export default class GleanSearchProvider {
 
     if (!serverURL && !instance) {
       throw new Error(
-        '[Glean] GLEAN_SERVER_URL (or GLEAN_INSTANCE) environment variable is required',
+        '[Glean] GLEAN_SERVER_URL (or deprecated GLEAN_INSTANCE) environment variable is required',
       );
     }
 

--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -6,7 +6,7 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token, not Indexing token)
- * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-server-id-be.glean.com')
  *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 

--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -6,7 +6,7 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token, not Indexing token)
- * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-server-id-be.glean.com')
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
  *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 

--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -6,7 +6,8 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token, not Indexing token)
- * - GLEAN_INSTANCE: Your Glean instance name (e.g., 'glean' for glean-be.glean.com)
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
+ *   Falls back to GLEAN_INSTANCE if GLEAN_SERVER_URL is not set.
  */
 
 import { Glean } from '@gleanwork/api-client';
@@ -19,6 +20,7 @@ export default class GleanSearchProvider {
 
   async initialize(context, _initData) {
     const apiToken = process.env.GLEAN_API_TOKEN;
+    const serverURL = process.env.GLEAN_SERVER_URL;
     const instance = process.env.GLEAN_INSTANCE;
 
     if (!apiToken) {
@@ -27,22 +29,26 @@ export default class GleanSearchProvider {
       );
     }
 
-    if (!instance) {
+    if (!serverURL && !instance) {
       throw new Error(
-        '[Glean] GLEAN_INSTANCE environment variable is required',
+        '[Glean] GLEAN_SERVER_URL (or GLEAN_INSTANCE) environment variable is required',
       );
     }
 
-    this.client = new Glean({
-      apiToken,
-      instance,
-    });
+    const clientOpts = { apiToken };
+    if (serverURL) {
+      clientOpts.serverURL = serverURL;
+    } else {
+      clientOpts.instance = instance;
+    }
+
+    this.client = new Glean(clientOpts);
 
     this.baseUrl = context.baseUrl;
     this.ready = true;
 
     console.log(
-      `[Glean] Initialized search provider for instance: ${instance}`,
+      `[Glean] Initialized search provider for ${serverURL || instance}`,
     );
   }
 
@@ -132,7 +138,7 @@ export default class GleanSearchProvider {
 
       return {
         healthy: true,
-        message: `Connected to Glean instance: ${process.env.GLEAN_INSTANCE}`,
+        message: `Connected to Glean: ${process.env.GLEAN_SERVER_URL || process.env.GLEAN_INSTANCE}`,
       };
     } catch (error) {
       return {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -7,7 +7,7 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token)
- * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-server-id-be.glean.com')
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
  *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -7,7 +7,7 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token)
- * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-server-id-be.glean.com')
  *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -8,7 +8,7 @@
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token)
  * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
- *   Falls back to GLEAN_INSTANCE if GLEAN_SERVER_URL is not set.
+ *   Falls back to GLEAN_INSTANCE (deprecated) if GLEAN_SERVER_URL is not set.
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -7,7 +7,8 @@
  *
  * Required environment variables:
  * - GLEAN_API_TOKEN: Your Glean API token (Client API token)
- * - GLEAN_INSTANCE: Your Glean instance name (e.g., 'glean' for glean-be.glean.com)
+ * - GLEAN_SERVER_URL: Your Glean server URL (e.g., 'https://your-company-be.glean.com')
+ *   Falls back to GLEAN_INSTANCE if GLEAN_SERVER_URL is not set.
  */
 
 import type { VercelRequest, VercelResponse } from '@vercel/node';

--- a/docs/api-info/indexing/documents/bulk-indexing.mdx
+++ b/docs/api-info/indexing/documents/bulk-indexing.mdx
@@ -102,7 +102,7 @@ import os
 
 with Glean(
     api_token=os.getenv("GLEAN_INDEXING_API_TOKEN", ""),
-    instance=os.getenv("GLEAN_INSTANCE", ""),
+    server_url=os.getenv("GLEAN_SERVER_URL", ""),
 ) as client:
     # Bulk index documents
     try:

--- a/docs/api-info/indexing/getting-started/index-documents.mdx
+++ b/docs/api-info/indexing/getting-started/index-documents.mdx
@@ -72,7 +72,7 @@ import os
 
 with Glean(
     api_token=os.getenv("GLEAN_API_TOKEN", ""),
-    instance=os.getenv("GLEAN_INSTANCE", ""),
+    server_url=os.getenv("GLEAN_SERVER_URL", ""),
 ) as client:
     # Index a document
     try:

--- a/docs/api-info/indexing/getting-started/setup-datasource.mdx
+++ b/docs/api-info/indexing/getting-started/setup-datasource.mdx
@@ -72,7 +72,7 @@ import os
 
 with Glean(
     api_token=os.getenv("GLEAN_INDEXING_API_TOKEN", ""),
-    instance=os.getenv("GLEAN_INSTANCE", ""),
+    server_url=os.getenv("GLEAN_SERVER_URL", ""),
 ) as client:
     # Create a datasource
     try:

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -14,28 +14,27 @@ Glean provides two main authentication methods to access its APIs, each with dif
 
 ---
 
-## Finding Your Glean Instance
+## Finding Your Server URL
 
-All Glean API requests require specifying your organization's specific Glean instance. The instance identifier is used in API endpoints and API Client/SDK configuration.
+All Glean API requests require your organization's server URL. The server URL is used in API endpoints and API Client/SDK configuration.
 
-### How to Find Your Instance
+### How to Find Your Server URL
 
 1. **Navigate to the About Page**: Visit [https://app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) in your Glean admin console
-2. **Locate Server Instance**: Find the **"Server instance (QE)"** field
-3. **Extract Instance Name**: Use the portion before `-be.glean.com`
+2. **Locate Server URL**: Find the **"Server instance (QE)"** field — this is your server URL
 
 ### Example
 
-If your Server instance shows: `https://acme-prod-be.glean.com/`  
-Your instance name is: **`acme-prod`**
+If the field shows: `https://acme-prod-be.glean.com/`
+Your server URL is: **`https://acme-prod-be.glean.com`**
 
 ### Usage in APIs
 
-Your instance name is used in:
-- **API Base URLs**: 
-  - Client API: `https://{instance}-be.glean.com/rest/api/v1/`
-  - Indexing API: `https://{instance}-be.glean.com/api/index/v1/`
-- **API Client/SDK Configuration**: Set as `GLEAN_INSTANCE` environment variable
+Your server URL is used in:
+- **API Base URLs**:
+  - Client API: `https://acme-prod-be.glean.com/rest/api/v1/`
+  - Indexing API: `https://acme-prod-be.glean.com/api/index/v1/`
+- **API Client/SDK Configuration**: Set as `GLEAN_SERVER_URL` environment variable
 
 ---
 
@@ -50,18 +49,18 @@ Glean offers two distinct APIs with different authentication capabilities. Choos
     - Search, chat, collections, agents
     - User-facing functionality
     - OAuth (recommended) + Glean tokens
-    - Base URL: `https://instance-be.glean.com/rest/api/v1/`
-    
+    - Base URL: `https://<your-server-url>/rest/api/v1/`
+
     [Implementation Guide →](/api-info/client/authentication/overview)
   </Card>
-  
+
   <Card title="Indexing API Authentication" icon="Database">
     **For administrative operations and content management**
-        
+
     - Document indexing, datasource management
     - Administrative operations
     - Glean tokens only (no OAuth support)
-    - Base URL: `https://instance-be.glean.com/api/index/v1/`
+    - Base URL: `https://<your-server-url>/api/index/v1/`
     
     [Implementation Guide →](/api-info/indexing/authentication/overview)
   </Card>

--- a/docs/guides/actions/authentication.mdx
+++ b/docs/guides/actions/authentication.mdx
@@ -52,10 +52,10 @@ When setting up OAuth (admin or user), you'll need to configure the following pa
 Your OAuth App must be configured to allow redirects (Callback URL) to:
 
 ```
-https://{your-glean-instance}-be.glean.com/tools/oauth/verify_code
+https://<your-server-url>/tools/oauth/verify_code
 ```
 
-You can find your instance name using our [instance lookup guide](/get-started/authentication#finding-your-glean-instance).
+Find your server URL at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean).
 
 Without this, the OAuth integration may fail or show invalid redirect URI errors.
 :::
@@ -87,16 +87,16 @@ import json
 import requests
 
 # Fill your glean instance here.
-YOUR_GLEAN_INSTANCE=''
-# Find this value using our instance lookup guide: /get-started/authentication#finding-your-glean-instance
+YOUR_GLEAN_SERVER_URL=''
+# Find your server URL at app.glean.com/admin/about-glean
 
-# Use this function as is in your code (once you have filled out YOUR_GLEAN_INSTANCE).
+# Use this function as is in your code (once you have filled out YOUR_GLEAN_SERVER_URL).
 # Pass the header value for Glean-Actions-Signature as the 'token' in this function.
 
 def verify_jwt(token):
     try:
         # First, we fetch the public key JSON response.
-        response = requests.get(f"https://{YOUR_GLEAN_INSTANCE}-be.glean.com/api/tools/v1/verification_key")
+        response = requests.get(f"{YOUR_GLEAN_SERVER_URL}/api/tools/v1/verification_key")
         response.raise_for_status() # Raises an exception for 4XX/5XX responses
         public_key_str = response.json()['publicKey']
 

--- a/docs/guides/agents/direct-api.mdx
+++ b/docs/guides/agents/direct-api.mdx
@@ -89,14 +89,14 @@ from glean.api_client import Glean, models
 class CustomAgent:
     def __init__(self):
         self.api_token = os.getenv("GLEAN_API_TOKEN")
-        self.instance = os.getenv("GLEAN_INSTANCE")
+        self.server_url = os.getenv("GLEAN_SERVER_URL")
         
-        if not self.api_token or not self.instance:
-            raise ValueError("GLEAN_API_TOKEN and GLEAN_INSTANCE must be set")
+        if not self.api_token or not self.server_url:
+            raise ValueError("GLEAN_API_TOKEN and GLEAN_SERVER_URL must be set")
     
     def search_documents(self, query: str, page_size: int = 5):
         """Search for relevant documents"""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 response = glean.client.search.search(
                     query=query,
@@ -109,7 +109,7 @@ class CustomAgent:
     
     def chat_with_context(self, query: str, search_results=None) -> str:
         """Generate response using chat API"""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 # Prepare context from search results
                 context = ""
@@ -179,15 +179,15 @@ from typing import List, Dict, Optional
 class AdvancedAgent:
     def __init__(self):
         self.api_token = os.getenv("GLEAN_API_TOKEN")
-        self.instance = os.getenv("GLEAN_INSTANCE")
+        self.server_url = os.getenv("GLEAN_SERVER_URL")
         self.conversation_history = []
         
-        if not self.api_token or not self.instance:
-            raise ValueError("GLEAN_API_TOKEN and GLEAN_INSTANCE must be set")
+        if not self.api_token or not self.server_url:
+            raise ValueError("GLEAN_API_TOKEN and GLEAN_SERVER_URL must be set")
     
     def search_with_filters(self, query: str, filters: Optional[Dict] = None, page_size: int = 10) -> List[Dict]:
         """Search with optional filters"""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 search_params = {
                     "query": query,
@@ -206,7 +206,7 @@ class AdvancedAgent:
     
     def chat_with_context(self, query: str, context_docs: Optional[List[Dict]] = None, save_to_history: bool = True) -> str:
         """Chat with document context and conversation history"""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 # Build message with context
                 message_parts = []
@@ -264,7 +264,7 @@ class AdvancedAgent:
     
     def summarize_documents(self, documents: List[Dict]) -> str:
         """Summarize a list of documents"""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 doc_texts = []
                 for doc in documents[:5]:  # Limit to 5 docs

--- a/docs/guides/agents/langchain.mdx
+++ b/docs/guides/agents/langchain.mdx
@@ -57,12 +57,12 @@ You'll need Glean [API credentials](/get-started/authentication), and specifical
 Configure your Glean credentials by setting the following environment variables:
 
 ```bash
-export GLEAN_INSTANCE="your-glean-instance"
+export GLEAN_SERVER_URL="https://your-company-be.glean.com"
 export GLEAN_API_TOKEN="your-glean-api-token"
 export GLEAN_ACT_AS="user@example.com"  # Optional: Email to act as when making requests
 ```
 
-To determine your `GLEAN_INSTANCE` value, see our [instance lookup guide](/get-started/authentication#finding-your-glean-instance) for detailed instructions.
+Find your server URL at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean).
 
 ### Usage Examples
 
@@ -189,7 +189,7 @@ Configure the retriever with custom settings:
 ```python
 # Initialize with custom settings
 retriever = GleanSearchRetriever(
-    instance="your-instance",  # Override environment variable
+    server_url="https://your-company-be.glean.com",  # Override environment variable
     api_token="your-api-token",  # Override environment variable
     act_as="user@example.com",   # Override environment variable
     page_size=10,               # Default number of results

--- a/docs/guides/agents/toolkit.mdx
+++ b/docs/guides/agents/toolkit.mdx
@@ -54,7 +54,7 @@ import os
 
 # Ensure environment variables are set
 os.environ["GLEAN_API_TOKEN"] = "your-api-token"
-os.environ["GLEAN_INSTANCE"] = "your-instance-name"
+os.environ["GLEAN_SERVER_URL"] = "https://your-company-be.glean.com"
 
 # Use with LangChain
 langchain_search = glean_search.as_langchain_tool()
@@ -110,7 +110,7 @@ from crewai import Agent, Task, Crew
 import os
 
 os.environ["GLEAN_API_TOKEN"] = "your-api-token"
-os.environ["GLEAN_INSTANCE"] = "your-instance-name"
+os.environ["GLEAN_SERVER_URL"] = "https://your-company-be.glean.com"
 
 # Create agents with different specializations
 researcher = Agent(

--- a/docs/guides/chat/chatbot-example.mdx
+++ b/docs/guides/chat/chatbot-example.mdx
@@ -28,14 +28,14 @@ from glean.api_client import Glean, models
 def send_chat_message(message_text):
     """Send a message to Glean Chat and get the response."""
     api_token = os.getenv("GLEAN_API_TOKEN")
-    instance = os.getenv("GLEAN_INSTANCE")
+    server_url = os.getenv("GLEAN_SERVER_URL")
     
     if not api_token:
         raise ValueError("GLEAN_API_TOKEN environment variable is required")
-    if not instance:
-        raise ValueError("GLEAN_INSTANCE environment variable is required")
+    if not server_url:
+        raise ValueError("GLEAN_SERVER_URL environment variable is required")
     
-    with Glean(api_token=api_token, instance=instance) as glean:
+    with Glean(api_token=api_token, server_url=server_url) as glean:
         try:
             response = glean.client.chat.create(
                 messages=[
@@ -94,7 +94,7 @@ Create a `.env` file in your project directory:
 
 ```bash
 GLEAN_API_TOKEN=your_chat_token_here
-GLEAN_INSTANCE=your_company_name
+GLEAN_SERVER_URL=https://your-company-be.glean.com
 ```
 
 ## Running the Example
@@ -102,7 +102,7 @@ GLEAN_INSTANCE=your_company_name
 1. Set your environment variables:
    ```bash
    export GLEAN_API_TOKEN="your_chat_token_here"
-   export GLEAN_INSTANCE="your_company_name"
+   export GLEAN_SERVER_URL="https://your-company-be.glean.com"
    ```
 
 2. Run the chatbot:
@@ -130,16 +130,16 @@ from glean.api_client import Glean, models
 def stream_chat_response(message_text):
     """Stream chat response in real-time."""
     api_token = os.getenv("GLEAN_API_TOKEN")
-    instance = os.getenv("GLEAN_INSTANCE")
+    server_url = os.getenv("GLEAN_SERVER_URL")
     
     if not api_token:
         print("Error: GLEAN_API_TOKEN environment variable required")
         return
-    if not instance:
-        print("Error: GLEAN_INSTANCE environment variable required")
+    if not server_url:
+        print("Error: GLEAN_SERVER_URL environment variable required")
         return
     
-    with Glean(api_token=api_token, instance=instance) as glean:
+    with Glean(api_token=api_token, server_url=server_url) as glean:
         try:
             response_stream = glean.client.chat.create_stream(
                 messages=[
@@ -194,16 +194,16 @@ class ConversationalChatbot:
     def __init__(self):
         self.chat_id = None
         self.api_token = os.getenv("GLEAN_API_TOKEN")
-        self.instance = os.getenv("GLEAN_INSTANCE")
+        self.server_url = os.getenv("GLEAN_SERVER_URL")
         
         if not self.api_token:
             raise ValueError("GLEAN_API_TOKEN environment variable is required")
-        if not self.instance:
-            raise ValueError("GLEAN_INSTANCE environment variable is required")
+        if not self.server_url:
+            raise ValueError("GLEAN_SERVER_URL environment variable is required")
     
     def send_message(self, user_message):
         """Send a message with conversation history."""
-        with Glean(api_token=self.api_token, instance=self.instance) as glean:
+        with Glean(api_token=self.api_token, server_url=self.server_url) as glean:
             try:
                 response = glean.client.chat.create(
                     messages=[
@@ -286,16 +286,16 @@ logger = logging.getLogger(__name__)
 def send_chat_message_with_retry(message_text, max_retries=3):
     """Send chat message with retry logic."""
     api_token = os.getenv("GLEAN_API_TOKEN")
-    instance = os.getenv("GLEAN_INSTANCE")
+    server_url = os.getenv("GLEAN_SERVER_URL")
     
     if not api_token:
         return "Missing GLEAN_API_TOKEN"
-    if not instance:
-        return "Missing GLEAN_INSTANCE"
+    if not server_url:
+        return "Missing GLEAN_SERVER_URL"
     
     for attempt in range(max_retries):
         try:
-            with Glean(api_token=api_token, instance=instance) as glean:
+            with Glean(api_token=api_token, server_url=server_url) as glean:
                 response = glean.client.chat.create(
                     messages=[
                         {
@@ -335,7 +335,7 @@ def send_chat_message_with_retry(message_text, max_retries=3):
 
 ```python
 # Use a specific agent for specialized responses
-with Glean(api_token=api_token, instance=instance) as glean:
+with Glean(api_token=api_token, server_url=server_url) as glean:
     response = glean.client.chat.create(
         messages=[
             {

--- a/docs/guides/search/overview.mdx
+++ b/docs/guides/search/overview.mdx
@@ -76,8 +76,8 @@ import requests
 import os
 
 api_token = os.getenv("GLEAN_API_TOKEN")
-instance = os.getenv("GLEAN_INSTANCE")
-base_url = f"https://{instance}-be.glean.com/rest/api/v1"
+server_url = os.getenv("GLEAN_SERVER_URL")
+base_url = f"{server_url}/rest/api/v1"
 
 headers = {
     "Authorization": f"Bearer {api_token}",
@@ -209,7 +209,7 @@ const SearchComponent = () => {
   
   const client = new Glean({
     apiToken: process.env.REACT_APP_GLEAN_TOKEN,
-    instance: process.env.REACT_APP_GLEAN_INSTANCE
+    serverURL: process.env.REACT_APP_GLEAN_SERVER_URL
   });
   
   const handleSearch = async (searchQuery: string) => {

--- a/docs/libraries/api-clients/go.mdx
+++ b/docs/libraries/api-clients/go.mdx
@@ -39,7 +39,7 @@ func main() {
 
   client := glean.New(
     glean.WithAPIToken(os.Getenv("GLEAN_API_TOKEN")),
-    glean.WithInstance(os.Getenv("GLEAN_INSTANCE")),
+    glean.WithServerURL(os.Getenv("GLEAN_SERVER_URL")),
   )
 
   message := glean.ChatMessageFragment{
@@ -242,7 +242,7 @@ func batchSearch(client *glean.Client, queries []string) ([]glean.SearchResponse
 ```go
 client := glean.New(
   glean.WithAPIToken("your-user-token"),
-  glean.WithInstance("your-company"),
+  glean.WithServerURL("https://your-company-be.glean.com"),
 )
 ```
 

--- a/docs/libraries/api-clients/java.mdx
+++ b/docs/libraries/api-clients/java.mdx
@@ -48,7 +48,7 @@ public class GleanExample {
   public static void main(String[] args) {
     Glean client = Glean.builder()
         .apiToken(System.getenv("GLEAN_API_TOKEN"))
-        .instance(System.getenv("GLEAN_INSTANCE"))
+        .serverURL(System.getenv("GLEAN_SERVER_URL"))
         .build();
 
     var response = client.client().chat().create()
@@ -78,10 +78,10 @@ public class GleanExample {
 public class ChatService {
   private final Glean client;
   
-  public ChatService(String apiToken, String instance) {
+  public ChatService(String apiToken, String serverURL) {
     this.client = Glean.builder()
         .apiToken(apiToken)
-        .instance(instance)
+        .serverURL(serverURL)
         .build();
   }
   
@@ -111,10 +111,10 @@ public class ChatService {
 public class SearchService {
   private final Glean client;
   
-  public SearchService(String apiToken, String instance) {
+  public SearchService(String apiToken, String serverURL) {
     this.client = Glean.builder()
         .apiToken(apiToken)
-        .instance(instance)
+        .serverURL(serverURL)
         .build();
   }
   
@@ -142,25 +142,25 @@ public class SearchService {
 @ConfigurationProperties(prefix = "glean")
 public class GleanConfig {
   private String apiToken;
-  private String instance;
-  
+  private String serverURL;
+
   // Getters and setters
   public String getApiToken() { return apiToken; }
   public void setApiToken(String apiToken) { this.apiToken = apiToken; }
-  
-  public String getInstance() { return instance; }
-  public void setInstance(String instance) { this.instance = instance; }
+
+  public String getServerURL() { return serverURL; }
+  public void setServerURL(String serverURL) { this.serverURL = serverURL; }
 }
 
 @Configuration
 @EnableConfigurationProperties(GleanConfig.class)
 public class GleanAutoConfiguration {
-  
+
   @Bean
   public Glean gleanClient(GleanConfig config) {
     return Glean.builder()
         .apiToken(config.getApiToken())
-        .instance(config.getInstance())
+        .serverURL(config.getServerURL())
         .build();
   }
 }
@@ -215,7 +215,7 @@ public class GleanController {
 ```java
 Glean client = Glean.builder()
     .apiToken("your-user-token")
-    .instance("your-company")
+    .serverURL("https://your-company-be.glean.com")
     .build();
 ```
 
@@ -225,7 +225,7 @@ Glean client = Glean.builder()
 # application.yml
 glean:
   api-token: ${GLEAN_API_TOKEN}
-  instance: ${GLEAN_INSTANCE}
+  server-url: ${GLEAN_SERVER_URL}
 ```
 
 ## Error Handling

--- a/docs/libraries/api-clients/python.mdx
+++ b/docs/libraries/api-clients/python.mdx
@@ -47,7 +47,7 @@ Glean's Python API client provides a Pythonic interface to Glean's Client API, m
 <Steps>
   <Step title="Set up environment variables">
     ```bash
-    export GLEAN_INSTANCE="your-company"
+    export GLEAN_SERVER_URL="https://your-company-be.glean.com"
     export GLEAN_API_TOKEN="your-token-here"
     ```
   </Step>
@@ -59,7 +59,7 @@ Glean's Python API client provides a Pythonic interface to Glean's Client API, m
 
     with Glean(
         api_token=os.getenv("GLEAN_API_TOKEN"),
-        instance=os.getenv("GLEAN_INSTANCE"),
+        server_url=os.getenv("GLEAN_SERVER_URL"),
     ) as client:
         response = client.client.chat.create(
             messages=[{
@@ -135,7 +135,7 @@ class ChatRequest(BaseModel):
 async def chat_endpoint(request: ChatRequest):
     with Glean(
         api_token=os.getenv("GLEAN_API_TOKEN"),
-        instance=os.getenv("GLEAN_INSTANCE"),
+        server_url=os.getenv("GLEAN_SERVER_URL"),
     ) as client:
         response = client.client.chat.create(
             messages=[{"fragments": [{"text": request.message}]}]
@@ -156,7 +156,7 @@ def chat_view(request):
     
     with Glean(
         api_token=os.getenv("GLEAN_API_TOKEN"),
-        instance=os.getenv("GLEAN_INSTANCE"),
+        server_url=os.getenv("GLEAN_SERVER_URL"),
     ) as client:
         response = client.client.chat.create(
             messages=[{"fragments": [{"text": message}]}]
@@ -178,7 +178,7 @@ user_input = st.text_input("Ask a question:")
 if user_input:
     with Glean(
         api_token=os.getenv("GLEAN_API_TOKEN"),
-        instance=os.getenv("GLEAN_INSTANCE"),
+        server_url=os.getenv("GLEAN_SERVER_URL"),
     ) as client:
         response = client.client.chat.create(
             messages=[{"fragments": [{"text": user_input}]}]
@@ -193,7 +193,7 @@ if user_input:
 ```python
 client = Glean(
     api_token="your-user-token",
-    instance="your-company"
+    server_url="https://your-company-be.glean.com"
 )
 ```
 

--- a/docs/libraries/api-clients/typescript.mdx
+++ b/docs/libraries/api-clients/typescript.mdx
@@ -45,7 +45,7 @@ import { Glean } from "@gleanwork/api-client";
 
 const client = new Glean({
   apiToken: process.env.GLEAN_API_TOKEN,
-  instance: process.env.GLEAN_INSTANCE,
+  serverURL: process.env.GLEAN_SERVER_URL,
 });
 
 const result = await client.client.chat.create({
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest) {
   
   const client = new Glean({
     apiToken: process.env.GLEAN_API_TOKEN!,
-    instance: process.env.GLEAN_INSTANCE!,
+    serverURL: process.env.GLEAN_SERVER_URL!,
   });
 
   const response = await client.client.chat.create({
@@ -120,11 +120,11 @@ export async function POST(request: NextRequest) {
 import React, { useState } from 'react';
 import { Glean } from '@gleanwork/api-client';
 
-export function ChatComponent({ apiToken, instance }) {
+export function ChatComponent({ apiToken, serverURL }) {
   const [input, setInput] = useState('');
   const [response, setResponse] = useState('');
-  
-  const client = new Glean({ apiToken, instance });
+
+  const client = new Glean({ apiToken, serverURL });
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -159,7 +159,7 @@ app.use(express.json());
 
 const client = new Glean({
   apiToken: process.env.GLEAN_API_TOKEN!,
-  instance: process.env.GLEAN_INSTANCE!,
+  serverURL: process.env.GLEAN_SERVER_URL!,
 });
 
 app.post('/api/chat', async (req, res) => {
@@ -180,7 +180,7 @@ app.post('/api/chat', async (req, res) => {
 ```typescript
 const client = new Glean({
   apiToken: "your-user-token",
-  instance: "your-company"
+  serverURL: "https://your-company-be.glean.com"
 });
 ```
 

--- a/packages/changelog-generator/README.md
+++ b/packages/changelog-generator/README.md
@@ -12,7 +12,7 @@ This package analyzes releases and OpenAPI spec changes and opens PRs with rende
 ## Environment
 
 - Required for GitHub access: `GITHUB_TOKEN`.
-- Optional for LLM summaries: `GLEAN_API_TOKEN`, `GLEAN_INSTANCE`, `CHANGELOG_SUMMARIZE=1`.
+- Optional for LLM summaries: `GLEAN_API_TOKEN`, `GLEAN_SERVER_URL` (or `GLEAN_INSTANCE`), `CHANGELOG_SUMMARIZE=1`.
 
 ## Local usage
 

--- a/packages/changelog-generator/README.md
+++ b/packages/changelog-generator/README.md
@@ -12,7 +12,7 @@ This package analyzes releases and OpenAPI spec changes and opens PRs with rende
 ## Environment
 
 - Required for GitHub access: `GITHUB_TOKEN`.
-- Optional for LLM summaries: `GLEAN_API_TOKEN`, `GLEAN_SERVER_URL` (or `GLEAN_INSTANCE`), `CHANGELOG_SUMMARIZE=1`.
+- Optional for LLM summaries: `GLEAN_API_TOKEN`, `GLEAN_SERVER_URL` (or deprecated `GLEAN_INSTANCE`), `CHANGELOG_SUMMARIZE=1`.
 
 ## Local usage
 

--- a/packages/changelog-generator/src/summarizer.ts
+++ b/packages/changelog-generator/src/summarizer.ts
@@ -134,11 +134,12 @@ async function summarizeWithGlean(
   opts: { maxChars: number; category?: string; hints?: Array<string> },
 ): Promise<string | null> {
   const apiToken = process.env.GLEAN_API_TOKEN;
+  const serverURL = process.env.GLEAN_SERVER_URL;
   const instance = process.env.GLEAN_INSTANCE;
 
-  if (!apiToken || !instance) {
+  if (!apiToken || (!serverURL && !instance)) {
     dbgSum(
-      'summarize:skipping LLM (missing GLEAN_API_TOKEN or GLEAN_INSTANCE)',
+      'summarize:skipping LLM (missing GLEAN_API_TOKEN or GLEAN_SERVER_URL)',
     );
     return null;
   }
@@ -151,7 +152,13 @@ async function summarizeWithGlean(
       (opts.hints || []).length,
       cleaned.length,
     );
-    const client = new Glean({ apiToken, instance });
+    const clientOpts: Record<string, string> = { apiToken };
+    if (serverURL) {
+      clientOpts.serverURL = serverURL;
+    } else {
+      clientOpts.instance = instance!;
+    }
+    const client = new Glean(clientOpts);
 
     const systemInstructions = [
       `You are a changelog entry generator. Output ONLY the changelog content.`,

--- a/scripts/indexing/.env.example
+++ b/scripts/indexing/.env.example
@@ -3,7 +3,7 @@
 
 GLEAN_INDEXING_API_TOKEN=your-api-token-here
 GLEAN_SERVER_URL=https://your-company-be.glean.com
-# Legacy instance name (still supported as fallback)
+# Deprecated: legacy instance name (still supported as fallback)
 # GLEAN_INSTANCE=your-glean-instance
 
 # Dry run mode (set to true to skip uploading, prints extraction summary)

--- a/scripts/indexing/.env.example
+++ b/scripts/indexing/.env.example
@@ -2,7 +2,9 @@
 # Copy this file to .env and fill in your values
 
 GLEAN_INDEXING_API_TOKEN=your-api-token-here
-GLEAN_INSTANCE=your-glean-instance
+GLEAN_SERVER_URL=https://your-company-be.glean.com
+# Legacy instance name (still supported as fallback)
+# GLEAN_INSTANCE=your-glean-instance
 
 # Dry run mode (set to true to skip uploading, prints extraction summary)
 DRY_RUN=true

--- a/scripts/indexing/README.md
+++ b/scripts/indexing/README.md
@@ -55,7 +55,7 @@ Run the indexing script locally:
 ```bash
 # Set required environment variables
 export GLEAN_INDEXING_API_TOKEN="your-api-token"
-export GLEAN_INSTANCE="your-glean-instance"
+export GLEAN_SERVER_URL="https://your-company-be.glean.com"
 
 # Run the script
 uv run main.py
@@ -64,7 +64,7 @@ uv run main.py
 ### Environment Variables
 
 - `GLEAN_INDEXING_API_TOKEN` - API token for Glean indexing
-- `GLEAN_INSTANCE` - Your Glean instance URL
+- `GLEAN_SERVER_URL` - Your Glean server URL (find at app.glean.com/admin/about-glean)
 
 ### GitHub Actions
 

--- a/scripts/mcp-local-server.ts
+++ b/scripts/mcp-local-server.ts
@@ -3,7 +3,7 @@
  * Local MCP server for testing the Glean search provider integration.
  *
  * Usage:
- *   1. Create a .env file with GLEAN_API_TOKEN and GLEAN_INSTANCE
+ *   1. Create a .env file with GLEAN_API_TOKEN and GLEAN_SERVER_URL
  *   2. Run: pnpm run mcp:local
  *
  * Then test with:
@@ -33,8 +33,10 @@ if (!process.env.GLEAN_API_TOKEN) {
   process.exit(1);
 }
 
-if (!process.env.GLEAN_INSTANCE) {
-  console.error('Error: GLEAN_INSTANCE environment variable is required');
+if (!process.env.GLEAN_SERVER_URL && !process.env.GLEAN_INSTANCE) {
+  console.error(
+    'Error: GLEAN_SERVER_URL (or GLEAN_INSTANCE) environment variable is required',
+  );
   process.exit(1);
 }
 
@@ -89,7 +91,7 @@ async function main() {
   server.listen(PORT, () => {
     console.log(`
 MCP server running at http://localhost:${PORT}/mcp
-Using Glean instance: ${process.env.GLEAN_INSTANCE}
+Using Glean: ${process.env.GLEAN_SERVER_URL || process.env.GLEAN_INSTANCE}
 
 Test commands:
   curl http://localhost:${PORT}/health

--- a/scripts/mcp-local-server.ts
+++ b/scripts/mcp-local-server.ts
@@ -35,7 +35,7 @@ if (!process.env.GLEAN_API_TOKEN) {
 
 if (!process.env.GLEAN_SERVER_URL && !process.env.GLEAN_INSTANCE) {
   console.error(
-    'Error: GLEAN_SERVER_URL (or GLEAN_INSTANCE) environment variable is required',
+    'Error: GLEAN_SERVER_URL (or deprecated GLEAN_INSTANCE) environment variable is required',
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- Updated ~15 hand-authored MDX docs to use `GLEAN_SERVER_URL` / `server_url` as primary
- Updated `.env.example` files to show `GLEAN_SERVER_URL` first
- Updated 4 infrastructure code files with `GLEAN_SERVER_URL` > `GLEAN_INSTANCE` fallback
- Skipped OpenAPI YAMLs (auto-updated from upstream Phase 3 regen)
- Language-specific updates: Python `server_url=`, TypeScript `serverURL:`, Java `.serverURL()`, Go `WithServerURL()`
- Part of the `instance → server_url` migration for DNS obfuscation support

## Test plan
- [x] Zero remaining `GLEAN_INSTANCE` in hand-authored docs
- [x] Infrastructure code has proper fallback logic
- [ ] `pnpm build` (Docusaurus build succeeds)
- [ ] Manual review of doc formatting