### PR TITLE
chore(changelog): 2026-03-26

### DIFF
--- a/changelog/entries/2026-03-25-api-client-go-0-11-37.md
+++ b/changelog/entries/2026-03-25-api-client-go-0-11-37.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.37'
+categories: ['API Clients']
+---
+
+Released Go API client v0.11.37 generated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.759.2 (2.869.23). - Updated Go API client to version v0.11.37 - Regenerated client from OpenAPI Doc 0.9.0 - Generation performed with Speakeasy CLI 1.759.2 (2.869.23)
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.37

--- a/changelog/entries/2026-03-25-api-client-java-0-12-32.md
+++ b/changelog/entries/2026-03-25-api-client-java-0-12-32.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.32'
+categories: ['API Clients']
+---
+
+Released Java API client v0.12.32 based on OpenAPI Doc 0.9.0 using Speakeasy CLI 1.759.2 (2.869.23). - Generated Java SDK version v0.12.32 - Published Java SDK v0.12.32 to Maven Central
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.32

--- a/changelog/entries/2026-03-25-api-client-python-0-12-17.md
+++ b/changelog/entries/2026-03-25-api-client-python-0-12-17.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.17'
+categories: ['API Clients']
+---
+
+Released Python API client v0.12.17 generated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.759.2 (2.869.23). - Generated Python SDK version v0.12.17 - Published Python package release v0.12.17 on PyPI
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.17

--- a/changelog/entries/2026-03-25-api-client-typescript-0-14-13.md
+++ b/changelog/entries/2026-03-25-api-client-typescript-0-14-13.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.13'
+categories: ['API Clients']
+---
+
+Released TypeScript API client v0.14.13 for the Glean REST API, published on npm as @gleanwork/api-client. - Generated from OpenAPI Doc 0.9.0 using Speakeasy CLI 1.759.2. - Includes full TypeScript types, async/await support, and fetch-based HTTP for browser and Node.js. - Provides unified Client...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.13


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-03-26.

Files:
- changelog/entries/2026-03-25-api-client-java-0-12-32.md
- changelog/entries/2026-03-25-api-client-python-0-12-17.md
- changelog/entries/2026-03-25-api-client-typescript-0-14-13.md
- changelog/entries/2026-03-25-api-client-go-0-11-37.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}