### PR TITLE
fix: explicitly enable externalJsonProps to activate MDX externalization

### DIFF
--- a/openapi.config.ts
+++ b/openapi.config.ts
@@ -3,6 +3,11 @@ import { customApiMdGenerator } from './scripts/generator/customMdGenerators';
 
 const sharedOptions = {
   showSchemas: false,
+  // Explicitly enable prop externalization (externalJsonProps defaults to true in
+  // validateOptions, but gen-api-docs CLI bypasses that validation, so we set it here
+  // to ensure large JSON props are written to separate .json files rather than inlined
+  // in MDX — this significantly reduces MDX file sizes and speeds up the Docusaurus build).
+  externalJsonProps: true,
   sidebarOptions: {
     groupPathsBy: 'tag' as const,
     categoryLinkSource: 'tag' as const,


### PR DESCRIPTION
## Summary

- Explicitly sets `externalJsonProps: true` in the shared OpenAPI config options

## Problem

`docusaurus-plugin-openapi-docs` v4.7.1 introduced an `externalJsonProps` option (default `true`) that externalizes large JSON props from MDX files into separate `.json` files. This significantly reduces MDX file sizes and speeds up the Docusaurus build step.

However, the `gen-api-docs` CLI command bypasses `validateOptions` (where Joi applies the `default(true)`), so `options.externalJsonProps` is `undefined` (falsy) during regeneration. The externalization check:

```js
if (options.externalJsonProps && (item.type === "api" || item.type === "schema")) {
```

...never triggers, leaving all JSON props inlined. For example, `chat.api.mdx` is currently **732 KB** entirely because of inlined JSON schema data.

## Fix

Explicitly set `externalJsonProps: true` in the `sharedOptions` in `openapi.config.ts`. This is the workaround for the plugin bug where CLI generation bypasses Joi option defaults.

## Impact

After the next `openapi:regenerate:all` run:
- Each API endpoint's MDX file will be much smaller (props externalized to `.json` files)
- The Docusaurus build step will be faster (webpack parses smaller MDX files)
- The `.json` external files are handled by the existing `openapi:clean:before:*` scripts (which delete all files in the output dirs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)