### PR TITLE
chore(changelog): 2026-03-24

### DIFF
--- a/changelog/entries/2026-03-23-api-client-go-0-11-35.md
+++ b/changelog/entries/2026-03-23-api-client-go-0-11-35.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-go v0.11.35'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Added**
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35

--- a/changelog/entries/2026-03-23-api-client-go-0-11-36.md
+++ b/changelog/entries/2026-03-23-api-client-go-0-11-36.md
@@ -1,0 +1,12 @@
+---
+title: 'api-client-go v0.11.36'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36

--- a/changelog/entries/2026-03-23-api-client-java-0-12-30.md
+++ b/changelog/entries/2026-03-23-api-client-java-0-12-30.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.30'
+categories: ['API Clients']
+---
+
+Chat citations now include across chat create, retrieve, and streaming APIs, changed , and findings export added an export type. - Added to and - Added to and to - Changed and added to
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.30

--- a/changelog/entries/2026-03-23-api-client-java-0-12-31.md
+++ b/changelog/entries/2026-03-23-api-client-java-0-12-31.md
@@ -1,0 +1,12 @@
+---
+title: 'api-client-java v0.12.31'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31

--- a/changelog/entries/2026-03-23-api-client-python-0-12-15.md
+++ b/changelog/entries/2026-03-23-api-client-python-0-12-15.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.15'
+categories: ['API Clients']
+---
+
+glean-api-client 0.12.15 adds citation fields to chat create, retrieve, and create_stream flows, changes in insights retrieve, and adds as an export type for findings export. - and add , and also adds - adds - changes , and adds
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.15

--- a/changelog/entries/2026-03-23-api-client-python-0-12-16.md
+++ b/changelog/entries/2026-03-23-api-client-python-0-12-16.md
@@ -1,0 +1,12 @@
+---
+title: 'api-client-python v0.12.16'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16

--- a/changelog/entries/2026-03-23-api-client-typescript-0-14-11.md
+++ b/changelog/entries/2026-03-23-api-client-typescript-0-14-11.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-typescript v0.14.11'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Added**
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11

--- a/changelog/entries/2026-03-23-api-client-typescript-0-14-12.md
+++ b/changelog/entries/2026-03-23-api-client-typescript-0-14-12.md
@@ -1,0 +1,12 @@
+---
+title: 'api-client-typescript v0.14.12'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Changed**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12


### PR DESCRIPTION
Adds 8 changelog entries generated on 2026-03-24.

Files:
- changelog/entries/2026-03-23-api-client-java-0-12-31.md
- changelog/entries/2026-03-23-api-client-java-0-12-30.md
- changelog/entries/2026-03-23-api-client-python-0-12-16.md
- changelog/entries/2026-03-23-api-client-python-0-12-15.md
- changelog/entries/2026-03-23-api-client-typescript-0-14-12.md
- changelog/entries/2026-03-23-api-client-typescript-0-14-11.md
- changelog/entries/2026-03-23-api-client-go-0-11-36.md
- changelog/entries/2026-03-23-api-client-go-0-11-35.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}