### PR TITLE
fix: add missing Translate import to custom OpenAPI MDX generator

### DIFF
--- a/scripts/generator/customMdGenerators.ts
+++ b/scripts/generator/customMdGenerators.ts
@@ -163,6 +163,7 @@ export function customApiMdGenerator({
     `import OperationTabs from "@theme/OperationTabs";\n`,
     `import TabItem from "@theme/TabItem";\n`,
     `import Heading from "@theme/Heading";\n`,
+    `import Translate from "@docusaurus/Translate";\n`,
     hasDeprecations
       ? `import ApiDeprecations from "@site/src/theme/ApiDeprecations";\n\n`
       : '\n',


### PR DESCRIPTION
The `docusaurus-plugin-openapi-docs` v4.7.1 upgrade (PR #373) introduced a `<Translate>` component in `createRequestHeader()`. The default plugin generator adds this import automatically, but our custom markdown generator in `customMdGenerators.ts` bypasses the default and was missing it. This causes all API pages (not just new ones) to fail during static site generation — which is why PR #423's CI is failing.
