### PR TITLE
docs: reword remaining backend URL references for DNS obfuscation

### DIFF
--- a/docs/guides/agents/langchain.mdx
+++ b/docs/guides/agents/langchain.mdx
@@ -57,7 +57,7 @@ You'll need Glean [API credentials](/get-started/authentication), and specifical
 Configure your Glean credentials by setting the following environment variables:
 
 ```bash
-export GLEAN_SERVER_URL="https://your-company-be.glean.com"
+export GLEAN_SERVER_URL="https://your-server-id-be.glean.com"
 export GLEAN_API_TOKEN="your-glean-api-token"
 export GLEAN_ACT_AS="user@example.com"  # Optional: Email to act as when making requests
 ```
@@ -189,7 +189,7 @@ Configure the retriever with custom settings:
 ```python
 # Initialize with custom settings
 retriever = GleanSearchRetriever(
-    server_url="https://your-company-be.glean.com",  # Override environment variable
+    server_url="https://your-server-id-be.glean.com",  # Override environment variable
     api_token="your-api-token",  # Override environment variable
     act_as="user@example.com",   # Override environment variable
     page_size=10,               # Default number of results

--- a/docs/guides/agents/toolkit.mdx
+++ b/docs/guides/agents/toolkit.mdx
@@ -54,7 +54,7 @@ import os
 
 # Ensure environment variables are set
 os.environ["GLEAN_API_TOKEN"] = "your-api-token"
-os.environ["GLEAN_SERVER_URL"] = "https://your-company-be.glean.com"
+os.environ["GLEAN_SERVER_URL"] = "https://your-server-id-be.glean.com"
 
 # Use with LangChain
 langchain_search = glean_search.as_langchain_tool()
@@ -110,7 +110,7 @@ from crewai import Agent, Task, Crew
 import os
 
 os.environ["GLEAN_API_TOKEN"] = "your-api-token"
-os.environ["GLEAN_SERVER_URL"] = "https://your-company-be.glean.com"
+os.environ["GLEAN_SERVER_URL"] = "https://your-server-id-be.glean.com"
 
 # Create agents with different specializations
 researcher = Agent(

--- a/docs/guides/chat/chatbot-example.mdx
+++ b/docs/guides/chat/chatbot-example.mdx
@@ -94,7 +94,7 @@ Create a `.env` file in your project directory:
 
 ```bash
 GLEAN_API_TOKEN=your_chat_token_here
-GLEAN_SERVER_URL=https://your-company-be.glean.com
+GLEAN_SERVER_URL=https://your-server-id-be.glean.com
 ```
 
 ## Running the Example
@@ -102,7 +102,7 @@ GLEAN_SERVER_URL=https://your-company-be.glean.com
 1. Set your environment variables:
    ```bash
    export GLEAN_API_TOKEN="your_chat_token_here"
-   export GLEAN_SERVER_URL="https://your-company-be.glean.com"
+   export GLEAN_SERVER_URL="https://your-server-id-be.glean.com"
    ```
 
 2. Run the chatbot:

--- a/docs/libraries/api-clients/go.mdx
+++ b/docs/libraries/api-clients/go.mdx
@@ -242,7 +242,7 @@ func batchSearch(client *glean.Client, queries []string) ([]glean.SearchResponse
 ```go
 client := glean.New(
   glean.WithAPIToken("your-user-token"),
-  glean.WithServerURL("https://your-company-be.glean.com"),
+  glean.WithServerURL("https://your-server-id-be.glean.com"),
 )
 ```
 

--- a/docs/libraries/api-clients/java.mdx
+++ b/docs/libraries/api-clients/java.mdx
@@ -215,7 +215,7 @@ public class GleanController {
 ```java
 Glean client = Glean.builder()
     .apiToken("your-user-token")
-    .serverURL("https://your-company-be.glean.com")
+    .serverURL("https://your-server-id-be.glean.com")
     .build();
 ```
 

--- a/docs/libraries/api-clients/python.mdx
+++ b/docs/libraries/api-clients/python.mdx
@@ -47,7 +47,7 @@ Glean's Python API client provides a Pythonic interface to Glean's Client API, m
 <Steps>
   <Step title="Set up environment variables">
     ```bash
