### PR TITLE
chore(changelog): 2026-03-17

### DIFF
--- a/changelog/entries/2026-03-16-api-client-go-0-11-31.md
+++ b/changelog/entries/2026-03-16-api-client-go-0-11-31.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.31'
+categories: ['API Clients']
+---
+
+This release adds a new chat response object and updates feed search request and result structures in the Go API client. - : added - : changed - : changed
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.31

--- a/changelog/entries/2026-03-16-api-client-java-0-12-26.md
+++ b/changelog/entries/2026-03-16-api-client-java-0-12-26.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-java v0.12.26'
+categories: ['API Clients']
+---
+
+- : **Added**.
+- : **Added**
+- : - **Changed**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26

--- a/changelog/entries/2026-03-16-api-client-python-0-12-11.md
+++ b/changelog/entries/2026-03-16-api-client-python-0-12-11.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-python v0.12.11'
+categories: ['API Clients']
+---
+
+- : **Added**.
+- : **Added**
+- : - **Changed**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11


### PR DESCRIPTION
Adds 3 changelog entries generated on 2026-03-17.

Files:
- changelog/entries/2026-03-16-api-client-java-0-12-26.md
- changelog/entries/2026-03-16-api-client-python-0-12-11.md
- changelog/entries/2026-03-16-api-client-go-0-11-31.md

Skipped:
- {repo: api-client-typescript, decision: skip, reason: no newer release than latest entry}
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}