### PR TITLE
fix: align brand CSS with glean-docs to fix font weight regression

### DIFF
--- a/packages/docusaurus-theme-glean/src/css/brand.css
+++ b/packages/docusaurus-theme-glean/src/css/brand.css
@@ -25,9 +25,36 @@
 
   /* Glean semantic colors */
   --ifm-color-success: #27ae60;
+  --ifm-color-success-dark: #229a56;
+  --ifm-color-success-darker: #1f8d4f;
+  --ifm-color-success-darkest: #1a7442;
+  --ifm-color-success-light: #3ec170;
+  --ifm-color-success-lighter: #55c97f;
+  --ifm-color-success-lightest: #82d9a0;
+
   --ifm-color-warning: #fff7be;
+  --ifm-color-warning-dark: #fff4ab;
+  --ifm-color-warning-darker: #fff298;
+  --ifm-color-warning-darkest: #ffed72;
+  --ifm-color-warning-light: #fff9d1;
+  --ifm-color-warning-lighter: #fffae4;
+  --ifm-color-warning-lightest: #fffcf7;
+
   --ifm-color-danger: #e02e2a;
+  --ifm-color-danger-dark: #ca2925;
+  --ifm-color-danger-darker: #be2622;
+  --ifm-color-danger-darkest: #9c1f1c;
+  --ifm-color-danger-light: #e64844;
+  --ifm-color-danger-lighter: #e95b57;
+  --ifm-color-danger-lightest: #ef827f;
+
   --ifm-color-info: #aab5ff;
+  --ifm-color-info-dark: #93a1ff;
+  --ifm-color-info-darker: #7c8eff;
+  --ifm-color-info-darkest: #5568ff;
+  --ifm-color-info-light: #c1c9ff;
+  --ifm-color-info-lighter: #d8ddff;
+  --ifm-color-info-lightest: #f5f6ff;
 
   /* Glean brand accent palette */
   --glean-brand-pink: #f1b7ff;
@@ -65,15 +92,15 @@
   --ifm-h5-font-size: 1rem;
   --ifm-h6-font-size: 0.9rem;
 
-  --docusaurus-highlighted-code-line-bg: rgba(216, 253, 73, 0.15);
+  --docusaurus-highlighted-code-line-bg: rgba(170, 181, 255, 0.15);
 
   /* Font family overrides */
   --ifm-font-family-base:
-    'Polysans Neutral', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
-    Cantarell, Noto Sans, sans-serif;
+    'DM Sans', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell,
+    Noto Sans, sans-serif;
   --ifm-heading-font-family:
-    'Polysans Neutral', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu,
-    Cantarell, Noto Sans, sans-serif;
+    'DM Sans', system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell,
+    Noto Sans, sans-serif;
   --ifm-font-weight-base: 400;
   --ifm-font-weight-medium: 500;
   --ifm-font-weight-semibold: 600;
@@ -101,8 +128,8 @@
   --ifm-color-content: #d1d5db;
   --ifm-heading-color: #f9fafb;
 
-  --ifm-background-color: #111827 !important;
-  --ifm-navbar-background-color: #111827;
+  --ifm-background-color: #202124 !important;
+  --ifm-navbar-background-color: #202124;
   --ifm-color-emphasis-100: #1f2937;
   --ifm-color-emphasis-200: #374151;
   --ifm-color-emphasis-300: #4b5563;
@@ -121,10 +148,43 @@
   --ifm-color-accent-lighter: #e4fd80;
   --ifm-color-accent-lightest: #edfdab;
 
-  --docusaurus-highlighted-code-line-bg: rgba(216, 253, 73, 0.3);
+  --docusaurus-highlighted-code-line-bg: rgba(205, 211, 255, 0.2);
 
   --ifm-link-color: #e5e7eb;
   --ifm-link-hover-color: #f9fafb;
+
+  /* Semantic color overrides for dark mode */
+  --ifm-color-success: #7dcea0;
+  --ifm-color-success-dark: #6bc492;
+  --ifm-color-success-darker: #59ba84;
+  --ifm-color-success-darkest: #47b076;
+  --ifm-color-success-light: #8fd8ae;
+  --ifm-color-success-lighter: #a1e2bc;
+  --ifm-color-success-lightest: #c5edd8;
+
+  --ifm-color-warning: #ffebb8;
+  --ifm-color-warning-dark: #ffe5a5;
+  --ifm-color-warning-darker: #ffdf92;
+  --ifm-color-warning-darkest: #ffd97f;
+  --ifm-color-warning-light: #fff1cb;
+  --ifm-color-warning-lighter: #fff7de;
+  --ifm-color-warning-lightest: #fffdf1;
+
+  --ifm-color-danger: #f39a9a;
+  --ifm-color-danger-dark: #f18787;
+  --ifm-color-danger-darker: #ef7474;
+  --ifm-color-danger-darkest: #ed6161;
+  --ifm-color-danger-light: #f5adad;
+  --ifm-color-danger-lighter: #f7c0c0;
+  --ifm-color-danger-lightest: #fbe6e6;
+
+  --ifm-color-info: #cdd3ff;
+  --ifm-color-info-dark: #bac1ff;
+  --ifm-color-info-darker: #a7afff;
+  --ifm-color-info-darkest: #949dff;
+  --ifm-color-info-light: #e0e5ff;
+  --ifm-color-info-lighter: #f3f7ff;
+  --ifm-color-info-lightest: #fafbff;
 }
 
 /* Common link styles for article and markdown content */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -11,15 +11,7 @@
 
 /* Import fonts */
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap');
-
-@font-face {
-  font-family: 'Polysans Neutral';
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
-  src: url('https://cdn.prod.website-files.com/6127a84dfe068e153ef20572/66b4a66d22e2c49832621144_PolySans-Neutral.woff2')
-    format('woff2');
-}
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,100..1000&display=swap');
 
 :root {
   /* MCP Tooltip Variables - Light mode: white on blue */


### PR DESCRIPTION
## Summary

- Fixes font weight regression by switching from Polysans Neutral (single-weight `@font-face` causing faux-bold) to DM Sans (variable weight, 100–1000) matching glean-docs
- Aligns shared theme `brand.css` with glean-docs as source of truth: full semantic color shade scales, dark mode background (`#202124`), and code highlight colors (info blue)
- Prepares for eventual monorepo merge — glean-docs can adopt the theme package without regression

## Test plan

- [x] `pnpm build` passes
- [x] Visual check: light mode font weights match glean-docs (headings bold, body regular)
- [x] Visual check: dark mode background color is neutral dark (`#202124`)
- [x] Visual check: admonitions render correctly with full color shade scales

🤖 Generated with [Claude Code](https://claude.com/claude-code)