### PR TITLE
chore: remove dotenv in favor of mise env file support

### DIFF
--- a/.github/workflows/changelog-generator.yml
+++ b/.github/workflows/changelog-generator.yml
@@ -63,7 +63,7 @@ jobs:
                   DEBUG: ${{ inputs.debug == 'true' && 'changelog*' || '' }}
               run: |
                   if [ "${{ inputs.dry_run }}" = "true" ]; then
-                      pnpm changelog:publish --dry-run
+                      mise x -- pnpm changelog:publish --dry-run
                   else
-                      pnpm changelog:publish
+                      mise x -- pnpm changelog:publish
                   fi

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
+[env]
+_.file = ".env"
+
 [tools]
 # NOTE: updating these versions does *NOT* change what Vercel uses during deploy / preview
 # make sure to update `engines` in package.json as well

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "docusaurus-plugin-openapi-docs": "^4.7.1",
     "docusaurus-plugin-search-glean": "^0.7.0",
     "docusaurus-theme-openapi-docs": "^4.6.0",
-    "dotenv": "^17.3.1",
     "feed": "^5.2.0",
     "js-yaml": "^4.1.1",
     "lucide-react": "^0.563.0",

--- a/packages/changelog-generator/package.json
+++ b/packages/changelog-generator/package.json
@@ -17,7 +17,6 @@
     "build:rss": "pnpm run -s compile:rss"
   },
   "dependencies": {
-    "dotenv": "^17.3.1",
     "debug": "^4.3.6",
     "find-up": "^8.0.0",
     "js-yaml": "^4.1.1",

--- a/packages/changelog-generator/src/index.ts
+++ b/packages/changelog-generator/src/index.ts
@@ -2,7 +2,6 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as dotenv from 'dotenv';
 import { findUp } from 'find-up';
 import { Command } from 'commander';
 import { createCommand } from './commands/entry-new.js';
@@ -56,18 +55,6 @@ async function findRepoRoot(startDir: string): Promise<string> {
 
 async function main() {
   const repoRoot = await findRepoRoot(process.cwd());
-
-  try {
-    const rootEnvPath = path.join(repoRoot, '.env');
-    const pkgEnvPath = path.join(
-      repoRoot,
-      'packages',
-      'changelog-generator',
-      '.env',
-    );
-    if (fs.existsSync(rootEnvPath)) dotenv.config({ path: rootEnvPath });
-    if (fs.existsSync(pkgEnvPath)) dotenv.config({ path: pkgEnvPath });
-  } catch {}
 
   const program = new Command();
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,9 +77,6 @@ importers:
       docusaurus-theme-openapi-docs:
         specifier: ^4.6.0
         version: 4.6.0(251df1c41c27c47642b16d3ab724e0f1)
-      dotenv:
-        specifier: ^17.3.1
-        version: 17.3.1
       feed:
         specifier: ^5.2.0
         version: 5.2.0
@@ -222,9 +219,6 @@ importers:
       debug:
         specifier: ^4.3.6
         version: 4.4.3
-      dotenv:
-        specifier: ^17.3.1
-        version: 17.3.1
       feed:
         specifier: ^5.2.0
         version: 5.2.0
@@ -5252,10 +5246,6 @@ packages:
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
     engines: {node: '>=10'}
-
-  dotenv@17.3.1:
-    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -11557,7 +11547,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.29.0)
       '@babel/preset-react': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.28.4
       '@babel/traverse': 7.28.4
       '@docusaurus/logger': 3.9.2
@@ -11583,7 +11573,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.29.0)
       '@babel/preset-react': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.29.0)
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@babel/runtime-corejs3': 7.28.4
       '@babel/traverse': 7.28.4
       '@docusaurus/logger': 3.9.2
@@ -11720,9 +11710,9 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)'
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.101.3(@swc/core@1.13.5))
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.101.3(@swc/core@1.13.5))
       react-router: 5.3.4(react@18.3.1)
-      react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
+      react-router-config: 5.1.1(react-router@5.3.4(react@19.2.4))(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
       semver: 7.7.2
       serve-handler: 6.1.6
@@ -16537,8 +16527,6 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  dotenv@17.3.1: {}
-
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -20255,15 +20243,9 @@ snapshots:
       sucrase: 3.35.1
       use-editable: 2.3.3(react@19.2.4)
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.101.3(@swc/core@1.13.5)):
-    dependencies:
-      '@babel/runtime': 7.28.6
-      react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      webpack: 5.101.3(@swc/core@1.13.5)
-
   react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@19.2.4))(webpack@5.101.3(@swc/core@1.13.5)):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.4)'
       webpack: 5.101.3(@swc/core@1.13.5)
 
@@ -20307,21 +20289,21 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
+  react-router-config@5.1.1(react-router@5.3.4(react@19.2.4))(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 18.3.1
-      react-router: 5.3.4(react@18.3.1)
+      react-router: 5.3.4(react@19.2.4)
 
   react-router-config@5.1.1(react-router@5.3.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       react: 19.2.4
       react-router: 5.3.4(react@19.2.4)
 
   react-router-dom@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -20332,7 +20314,7 @@ snapshots:
 
   react-router-dom@5.3.4(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -20343,7 +20325,7 @@ snapshots:
 
   react-router@5.3.4(react@18.3.1):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
@@ -20356,7 +20338,7 @@ snapshots:
 
   react-router@5.3.4(react@19.2.4):
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0

--- a/scripts/mcp-local-server.ts
+++ b/scripts/mcp-local-server.ts
@@ -18,7 +18,6 @@
  *     -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"docs_search","arguments":{"query":"OAuth"}}}'
  */
 
-import 'dotenv/config';
 import http from 'http';
 import path from 'path';
 import { fileURLToPath } from 'url';


### PR DESCRIPTION
We already require mise for tooling in this repo, and it has native support for loading `.env` files via `[env] _.file = ".env"` in `mise.toml`. The `dotenv` npm package was only doing work for local dev (CI injects env vars via workflow `env:` blocks), and locally `mise activate` already handles env loading — so `dotenv` is redundant.

The one wrinkle is that `jdx/mise-action` in CI only installs tools and sets up shims — it doesn't load mise's `[env]` config. To cover this, the changelog CI step now wraps the command with `mise x --` which runs it in mise's full environment.

See https://mise.jdx.dev/environments/#env-file for mise's env file docs.
