### PR TITLE
feat: dark-mode carousel code blocks, Linear connector demo, icon fixes

### DIFF
--- a/docs/guides/chat/deep-linked-citations.mdx
+++ b/docs/guides/chat/deep-linked-citations.mdx
@@ -32,7 +32,7 @@ Deep-linked citations are available when all of the following are true:
     Your `/chat` request must use Agentic Loop. Set `agentConfig.agent` to `"FAST"` or `"ADVANCED"` in your request.
     If omitted, requests default to Chat V2 which does not support deep-linked citations.
   </Card>
-  <Card title="Supported LLM Models" icon="Brain">
+  <Card title="Supported LLM Models" icon="Cpu">
     Deep-linked citations are supported with OpenAI (GPT) and Anthropic (Claude) models.
     Gemini is not currently supported.
   </Card>
@@ -144,7 +144,7 @@ Top-level `citations[]` on the message remain unchanged and still hold document-
   <Card title="Minimal Migration" icon="Shield">
     Stay compatible without UI changes—just update your types to tolerate the new fields
   </Card>
-  <Card title="Full Migration" icon="Sparkles">
+  <Card title="Full Migration" icon="sparkles" iconSet="glean">
     Render deep-linked citations with hover previews showing direct quotes
   </Card>
 </CardGroup>

--- a/packages/docusaurus-theme-glean/src/css/brand.css
+++ b/packages/docusaurus-theme-glean/src/css/brand.css
@@ -23,6 +23,33 @@
   /* Accent color (light yellow/green) */
   --ifm-color-accent: #d8fd49;
 
+  /* Glean semantic colors */
+  --ifm-color-success: #27ae60;
+  --ifm-color-warning: #fff7be;
+  --ifm-color-danger: #e02e2a;
+  --ifm-color-info: #aab5ff;
+
+  /* Glean brand accent palette */
+  --glean-brand-pink: #f1b7ff;
+  --glean-brand-peach: #ffcfbd;
+  --glean-brand-light-blue: #a9e0ff;
+  --glean-brand-yellow: #ffdf69;
+  --glean-brand-apple-green: #daf181;
+  --glean-brand-ivory: #f6f3eb;
+
+  /* Glean border-radius scale */
+  --glean-border-radius-sm: 4px;
+  --glean-border-radius-md: 8px;
+  --glean-border-radius-lg: 12px;
+  --glean-border-radius-xl: 16px;
+  --glean-border-radius-2xl: 24px;
+
+  /* Glean box-shadow scale */
+  --glean-shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 0 0 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-md: 0 8px 8px -4px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-lg: 0 8px 24px -6px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-xl: 0 32px 32px -8px rgba(0, 0, 0, 0.08), 0 0 32px -8px rgba(0, 0, 0, 0.12), 0 0 1px 0 rgba(0, 0, 0, 0.2);
+
   --ifm-font-size-base: 87.5%;
   --ifm-code-font-size: 85%;
 
@@ -43,7 +70,10 @@
     'Polysans Neutral', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
     Cantarell, Noto Sans, sans-serif;
   --ifm-font-weight-base: 400;
-  --ifm-heading-font-weight: 400;
+  --ifm-font-weight-medium: 500;
+  --ifm-font-weight-semibold: 600;
+  --ifm-font-weight-bold: 700;
+  --ifm-heading-font-weight: 600;
 
   /* Custom font variables */
   --font-jetbrains-mono:
