### PR TITLE
chore(changelog): 2026-04-15

### DIFF
--- a/changelog/entries/2026-04-08-glean-agent-toolkit-0-5-0.md
+++ b/changelog/entries/2026-04-08-glean-agent-toolkit-0-5-0.md
@@ -1,0 +1,10 @@
+---
+title: 'glean-agent-toolkit 0.5.0'
+categories: ['Glean Agent Toolkit']
+---
+
+Glean Agent Toolkit improved developer setup and compatibility with installable skills, injectable GleanContext, unified adapter extras, retry and environment configuration updates, and LangGraph 1.x support. - Added installable skills for SDK usage and tool building, an injectable GleanContext in...
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.5.0

--- a/changelog/entries/2026-04-09-api-client-go-0-11-40.md
+++ b/changelog/entries/2026-04-09-api-client-go-0-11-40.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.40'
+categories: ['API Clients']
+---
+
+The Go API client updates with a changed and adds the enum value to results. - : changed - : added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.40

--- a/changelog/entries/2026-04-13-api-client-go-0-11-41.md
+++ b/changelog/entries/2026-04-13-api-client-go-0-11-41.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.41'
+categories: ['API Clients']
+---
+
+The Go API client now includes new workflow and governance export fields in search feed and findings export request and response models. - added - added and - added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.41

--- a/changelog/entries/2026-04-13-api-client-typescript-0-14-17.md
+++ b/changelog/entries/2026-04-13-api-client-typescript-0-14-17.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.17'
+categories: ['API Clients']
+---
+
+The API client adds new workflow draft timestamp and findings export status fields in search and governance responses, plus a status filter for creating findings exports. - adds - adds and - adds
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.17


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-04-15.

Files:
- changelog/entries/2026-04-13-api-client-typescript-0-14-17.md
- changelog/entries/2026-04-13-api-client-go-0-11-41.md
- changelog/entries/2026-04-09-api-client-go-0-11-40.md
- changelog/entries/2026-04-08-glean-agent-toolkit-0-5-0.md

Skipped:
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}

Errors:
- {repo: api-client-java, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}
- {repo: api-client-python, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}
- {repo: api-client-typescript, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}
- {repo: api-client-go, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}