### PR TITLE
chore(changelog): 2026-03-12

### DIFF
--- a/changelog/entries/2026-03-11-api-client-go-0-11-30.md
+++ b/changelog/entries/2026-03-11-api-client-go-0-11-30.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-go v0.11.30'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Added**
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30

--- a/changelog/entries/2026-03-11-api-client-java-0-12-25.md
+++ b/changelog/entries/2026-03-11-api-client-java-0-12-25.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-java v0.12.25'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Added**
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25

--- a/changelog/entries/2026-03-11-api-client-python-0-12-10.md
+++ b/changelog/entries/2026-03-11-api-client-python-0-12-10.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.10'
+categories: ['API Clients']
+---
+
+Added new auth metadata fields to chat APIs and a name field to agent schema retrieval responses. - Added request and response to - Added response to - Added request to and response to
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.10


### PR DESCRIPTION
Adds 3 changelog entries generated on 2026-03-12.

Files:
- changelog/entries/2026-03-11-api-client-java-0-12-25.md
- changelog/entries/2026-03-11-api-client-python-0-12-10.md
- changelog/entries/2026-03-11-api-client-go-0-11-30.md

Skipped:
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}