@@ -280,10 +310,51 @@ article li a:hover,
 article h1,
 .main-wrapper h1 {
   letter-spacing: 0.025em;
-  font-weight: 700;
+  font-weight: var(--ifm-font-weight-bold);
   line-height: 1.2;
   margin-bottom: 1.5rem;
   color: var(--ifm-heading-color);
+}
+
+.markdown h2,
+article h2 {
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
+.markdown h3,
+article h3 {
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
+.markdown h4,
+article h4,
+.markdown h5,
+article h5,
+.markdown h6,
+article h6 {
+  font-weight: var(--ifm-font-weight-medium);
+}
+
+.markdown strong,
+article strong,
+.markdown b,
+article b {
+  font-weight: var(--ifm-font-weight-semibold);
+}
+
+/* Sidebar background */
+.theme-doc-sidebar-container {
+  background-color: #f6f6f6;
+}
+
+[data-theme='dark'] .theme-doc-sidebar-container {
+  background-color: unset;
+}
+
+/* Admonitions — remove Infima's default left border, use radius token */
+.alert {
+  border: none;
+  border-radius: var(--glean-border-radius-md);
 }
 
 html {
@@ -314,12 +385,12 @@ html {
 
 .tabs-container [role='tabpanel'] pre::-webkit-scrollbar-track {
   background: var(--ifm-color-emphasis-200);
-  border-radius: 3px;
+  border-radius: var(--glean-border-radius-sm);
 }
 
 .tabs-container [role='tabpanel'] pre::-webkit-scrollbar-thumb {
   background: var(--ifm-color-emphasis-400);
-  border-radius: 3px;
+  border-radius: var(--glean-border-radius-sm);
 }
 
 .tabs-container [role='tabpanel'] pre::-webkit-scrollbar-thumb:hover {

--- a/packages/docusaurus-theme-glean/src/css/brand.css
+++ b/packages/docusaurus-theme-glean/src/css/brand.css
@@ -45,10 +45,15 @@
   --glean-border-radius-2xl: 24px;
 
   /* Glean box-shadow scale */
-  --glean-shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 0 0 0 rgba(0, 0, 0, 0.4);
-  --glean-shadow-md: 0 8px 8px -4px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
-  --glean-shadow-lg: 0 8px 24px -6px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
-  --glean-shadow-xl: 0 32px 32px -8px rgba(0, 0, 0, 0.08), 0 0 32px -8px rgba(0, 0, 0, 0.12), 0 0 1px 0 rgba(0, 0, 0, 0.2);
+  --glean-shadow-sm:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 0 0 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-md:
+    0 8px 8px -4px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-lg:
+    0 8px 24px -6px rgba(0, 0, 0, 0.15), 0 0 1px 0 rgba(0, 0, 0, 0.4);
+  --glean-shadow-xl:
+    0 32px 32px -8px rgba(0, 0, 0, 0.08), 0 0 32px -8px rgba(0, 0, 0, 0.12),
+    0 0 1px 0 rgba(0, 0, 0, 0.2);
 
   --ifm-font-size-base: 87.5%;
   --ifm-code-font-size: 85%;

--- a/packages/docusaurus-theme-glean/src/theme/Icons/index.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/Icons/index.tsx
@@ -42,9 +42,15 @@ function GleanIcon({
           .replace(/<svg([^>]*)\s+height="[^"]*"/, '<svg$1')
           .replace(/<svg/, '<svg style="width: 100%; height: 100%"');
 
-        // Add fill="currentColor" to path elements that don't have fill specified
+        // For stroke-only paths (no explicit fill): use fill="none" to preserve
+        // the stroke-only design intent. Without this, the path gets filled solid.
         cleanedSvg = cleanedSvg.replace(
-          /<path(?![^>]*fill=)([^>]*)>/g,
+          /<path(?=[^>]*stroke=)(?![^>]*fill=)([^>]*)>/g,
+          '<path$1 fill="none">',
+        );
+        // For paths with neither stroke nor fill: add fill="currentColor"
+        cleanedSvg = cleanedSvg.replace(
+          /<path(?![^>]*stroke=)(?![^>]*fill=)([^>]*)>/g,
           '<path$1 fill="currentColor">',
         );
 

--- a/src/components/Homepage/CarouselSection.module.css
+++ b/src/components/Homepage/CarouselSection.module.css
@@ -6,7 +6,7 @@
 /* CAROUSEL STYLING */
 .carousel {
   padding-bottom: 2rem;
-  overflow: visible;
+  overflow: hidden;
   position: relative;
 }
 
@@ -64,21 +64,14 @@
   width: 100%;
   background: linear-gradient(135deg, #0b0e51 0%, #4785b0 100%) !important;
   border-radius: 12px;
-  padding: 2rem 2rem 0 2rem;
+  padding: 1.5rem 1.5rem 0 1.5rem;
 }
 
 .codeWrapInner {
   width: 100%;
-}
-
-/* Keep code flush with bottom of gradient (override theme spacing) */
-.codeWrapInner :global(pre),
-.codeWrapInner :global(.prism-code) {
-  margin-bottom: 0 !important;
-  padding-bottom: 0 !important;
-}
-.codeWrapInner > * {
-  margin-bottom: 0 !important;
+  max-height: 340px;
+  overflow: auto;
+  border-radius: 0 0 10px 10px;
 }
 
 /* IMAGE STYLING */

--- a/src/components/Homepage/CarouselSection.tsx
+++ b/src/components/Homepage/CarouselSection.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import clsx from 'clsx';
-import CodeBlock from '@theme/CodeBlock';
+import { Highlight, themes } from 'prism-react-renderer';
 import ThemedImage from '@theme/ThemedImage';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Autoplay, Pagination } from 'swiper/modules';
@@ -116,21 +116,36 @@ result = crew.kickoff()`,
     ctaIcon: 'Database',
     ctaIconSet: 'feather',
     codeLanguage: 'python',
-    codeContent: `import os
-from glean import Glean, models
+    codeContent: `from glean.indexing.connectors import BaseDatasourceConnector
+from glean.indexing.models import (
+    ContentDefinition, CustomDatasourceConfig, DocumentDefinition,
+)
+from glean.api_client.models import DatasourceCategory
 
-with Glean(
-    instance='acme',
-    api_token=os.getenv('GLEAN_INDEXING_TOKEN', ''),
-) as g:
-    document = models.DocumentDefinition(
-        id='doc-123',
-        title='Q4 Sales Report',
-        body='Our Q4 performance exceeded expectations...',
-        datasource='internal-docs'
+class LinearConnector(BaseDatasourceConnector[dict]):
+    configuration = CustomDatasourceConfig(
+        name="linear",
+        display_name="Linear",
+        datasource_category=DatasourceCategory.TICKETS,
     )
 
-    g.indexing.index_document(document=document)`,
+    def transform(self, issues: list[dict]) -> list[DocumentDefinition]:
+        return [
+            DocumentDefinition(
+                id=issue["id"],
+                title=issue["title"],
+                datasource=self.name,
+                body=ContentDefinition(
+                    mime_type="text/plain",
+                    text_content=issue.get("description", ""),
+                ),
+            )
+            for issue in issues
+        ]
+
+connector = LinearConnector(name="linear", data_client=client)
+connector.configure_datasource()
+connector.index_data()`,
   },
 ];
 
@@ -201,9 +216,23 @@ export default function CarouselSection() {
                 ) : (
                   <div className={styles.codeWrap}>
                     <div className={styles.codeWrapInner}>
-                      <CodeBlock language={slide.codeLanguage} showLineNumbers>
-                        {slide.codeContent}
-                      </CodeBlock>
+                      <Highlight
+                        theme={themes.dracula}
+                        code={slide.codeContent.trim()}
+                        language={slide.codeLanguage}
+                      >
+                        {({ className, style, tokens, getLineProps, getTokenProps }) => (
+                          <pre className={className} style={{ ...style, margin: 0, padding: '1rem 1.25rem', fontSize: '0.78rem', lineHeight: 1.55 }}>
+                            {tokens.map((line, i) => (
+                              <div key={i} {...getLineProps({ line })}>
+                                {line.map((token, key) => (
+                                  <span key={key} {...getTokenProps({ token })} />
+                                ))}
+                              </div>
+                            ))}
+                          </pre>
+                        )}
+                      </Highlight>
                     </div>
                   </div>
                 )}

--- a/src/components/Homepage/CarouselSection.tsx
+++ b/src/components/Homepage/CarouselSection.tsx
@@ -221,12 +221,30 @@ export default function CarouselSection() {
                         code={slide.codeContent.trim()}
                         language={slide.codeLanguage}
                       >
-                        {({ className, style, tokens, getLineProps, getTokenProps }) => (
-                          <pre className={className} style={{ ...style, margin: 0, padding: '1rem 1.25rem', fontSize: '0.78rem', lineHeight: 1.55 }}>
+                        {({
+                          className,
+                          style,
+                          tokens,
+                          getLineProps,
+                          getTokenProps,
+                        }) => (
+                          <pre
+                            className={className}
+                            style={{
+                              ...style,
+                              margin: 0,
+                              padding: '1rem 1.25rem',
+                              fontSize: '0.78rem',
+                              lineHeight: 1.55,
+                            }}
+                          >
                             {tokens.map((line, i) => (
                               <div key={i} {...getLineProps({ line })}>
                                 {line.map((token, key) => (
-                                  <span key={key} {...getTokenProps({ token })} />
+                                  <span
+                                    key={key}
+                                    {...getTokenProps({ token })}
+                                  />
                                 ))}
                               </div>
                             ))}


### PR DESCRIPTION
## Summary

- **Carousel dark mode**: Replaced Docusaurus `CodeBlock` with `prism-react-renderer` `Highlight` + `themes.dracula` directly. `CodeBlock` bakes inline styles at render time from the site's current theme — the only way to force dark is to pass a dark theme object at the component level.
- **Linear connector slide**: Updated the "Bring Every Data Source" carousel slide (slide 4) to show a real `glean-indexing-sdk` connector class (`LinearConnector` extending `BaseDatasourceConnector`) instead of the generic SDK usage example.
- **Carousel layout fixes**:
  - Code panels capped at 340px height with `overflow: auto` so long snippets don't blow out the slide height
  - Swiper `overflow: visible` → `hidden` to prevent the dark gradient container from bleeding into adjacent image slides during autoplay transitions
- **Icon rendering fix (theme package)**: `GleanIcon` SVG cleanup was adding `fill="currentColor"` to ALL paths without an explicit fill attribute — including stroke-only paths, which turned them into solid filled shapes. The `code-block` icon was rendering as a solid blue wedge instead of the `</>` bracket shape. Fix: paths with `stroke=` but no `fill=` now get `fill="none"`, preserving the designer's stroke-only intent.
- **Invalid icon names**: `icon="Brain"` → `icon="Cpu"` and `icon="Sparkles"` → `icon="sparkles" iconSet="glean"` in `deep-linked-citations.mdx` — `Brain` and `Sparkles` don't exist in react-feather or the Glean icon manifest, causing silent empty renders.

## Test plan

- [ ] Homepage carousel: slides 3 and 4 show dark code blocks (Dracula theme) regardless of site light/dark mode toggle
- [ ] Slide 4 shows `LinearConnector` class with `BaseDatasourceConnector`, `CustomDatasourceConfig`, and `transform()` — scrollable if taller than 340px
- [ ] Toggling between carousel slides shows clean transitions with no dark gradient bleeding onto image slides
- [ ] "Build with Our APIs" feature card shows a `</>` code-block icon, not a solid filled triangle
- [ ] `/guides/chat/deep-linked-citations` page renders `Cpu` and `sparkles` icons correctly (no empty icon slots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)