### PR TITLE
chore(changelog): 2026-03-28

### DIFF
--- a/changelog/entries/2026-03-27-api-client-go-0-11-38.md
+++ b/changelog/entries/2026-03-27-api-client-go-0-11-38.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.38'
+categories: ['API Clients']
+---
+
+The Go API client adds the status enum to chat citation and file metadata fields and adds to document indexing requests. - Added to chat create and createStream request citation source file metadata. - Added to chat create and retrieve response citation metadata and chat uploadFiles and...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.38

--- a/changelog/entries/2026-03-27-api-client-java-0-12-33.md
+++ b/changelog/entries/2026-03-27-api-client-java-0-12-33.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.33'
+categories: ['API Clients']
+---
+
+Added support for the metadata status in chat citation and file fields, and added to document indexing requests. - Added to chat create and createStream request citation source files. - Added to chat create, retrieve, uploadFiles, and retrieveFiles response citation and file metadata. - Added to...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.33

--- a/changelog/entries/2026-03-27-api-client-python-0-12-18.md
+++ b/changelog/entries/2026-03-27-api-client-python-0-12-18.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.18'
+categories: ['API Clients']
+---
+
+The API client now supports a file metadata status in chat request and response citation objects and adds to document indexing requests. - Added in request citations and response message citations, and in request citations. - Added to response chat message citations, and added in and responses. -...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.18

--- a/changelog/entries/2026-03-27-api-client-typescript-0-14-14.md
+++ b/changelog/entries/2026-03-27-api-client-typescript-0-14-14.md
@@ -1,0 +1,13 @@
+---
+title: 'api-client-typescript v0.14.14'
+categories: ['API Clients']
+---
+
+- : - **Added**.
+- : - **Added**
+- **Added**
+- : **Added**
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-03-28.

Files:
- changelog/entries/2026-03-27-api-client-java-0-12-33.md
- changelog/entries/2026-03-27-api-client-python-0-12-18.md
- changelog/entries/2026-03-27-api-client-typescript-0-14-14.md
- changelog/entries/2026-03-27-api-client-go-0-11-38.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}