### PR TITLE
chore(changelog): 2026-03-19

### DIFF
--- a/changelog/entries/2026-03-18-api-client-go-0-11-33.md
+++ b/changelog/entries/2026-03-18-api-client-go-0-11-33.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.33'
+categories: ['API Clients']
+---
+
+Released Go API client v0.11.33 based on OpenAPI Doc 0.9.0 using Speakeasy CLI 1.757.0 (2.866.0). - Updated Go client generation to OpenAPI Doc 0.9.0. - Regenerated Go SDK as version v0.11.33. - Published Go API client release v0.11.33.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.33

--- a/changelog/entries/2026-03-18-api-client-java-0-12-28.md
+++ b/changelog/entries/2026-03-18-api-client-java-0-12-28.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.28'
+categories: ['API Clients']
+---
+
+Updated Java API client to version 0.12.28 based on OpenAPI Doc 0.9.0 and Speakeasy CLI 1.757.0 (2.866.0), with a new release published to Maven Central. - Generated Java client: v0.12.28 - OpenAPI specification: 0.9.0; Speakeasy CLI: 1.757.0 (2.866.0) - Maven Central release: v0.12.28
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.28

--- a/changelog/entries/2026-03-18-api-client-python-0-12-13.md
+++ b/changelog/entries/2026-03-18-api-client-python-0-12-13.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.13'
+categories: ['API Clients']
+---
+
+Released Python API client v0.12.13 based on OpenAPI Doc 0.9.0 and updated Speakeasy CLI tooling. - Generated python v0.12.13 from OpenAPI Doc 0.9.0 - Published python client as PyPI release v0.12.13
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.13

--- a/changelog/entries/2026-03-18-api-client-typescript-0-14-9.md
+++ b/changelog/entries/2026-03-18-api-client-typescript-0-14-9.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.9'
+categories: ['API Clients']
+---
+
+Updated the Glean TypeScript API client to v0.14.9 based on OpenAPI Doc 0.9.0. - TypeScript SDK regenerated as version 0.14.9. - Published NPM package @gleanwork/api-client at version 0.14.9.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.9


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-03-19.

Files:
- changelog/entries/2026-03-18-api-client-java-0-12-28.md
- changelog/entries/2026-03-18-api-client-python-0-12-13.md
- changelog/entries/2026-03-18-api-client-typescript-0-14-9.md
- changelog/entries/2026-03-18-api-client-go-0-11-33.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}