### PR TITLE
chore(changelog): 2026-03-20

### DIFF
--- a/changelog/entries/2026-03-19-api-client-go-0-11-34.md
+++ b/changelog/entries/2026-03-19-api-client-go-0-11-34.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.34'
+categories: ['API Clients']
+---
+
+Released Go API client v0.11.34 generated from OpenAPI Doc 0.9.0. - Based on OpenAPI Doc version 0.9.0 - Regenerated Go SDK (v0.11.34) using updated inputs - Published Go API client release v0.11.34
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.34

--- a/changelog/entries/2026-03-19-api-client-java-0-12-29.md
+++ b/changelog/entries/2026-03-19-api-client-java-0-12-29.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.29'
+categories: ['API Clients']
+---
+
+Released Java API client version 0.12.29 based on OpenAPI Doc 0.9.0 and updated Speakeasy CLI tooling. - Generated Java SDK v0.12.29 - Published Java SDK v0.12.29 to Maven Central
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.29

--- a/changelog/entries/2026-03-19-api-client-python-0-12-14.md
+++ b/changelog/entries/2026-03-19-api-client-python-0-12-14.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.14'
+categories: ['API Clients']
+---
+
+Released Python API client v0.12.14 based on OpenAPI Doc 0.9.0 and updated Speakeasy CLI tooling. - Updated client generation to use OpenAPI Doc 0.9.0. - Regenerated Python SDK at version 0.12.14. - Published Python client v0.12.14 to PyPI.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.14

--- a/changelog/entries/2026-03-19-api-client-typescript-0-14-10.md
+++ b/changelog/entries/2026-03-19-api-client-typescript-0-14-10.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.10'
+categories: ['API Clients']
+---
+
+Released Glean TypeScript API client v0.14.10 based on OpenAPI Doc 0.9.0. - Updated generated TypeScript SDK to version 0.14.10. - Published @gleanwork/api-client NPM package at version 0.14.10.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.10


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-03-20.

Files:
- changelog/entries/2026-03-19-api-client-java-0-12-29.md
- changelog/entries/2026-03-19-api-client-python-0-12-14.md
- changelog/entries/2026-03-19-api-client-typescript-0-14-10.md
- changelog/entries/2026-03-19-api-client-go-0-11-34.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}