-    export GLEAN_SERVER_URL="https://your-company-be.glean.com"
+    export GLEAN_SERVER_URL="https://your-server-id-be.glean.com"
     export GLEAN_API_TOKEN="your-token-here"
     ```
   </Step>
@@ -193,7 +193,7 @@ if user_input:
 ```python
 client = Glean(
     api_token="your-user-token",
-    server_url="https://your-company-be.glean.com"
+    server_url="https://your-server-id-be.glean.com"
 )
 ```
 

--- a/docs/libraries/api-clients/typescript.mdx
+++ b/docs/libraries/api-clients/typescript.mdx
@@ -180,7 +180,7 @@ app.post('/api/chat', async (req, res) => {
 ```typescript
 const client = new Glean({
   apiToken: "your-user-token",
-  serverURL: "https://your-company-be.glean.com"
+  serverURL: "https://your-server-id-be.glean.com"
 });
 ```
 

--- a/docs/libraries/web-sdk/authentication/default-sso.mdx
+++ b/docs/libraries/web-sdk/authentication/default-sso.mdx
@@ -144,7 +144,7 @@ function SearchComponent() {
 
     // Render search box with SSO auth (default)
     GleanWebSDK.renderSearchBox(searchRef.current, {
-      backend: 'https://your-company-be.glean.com/',
+      backend: 'https://your-server-id-be.glean.com/',
       searchBoxCustomizations: {
         placeholderText: 'Search your company...'
       }

--- a/docs/libraries/web-sdk/authentication/server-to-server.mdx
+++ b/docs/libraries/web-sdk/authentication/server-to-server.mdx
@@ -78,7 +78,7 @@ The default TTL for generated tokens is 2 hours, but this is configurable. Conta
     app.post("/api/get-glean-token", async (req, res) => {
       const { userEmail } = req.body;
 
-      // Your backend URL (e.g., 'https://your-company-be.glean.com')
+      // Your backend URL (find at https://app.glean.com/admin/about-glean)
       const backend = process.env.GLEAN_BACKEND_URL;
       const apiKey = process.env.GLEAN_API_KEY;
 
@@ -238,7 +238,7 @@ The default TTL for Glean generated tokens is 2 hours, but this is configurable.
       // Retrieve the user's OAuth access token
       const accessToken = <USER'S ACCESS TOKEN>;
 
-      // Your backend URL (e.g., 'https://your-company-be.glean.com')
+      // Your backend URL (find at https://app.glean.com/admin/about-glean)
       const backend = process.env.GLEAN_BACKEND_URL;
 
       const tokenApiPath = backend.endsWith("/")

--- a/docs/libraries/web-sdk/components/autocomplete.mdx
+++ b/docs/libraries/web-sdk/components/autocomplete.mdx
@@ -25,7 +25,7 @@ Include the JavaScript library in your page's `<head>` section. Replace `GLEAN_A
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>

--- a/docs/libraries/web-sdk/components/chat.mdx
+++ b/docs/libraries/web-sdk/components/chat.mdx
@@ -22,7 +22,7 @@ First, include the JavaScript library in the `<head>` section of your page. Repl
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>

--- a/docs/libraries/web-sdk/components/modal-search.mdx
+++ b/docs/libraries/web-sdk/components/modal-search.mdx
@@ -26,7 +26,7 @@ Include the JavaScript library in your page's `<head>` section. Replace `GLEAN_A
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>

--- a/docs/libraries/web-sdk/components/recommendations.mdx
+++ b/docs/libraries/web-sdk/components/recommendations.mdx
@@ -22,7 +22,7 @@ Include the JavaScript library in your page's `<head>` section. Replace `GLEAN_A
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>

--- a/docs/libraries/web-sdk/components/settings.mdx
+++ b/docs/libraries/web-sdk/components/settings.mdx
@@ -26,7 +26,7 @@ First, include the JavaScript library in the `<head>` section of your page. Repl
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>

--- a/docs/libraries/web-sdk/components/sidebar.mdx
+++ b/docs/libraries/web-sdk/components/sidebar.mdx
@@ -24,7 +24,7 @@ Include the JavaScript library in your page's `<head>` section. Replace `GLEAN_A
 
 :::info
   The Glean web app domain differs from your company's Glean backend domain
-  (which typically follows the format `your-company-be.glean.com`).
+  (find yours at [app.glean.com/admin/about-glean](https://app.glean.com/admin/about-glean) under "Server instance (QE)").
 :::
 
 <Tabs>


### PR DESCRIPTION
## Summary

Follows up on [#379](https://github.com/gleanwork/glean-developer-site/pull/379) by Chris Freeman.

Glean is moving to opaque backend URLs for new customers:
```
Before:  acme-corp-be.glean.com      ← customer name exposed
After:   4f5226e2-be.glean.com       ← opaque 8-char hex UUID
```

These pages used `your-company-be.glean.com` as a placeholder, implying the URL is derivable from a company name. This PR updates all instances to use `your-server-id-be.glean.com` (the agreed placeholder from #379 review) and points to the About page for URL discovery.

### Changes
- **6 Web SDK component pages** (autocomplete, chat, modal-search, recommendations, settings, sidebar): replace format hint with About page link
- **4 API client pages** (Go, Java, Python, TypeScript): `your-company` → `your-server-id` in code examples
- **2 agent guide pages** (LangChain, toolkit): same placeholder swap in env var examples
- **2 auth pages** (default-sso, server-to-server): placeholder swap + About page comment
- **1 chatbot example page**: placeholder swap in `.env` and export examples

### Related PRs
- Customer docs: askscio/glean-docs#217 (SSO + MCP page rewords on docs.glean.com)

## Test plan
- [x] `pnpm build` succeeds
- [x] Manual review of affected pages