### PR TITLE
chore(changelog): 2026-03-06

### DIFF
--- a/changelog/entries/2026-03-05-configure-mcp-server-3-1-0.md
+++ b/changelog/entries/2026-03-05-configure-mcp-server-3-1-0.md
@@ -1,0 +1,10 @@
+---
+title: 'configure-mcp-server v3.1.0'
+categories: ['MCP']
+---
+
+This release adds server URL configurability for MCP and updates the MCP config package dependency. - Added CLI flag to configure the MCP server endpoint - Added environment variable support for MCP server configuration - Migrated MCP config dependency from to
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.1.0

--- a/changelog/entries/2026-03-05-glean-agent-toolkit-0-4-0.md
+++ b/changelog/entries/2026-03-05-glean-agent-toolkit-0-4-0.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-agent-toolkit 0.4.0'
+categories: ['Glean Agent Toolkit']
+---
+
+Improves Glean Agent Toolkit’s environment configuration, developer setup, and schema capabilities while fixing adapter hints and lint issues. - Support GLEAN_SERVER_URL with GLEAN_INSTANCE fallback and add API client retry configuration controlled via environment variables - Adopt mise with full...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.4.0

--- a/changelog/entries/2026-03-05-glean-indexing-sdk-1-0-0b1.md
+++ b/changelog/entries/2026-03-05-glean-indexing-sdk-1-0-0b1.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-indexing-sdk v1.0.0b1'
+categories: ['Glean Indexing SDK']
+---
+
+Glean Indexing SDK now supports configuration via GLEAN_SERVER_URL with GLEAN_INSTANCE fallback and introduces improved error handling and documentation. - Added support for configuring the SDK using GLEAN_SERVER_URL with GLEAN_INSTANCE as a fallback. - Introduced a custom exception hierarchy to...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-indexing-sdk/releases/tag/v1.0.0b1

--- a/changelog/entries/2026-03-05-langchain-glean-0-4-0.md
+++ b/changelog/entries/2026-03-05-langchain-glean-0-4-0.md
@@ -1,0 +1,10 @@
+---
+title: 'langchain-glean v0.4.0'
+categories: ['langchain-glean']
+---
+
+Adds server_url configuration with instance fallback and updates tooling and SDK usage for improved developer ergonomics. - Added server_url support with automatic fallback to the Glean instance. - Migrated task runner from go-task to native mise tasks. - Updated Speakeasy SDK usage and...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/langchain-glean/releases/tag/v0.4.0

--- a/changelog/entries/2026-03-05-mcp-config-schema-4-3-0.md
+++ b/changelog/entries/2026-03-05-mcp-config-schema-4-3-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v4.3.0'
+categories: ['MCP']
+---
+
+No changes documented for mcp-config-schema v4.3.0 beyond the version bump.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v4.3.0

--- a/changelog/entries/2026-03-05-mcp-server-0-10-0.md
+++ b/changelog/entries/2026-03-05-mcp-server-0-10-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-server v0.10.0'
+categories: ['MCP']
+---
+
+A changelog entry can’t be generated yet because only the version label (“mcp-server v0.10.0”) was provided, and the actual release note contents are missing. Please paste the full release notes text for mcp-server v0.10.0 so I can turn it into a compliant changelog entry following your rules.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-server/releases/tag/v0.10.0


### PR DESCRIPTION
Adds 6 changelog entries generated on 2026-03-06.

Files:
- changelog/entries/2026-03-05-glean-agent-toolkit-0-4-0.md
- changelog/entries/2026-03-05-mcp-server-0-10-0.md
- changelog/entries/2026-03-05-mcp-config-schema-4-3-0.md
- changelog/entries/2026-03-05-configure-mcp-server-3-1-0.md
- changelog/entries/2026-03-05-glean-indexing-sdk-1-0-0b1.md
- changelog/entries/2026-03-05-langchain-glean-0-4-0.md

Skipped:
- {repo: api-client-java, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-python, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-go, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}