### PR TITLE
chore(changelog): 2026-03-18

### DIFF
--- a/changelog/entries/2026-03-17-api-client-go-0-11-32.md
+++ b/changelog/entries/2026-03-17-api-client-go-0-11-32.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.32'
+categories: ['API Clients']
+---
+
+Released Go API client version 0.11.32 based on OpenAPI Doc 0.9.0. - Updated Go API client to v0.11.32 - Regenerated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.755.1 (2.865.2)
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.32

--- a/changelog/entries/2026-03-17-api-client-java-0-12-27.md
+++ b/changelog/entries/2026-03-17-api-client-java-0-12-27.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.27'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.27 based on OpenAPI Doc 0.9.0 and the latest Speakeasy CLI tooling. - Regenerated Java SDK at v0.12.27 - Published Java SDK v0.12.27 to Maven Central
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.27

--- a/changelog/entries/2026-03-17-api-client-python-0-12-12.md
+++ b/changelog/entries/2026-03-17-api-client-python-0-12-12.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.12'
+categories: ['API Clients']
+---
+
+Released Python API client v0.12.12 generated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.755.1 (2.865.2). - Generated Python SDK version v0.12.12 - Published PyPI release v0.12.12
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.12

--- a/changelog/entries/2026-03-17-api-client-typescript-0-14-8.md
+++ b/changelog/entries/2026-03-17-api-client-typescript-0-14-8.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.8'
+categories: ['API Clients']
+---
+
+This release updates multiple request/response schemas (including chat, search, collections, answers, pins, announcements, entities, shortcuts, verification) and adds new datasource configuration endpoints, with several breaking changes. - Introduced breaking response changes to chat, search...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.8


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-03-18.

Files:
- changelog/entries/2026-03-17-api-client-java-0-12-27.md
- changelog/entries/2026-03-17-api-client-python-0-12-12.md
- changelog/entries/2026-03-17-api-client-typescript-0-14-8.md
- changelog/entries/2026-03-17-api-client-go-0-11-32.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}