### PR TITLE
chore(changelog): 2026-03-10

### DIFF
--- a/changelog/entries/2026-03-09-api-client-go-0-11-29.md
+++ b/changelog/entries/2026-03-09-api-client-go-0-11-29.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.29'
+categories: ['API Clients']
+---
+
+This release introduces widespread response and snippet schema changes across the Go client, multiple breaking changes to chat and search APIs, new datasource configuration endpoints, and an updated agents error model. - Breaking changes to responses for Chat (Create, Retrieve, List, CreateStream),...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.29

--- a/changelog/entries/2026-03-09-api-client-java-0-12-24.md
+++ b/changelog/entries/2026-03-09-api-client-java-0-12-24.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.24'
+categories: ['API Clients']
+---
+
+This release updates multiple client request/response schemas (including snippets and chat messages), introduces new datasource configuration endpoints, and deprecates a people indexing API. - Introduced breaking response changes across search, chat, messages, autocomplete, and related...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.24

--- a/changelog/entries/2026-03-09-api-client-python-0-12-9.md
+++ b/changelog/entries/2026-03-09-api-client-python-0-12-9.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-python v0.12.9'
+categories: ['API Clients']
+---
+
+- : - **Changed**.
+- : - **Changed**
+- **Changed** (Breaking ⚠️)
+- : - **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9


### PR DESCRIPTION
Adds 3 changelog entries generated on 2026-03-10.

Files:
- changelog/entries/2026-03-09-api-client-java-0-12-24.md
- changelog/entries/2026-03-09-api-client-python-0-12-9.md
- changelog/entries/2026-03-09-api-client-go-0-11-29.md

Skipped:
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}