### PR TITLE
fix(changelog): fix 18 broken entries and harden summarizer validation

### DIFF
--- a/changelog/entries/2026-02-09-api-client-go-0-11-24.md
+++ b/changelog/entries/2026-02-09-api-client-go-0-11-24.md
@@ -3,8 +3,7 @@ title: 'api-client-go v0.11.24'
 categories: ['API Clients']
 ---
 
-- : **Added**.
-- : **Added**
+The response.Tools field was added to Glean.Client.Agents.RetrieveSchemas(). - Added Tools field to the agent schema retrieval response
 
 {/* truncate */}
 

--- a/changelog/entries/2026-02-09-api-client-python-0-12-3.md
+++ b/changelog/entries/2026-02-09-api-client-python-0-12-3.md
@@ -3,8 +3,7 @@ title: 'api-client-python v0.12.3'
 categories: ['API Clients']
 ---
 
-- : **Added**.
-- : **Added**
+The response.tools field was added to glean.client.agents.retrieve_schemas(). - Added tools field to the agent schema retrieval response
 
 {/* truncate */}
 

--- a/changelog/entries/2026-02-10-api-client-go-0-11-25.md
+++ b/changelog/entries/2026-02-10-api-client-go-0-11-25.md
@@ -3,8 +3,7 @@ title: 'api-client-go v0.11.25'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
+The request.Feedback1.Event enum value feedbackTimeSaved was added to Glean.Client.Activity.Feedback(). - Added feedbackTimeSaved enum to activity feedback events
 
 {/* truncate */}
 

--- a/changelog/entries/2026-02-10-api-client-python-0-12-5.md
+++ b/changelog/entries/2026-02-10-api-client-python-0-12-5.md
@@ -3,8 +3,7 @@ title: 'api-client-python v0.12.5'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
+The request.feedback1.event enum value feedback_time_saved was added to glean.client.activity.feedback(). - Added feedback_time_saved enum to activity feedback events
 
 {/* truncate */}
 

--- a/changelog/entries/2026-02-18-api-client-typescript-0-14-5.md
+++ b/changelog/entries/2026-02-18-api-client-typescript-0-14-5.md
@@ -3,10 +3,7 @@ title: 'api-client-typescript v0.14.5'
 categories: ['API Clients']
 ---
 
-- : - **Changed**.
-- : - **Changed**
-- **Changed** (Breaking ⚠️)
-- : **Changed** (Breaking ⚠️)
+Breaking changes to response types in glean.client.chat.create() and glean.client.chat.retrieve(); changed messageType on chat messages in glean.client.chat.createStream(). - Added unauthorizedDatasourceInstances to response and error types in glean.client.search.query(), glean.client.search.queryAsAdmin(), glean.client.search.autocomplete(), glean.client.search.recommendations(), and glean.client.messages.retrieve()
 
 {/* truncate */}
 

--- a/changelog/entries/2026-02-20-api-client-python-0-12-8.md
+++ b/changelog/entries/2026-02-20-api-client-python-0-12-8.md
@@ -3,8 +3,7 @@ title: 'api-client-python v0.12.8'
 categories: ['API Clients']
 ---
 
-- : **Changed**.
-- : **Changed**
+The response.unauthorized_datasource_instances field was changed in glean.authentication.checkdatasourceauth(). - Review usage of this endpoint for compatibility with the updated response field
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-09-api-client-python-0-12-9.md
+++ b/changelog/entries/2026-03-09-api-client-python-0-12-9.md
@@ -3,10 +3,7 @@ title: 'api-client-python v0.12.9'
 categories: ['API Clients']
 ---
 
-- : - **Changed**.
-- : - **Changed**
-- **Changed** (Breaking ⚠️)
-- : - **Changed**
+Breaking changes to response types in glean.client.chat.create(), glean.client.search.query(), glean.client.search.recommendations(), glean.client.search.autocomplete(), glean.client.search.query_as_admin(), and glean.client.messages.retrieve(). - Added glean.datasources.get_datasource_instance_configuration() and glean.datasources.update_datasource_instance_configuration() - Added 404 error type to glean.client.agents.retrieve() - Changed snippet structures across search, chat, collections, and entity endpoints - Deprecated glean.indexing.people.bulk_index()
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-11-api-client-go-0-11-30.md
+++ b/changelog/entries/2026-03-11-api-client-go-0-11-30.md
@@ -3,10 +3,7 @@ title: 'api-client-go v0.11.30'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Added**
-- : **Added**
+Added TokenEndpointAuthMethod to action metadata auth fields in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added Name field to the Glean.Client.Agents.RetrieveSchemas() response
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-11-api-client-java-0-12-25.md
+++ b/changelog/entries/2026-03-11-api-client-java-0-12-25.md
@@ -3,10 +3,7 @@ title: 'api-client-java v0.12.25'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Added**
-- : **Added**
+Added tokenEndpointAuthMethod to action metadata auth fields in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added name field to the glean.client.agents.retrieveSchemas() response
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-16-api-client-java-0-12-26.md
+++ b/changelog/entries/2026-03-16-api-client-java-0-12-26.md
@@ -3,10 +3,7 @@ title: 'api-client-java v0.12.26'
 categories: ['API Clients']
 ---
 
-- : **Added**.
-- : **Added**
-- : - **Changed**
-- **Changed**
+The response.chat field was added to glean.client.chat.create() and request.feedRequest.categories and response.results were changed in glean.client.search.retrieveFeed(). - Added chat field to chat create response - Changed feed request categories and response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-16-api-client-python-0-12-11.md
+++ b/changelog/entries/2026-03-16-api-client-python-0-12-11.md
@@ -3,10 +3,7 @@ title: 'api-client-python v0.12.11'
 categories: ['API Clients']
 ---
 
-- : **Added**.
-- : **Added**
-- : - **Changed**
-- **Changed**
+The response.chat field was added to glean.client.chat.create() and request.categories and response.results were changed in glean.client.search.retrieve_feed(). - Added chat field to chat create response - Changed feed request categories and response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-go-0-11-35.md
+++ b/changelog/entries/2026-03-23-api-client-go-0-11-35.md
@@ -3,10 +3,7 @@ title: 'api-client-go v0.11.35'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Added**
-- : **Added**
+Added SourceCustomEntity to message citations in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added issues enum to Glean.Governance.Createfindingsexport() export type - Changed response.OverviewResponse in Glean.Client.Insights.Retrieve()
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-go-0-11-36.md
+++ b/changelog/entries/2026-03-23-api-client-go-0-11-36.md
@@ -3,9 +3,7 @@ title: 'api-client-go v0.11.36'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Changed**
+The request.FeedRequest.Categories enum value weeklyMeetings was added and response.Results was changed in Glean.Client.Search.RetrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-java-0-12-31.md
+++ b/changelog/entries/2026-03-23-api-client-java-0-12-31.md
@@ -3,9 +3,7 @@ title: 'api-client-java v0.12.31'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Changed**
+The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-python-0-12-16.md
+++ b/changelog/entries/2026-03-23-api-client-python-0-12-16.md
@@ -3,9 +3,7 @@ title: 'api-client-python v0.12.16'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Changed**
+The request.categories enum value weekly_meetings was added and response.results was changed in glean.client.search.retrieve_feed(). - Added weekly_meetings category enum - Changed feed response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-typescript-0-14-11.md
+++ b/changelog/entries/2026-03-23-api-client-typescript-0-14-11.md
@@ -3,10 +3,7 @@ title: 'api-client-typescript v0.14.11'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Added**
-- : **Added**
+Added sourceCustomEntity to message citations in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added issues enum to glean.governance.createfindingsexport() export type - Changed response.overviewResponse in glean.client.insights.retrieve()
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-23-api-client-typescript-0-14-12.md
+++ b/changelog/entries/2026-03-23-api-client-typescript-0-14-12.md
@@ -3,9 +3,7 @@ title: 'api-client-typescript v0.14.12'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Changed**
+The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results
 
 {/* truncate */}
 

--- a/changelog/entries/2026-03-27-api-client-typescript-0-14-14.md
+++ b/changelog/entries/2026-03-27-api-client-typescript-0-14-14.md
@@ -3,10 +3,7 @@ title: 'api-client-typescript v0.14.14'
 categories: ['API Clients']
 ---
 
-- : - **Added**.
-- : - **Added**
-- **Added**
-- : **Added**
+Added partiallyProcessed status enum to chat file metadata in glean.client.chat.create(), glean.client.chat.retrieve(), glean.client.chat.createStream(), glean.client.chat.uploadFiles(), and glean.client.chat.retrieveFiles(). - Added nativeAppUrl field to document indexing requests in glean.indexing.documents.addOrUpdate(), glean.indexing.documents.index(), and glean.indexing.documents.bulkIndex()
 
 {/* truncate */}
 

--- a/packages/changelog-generator/src/summarizer.ts
+++ b/packages/changelog-generator/src/summarizer.ts
@@ -61,6 +61,14 @@ function normalizeText(text: string): string {
   return t.trim();
 }
 
+function isGarbageBullet(text: string): boolean {
+  if (/^[:\s\-*]*\*\*\w+\*\*[.\s]*$/.test(text)) return true;
+  if (/^:\s*-?\s*\*\*/.test(text)) return true;
+  const alphaOnly = text.replace(/[^a-zA-Z]/g, '');
+  if (alphaOnly.length < 10) return true;
+  return false;
+}
+
 function heuristicSummarize(
   text: string,
   opts: { maxChars: number; maxBullets: number },
@@ -79,7 +87,9 @@ function heuristicSummarize(
     }
   }
   if (!intro && lines.length > 0) intro = lines[0];
-  if (!intro) intro = 'Maintenance updates and improvements.';
+  if (!intro || isGarbageBullet(intro)) {
+    intro = 'Maintenance updates and improvements.';
+  }
   if (!/[.!?]$/.test(intro)) intro += '.';
   if (intro.length > opts.maxChars) {
     intro =
@@ -95,7 +105,7 @@ function heuristicSummarize(
     for (const l of lines) {
       if (l.startsWith('- ')) {
         const b = l.slice(2).trim();
-        if (b && /[a-zA-Z]/.test(b)) bullets.push(b);
+        if (b && /[a-zA-Z]/.test(b) && !isGarbageBullet(b)) bullets.push(b);
       }
       if (bullets.length >= maxBullets) break;
     }
@@ -104,7 +114,9 @@ function heuristicSummarize(
       const sentences = cleaned
         .split(/[.!?]\s+/)
         .map((s) => s.trim())
-        .filter((s) => s.length > 20 && /[a-zA-Z]/.test(s));
+        .filter(
+          (s) => s.length > 20 && /[a-zA-Z]/.test(s) && !isGarbageBullet(s),
+        );
       for (const s of sentences.slice(0, maxBullets)) bullets.push(s + '.');
     }
   }
@@ -124,6 +136,7 @@ function hasPlaceholderText(text: string): boolean {
     /\s+\.\s+/,
     /\bthe\s+field\s+is\s+now\s+included\s+in\s+within/,
     /\bresponse\s+type\s+for\s+has\s+changed/,
+    /^-\s*:\s*-?\s*\*\*/m,
   ];
 
   return placeholderPatterns.some((pattern) => pattern.test(text));
@@ -138,10 +151,9 @@ async function summarizeWithGlean(
   const instance = process.env.GLEAN_INSTANCE;
 
   if (!apiToken || (!serverURL && !instance)) {
-    dbgSum(
-      'summarize:skipping LLM (missing GLEAN_API_TOKEN or GLEAN_SERVER_URL)',
+    throw new Error(
+      'LLM summarization requires GLEAN_API_TOKEN and either GLEAN_SERVER_URL or GLEAN_INSTANCE to be set.',
     );
-    return null;
   }
 
   try {
@@ -237,9 +249,9 @@ async function summarizeWithGlean(
           .slice(0, opts.maxChars)
           .replace(/\s+\S*$/, '')
           .trim() + '...';
-  } catch (err) {
-    dbgSum('summarize:error %o', err);
-    return null;
+  } catch (err: any) {
+    const message = err?.message || String(err);
+    throw new Error(`Glean API chat request failed: ${message}`);
   }
 }
 
@@ -261,10 +273,19 @@ export async function summarizeRelease(
       hints: opts.hints,
     });
     if (llm) return llm;
+
+    throw new Error(
+      'LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. ' +
+        'Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.',
+    );
   }
-  dbgSum('summarize:fallback heuristic');
-  return heuristicSummarize(text, {
-    maxChars: opts.maxChars,
-    maxBullets: opts.maxBullets,
-  });
+
+  if (opts.mode === 'heuristic') {
+    return heuristicSummarize(text, {
+      maxChars: opts.maxChars,
+      maxBullets: opts.maxBullets,
+    });
+  }
+
+  return 'Maintenance updates and improvements.';
 }

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -8,8 +8,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14</a></p>\n",
+      "summary": "<p>Added partiallyProcessed status enum to chat file metadata in glean.client.chat.create(), glean.client.chat.retrieve(), glean.client.chat.createStream(), glean.client.chat.uploadFiles(), and glean.client.chat.retrieveFiles(). - Added nativeAppUrl field to document indexing requests in glean.indexing.documents.addOrUpdate(), glean.indexing.documents.index(), and glean.indexing.documents.bulkIndex()</p>\n",
+      "fullContent": "<p>Added partiallyProcessed status enum to chat file metadata in glean.client.chat.create(), glean.client.chat.retrieve(), glean.client.chat.createStream(), glean.client.chat.uploadFiles(), and glean.client.chat.retrieveFiles(). - Added nativeAppUrl field to document indexing requests in glean.indexing.documents.addOrUpdate(), glean.indexing.documents.index(), and glean.indexing.documents.bulkIndex()</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-27-api-client-typescript-0-14-14.md"
     },
@@ -112,8 +112,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12</a></p>\n",
+      "summary": "<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n",
+      "fullContent": "<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-typescript-0-14-12.md"
     },
@@ -125,8 +125,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11</a></p>\n",
+      "summary": "<p>Added sourceCustomEntity to message citations in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added issues enum to glean.governance.createfindingsexport() export type - Changed response.overviewResponse in glean.client.insights.retrieve()</p>\n",
+      "fullContent": "<p>Added sourceCustomEntity to message citations in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added issues enum to glean.governance.createfindingsexport() export type - Changed response.overviewResponse in glean.client.insights.retrieve()</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-typescript-0-14-11.md"
     },
@@ -138,8 +138,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16</a></p>\n",
+      "summary": "<p>The request.categories enum value weekly_meetings was added and response.results was changed in glean.client.search.retrieve_feed(). - Added weekly_meetings category enum - Changed feed response results</p>\n",
+      "fullContent": "<p>The request.categories enum value weekly_meetings was added and response.results was changed in glean.client.search.retrieve_feed(). - Added weekly_meetings category enum - Changed feed response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-python-0-12-16.md"
     },
@@ -164,8 +164,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31</a></p>\n",
+      "summary": "<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n",
+      "fullContent": "<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-java-0-12-31.md"
     },
@@ -190,8 +190,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36</a></p>\n",
+      "summary": "<p>The request.FeedRequest.Categories enum value weeklyMeetings was added and response.Results was changed in Glean.Client.Search.RetrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n",
+      "fullContent": "<p>The request.FeedRequest.Categories enum value weeklyMeetings was added and response.Results was changed in Glean.Client.Search.RetrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-go-0-11-36.md"
     },
@@ -203,8 +203,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35</a></p>\n",
+      "summary": "<p>Added SourceCustomEntity to message citations in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added issues enum to Glean.Governance.Createfindingsexport() export type - Changed response.OverviewResponse in Glean.Client.Insights.Retrieve()</p>\n",
+      "fullContent": "<p>Added SourceCustomEntity to message citations in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added issues enum to Glean.Governance.Createfindingsexport() export type - Changed response.OverviewResponse in Glean.Client.Insights.Retrieve()</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-23-api-client-go-0-11-35.md"
     },
@@ -372,8 +372,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11</a></p>\n",
+      "summary": "<p>The response.chat field was added to glean.client.chat.create() and request.categories and response.results were changed in glean.client.search.retrieve_feed(). - Added chat field to chat create response - Changed feed request categories and response results</p>\n",
+      "fullContent": "<p>The response.chat field was added to glean.client.chat.create() and request.categories and response.results were changed in glean.client.search.retrieve_feed(). - Added chat field to chat create response - Changed feed request categories and response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-16-api-client-python-0-12-11.md"
     },
@@ -385,8 +385,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26</a></p>\n",
+      "summary": "<p>The response.chat field was added to glean.client.chat.create() and request.feedRequest.categories and response.results were changed in glean.client.search.retrieveFeed(). - Added chat field to chat create response - Changed feed request categories and response results</p>\n",
+      "fullContent": "<p>The response.chat field was added to glean.client.chat.create() and request.feedRequest.categories and response.results were changed in glean.client.search.retrieveFeed(). - Added chat field to chat create response - Changed feed request categories and response results</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-16-api-client-java-0-12-26.md"
     },
@@ -424,8 +424,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25</a></p>\n",
+      "summary": "<p>Added tokenEndpointAuthMethod to action metadata auth fields in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added name field to the glean.client.agents.retrieveSchemas() response</p>\n",
+      "fullContent": "<p>Added tokenEndpointAuthMethod to action metadata auth fields in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added name field to the glean.client.agents.retrieveSchemas() response</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25\">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-11-api-client-java-0-12-25.md"
     },
@@ -437,8 +437,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n<li><strong>Added</strong></li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30</a></p>\n",
+      "summary": "<p>Added TokenEndpointAuthMethod to action metadata auth fields in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added Name field to the Glean.Client.Agents.RetrieveSchemas() response</p>\n",
+      "fullContent": "<p>Added TokenEndpointAuthMethod to action metadata auth fields in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added Name field to the Glean.Client.Agents.RetrieveSchemas() response</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-11-api-client-go-0-11-30.md"
     },
@@ -450,8 +450,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Changed</strong>.</li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong> (Breaking ⚠️)</li>\n<li>: - <strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Changed</strong>.</li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong> (Breaking ⚠️)</li>\n<li>: - <strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9</a></p>\n",
+      "summary": "<p>Breaking changes to response types in glean.client.chat.create(), glean.client.search.query(), glean.client.search.recommendations(), glean.client.search.autocomplete(), glean.client.search.query_as_admin(), and glean.client.messages.retrieve(). - Added glean.datasources.get_datasource_instance_configuration() and glean.datasources.update_datasource_instance_configuration() - Added 404 error type to glean.client.agents.retrieve() - Changed snippet structures across search, chat, collections, and entity endpoints - Deprecated glean.indexing.people.bulk_index()</p>\n",
+      "fullContent": "<p>Breaking changes to response types in glean.client.chat.create(), glean.client.search.query(), glean.client.search.recommendations(), glean.client.search.autocomplete(), glean.client.search.query_as_admin(), and glean.client.messages.retrieve(). - Added glean.datasources.get_datasource_instance_configuration() and glean.datasources.update_datasource_instance_configuration() - Added 404 error type to glean.client.agents.retrieve() - Changed snippet structures across search, chat, collections, and entity endpoints - Deprecated glean.indexing.people.bulk_index()</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-03-09-api-client-python-0-12-9.md"
     },
@@ -619,8 +619,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: <strong>Changed</strong>.</li>\n<li>: <strong>Changed</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: <strong>Changed</strong>.</li>\n<li>: <strong>Changed</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8</a></p>\n",
+      "summary": "<p>The response.unauthorized_datasource_instances field was changed in glean.authentication.checkdatasourceauth(). - Review usage of this endpoint for compatibility with the updated response field</p>\n",
+      "fullContent": "<p>The response.unauthorized_datasource_instances field was changed in glean.authentication.checkdatasourceauth(). - Review usage of this endpoint for compatibility with the updated response field</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-20-api-client-python-0-12-8.md"
     },
@@ -723,8 +723,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Changed</strong>.</li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong> (Breaking ⚠️)</li>\n<li>: <strong>Changed</strong> (Breaking ⚠️)</li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Changed</strong>.</li>\n<li>: - <strong>Changed</strong></li>\n<li><strong>Changed</strong> (Breaking ⚠️)</li>\n<li>: <strong>Changed</strong> (Breaking ⚠️)</li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5</a></p>\n",
+      "summary": "<p>Breaking changes to response types in glean.client.chat.create() and glean.client.chat.retrieve(); changed messageType on chat messages in glean.client.chat.createStream(). - Added unauthorizedDatasourceInstances to response and error types in glean.client.search.query(), glean.client.search.queryAsAdmin(), glean.client.search.autocomplete(), glean.client.search.recommendations(), and glean.client.messages.retrieve()</p>\n",
+      "fullContent": "<p>Breaking changes to response types in glean.client.chat.create() and glean.client.chat.retrieve(); changed messageType on chat messages in glean.client.chat.createStream(). - Added unauthorizedDatasourceInstances to response and error types in glean.client.search.query(), glean.client.search.queryAsAdmin(), glean.client.search.autocomplete(), glean.client.search.recommendations(), and glean.client.messages.retrieve()</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5\">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-18-api-client-typescript-0-14-5.md"
     },
@@ -788,8 +788,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5</a></p>\n",
+      "summary": "<p>The request.feedback1.event enum value feedback_time_saved was added to glean.client.activity.feedback(). - Added feedback_time_saved enum to activity feedback events</p>\n",
+      "fullContent": "<p>The request.feedback1.event enum value feedback_time_saved was added to glean.client.activity.feedback(). - Added feedback_time_saved enum to activity feedback events</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-10-api-client-python-0-12-5.md"
     },
@@ -814,8 +814,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: - <strong>Added</strong>.</li>\n<li>: - <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25</a></p>\n",
+      "summary": "<p>The request.Feedback1.Event enum value feedbackTimeSaved was added to Glean.Client.Activity.Feedback(). - Added feedbackTimeSaved enum to activity feedback events</p>\n",
+      "fullContent": "<p>The request.Feedback1.Event enum value feedbackTimeSaved was added to Glean.Client.Activity.Feedback(). - Added feedbackTimeSaved enum to activity feedback events</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-10-api-client-go-0-11-25.md"
     },
@@ -853,8 +853,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3</a></p>\n",
+      "summary": "<p>The response.tools field was added to glean.client.agents.retrieve_schemas(). - Added tools field to the agent schema retrieval response</p>\n",
+      "fullContent": "<p>The response.tools field was added to glean.client.agents.retrieve_schemas(). - Added tools field to the agent schema retrieval response</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3\">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-09-api-client-python-0-12-3.md"
     },
@@ -879,8 +879,8 @@
       "categories": [
         "API Clients"
       ],
-      "summary": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n</ul>\n",
-      "fullContent": "<ul>\n<li>: <strong>Added</strong>.</li>\n<li>: <strong>Added</strong></li>\n</ul>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24</a></p>\n",
+      "summary": "<p>The response.Tools field was added to Glean.Client.Agents.RetrieveSchemas(). - Added Tools field to the agent schema retrieval response</p>\n",
+      "fullContent": "<p>The response.Tools field was added to Glean.Client.Agents.RetrieveSchemas(). - Added Tools field to the agent schema retrieval response</p>\n<p>Full release notes: <a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24\">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24</a></p>\n",
       "hasTruncation": true,
       "fileName": "2026-02-09-api-client-go-0-11-24.md"
     },

--- a/static/changelog.xml
+++ b/static/changelog.xml
@@ -19,19 +19,9 @@
             <link>https://developers.glean.com/changelog#api-client-typescript-0-14-14</link>
             <guid isPermaLink="false">2026-03-27-api-client-typescript-0-14-14</guid>
             <pubDate>Fri, 27 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>Added partiallyProcessed status enum to chat file metadata in glean.client.chat.create(), glean.client.chat.retrieve(), glean.client.chat.createStream(), glean.client.chat.uploadFiles(), and glean.client.chat.retrieveFiles(). - Added nativeAppUrl field to document indexing requests in glean.indexing.documents.addOrUpdate(), glean.indexing.documents.index(), and glean.indexing.documents.bulkIndex()</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Added partiallyProcessed status enum to chat file metadata in glean.client.chat.create(), glean.client.chat.retrieve(), glean.client.chat.createStream(), glean.client.chat.uploadFiles(), and glean.client.chat.retrieveFiles(). - Added nativeAppUrl field to document indexing requests in glean.indexing.documents.addOrUpdate(), glean.indexing.documents.index(), and glean.indexing.documents.bulkIndex()</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.14</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -133,17 +123,9 @@
             <link>https://developers.glean.com/changelog#api-client-typescript-0-14-12</link>
             <guid isPermaLink="false">2026-03-23-api-client-typescript-0-14-12</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.12</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -154,19 +136,9 @@
             <link>https://developers.glean.com/changelog#api-client-typescript-0-14-11</link>
             <guid isPermaLink="false">2026-03-23-api-client-typescript-0-14-11</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>Added sourceCustomEntity to message citations in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added issues enum to glean.governance.createfindingsexport() export type - Changed response.overviewResponse in glean.client.insights.retrieve()</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Added sourceCustomEntity to message citations in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added issues enum to glean.governance.createfindingsexport() export type - Changed response.overviewResponse in glean.client.insights.retrieve()</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.11</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -177,17 +149,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-16</link>
             <guid isPermaLink="false">2026-03-23-api-client-python-0-12-16</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.categories enum value weekly_meetings was added and response.results was changed in glean.client.search.retrieve_feed(). - Added weekly_meetings category enum - Changed feed response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.categories enum value weekly_meetings was added and response.results was changed in glean.client.search.retrieve_feed(). - Added weekly_meetings category enum - Changed feed response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.16</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -211,17 +175,9 @@
             <link>https://developers.glean.com/changelog#api-client-java-0-12-31</link>
             <guid isPermaLink="false">2026-03-23-api-client-java-0-12-31</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.feedRequest.categories enum value weeklyMeetings was added and response.results was changed in glean.client.search.retrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.31</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -245,17 +201,9 @@
             <link>https://developers.glean.com/changelog#api-client-go-0-11-36</link>
             <guid isPermaLink="false">2026-03-23-api-client-go-0-11-36</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.FeedRequest.Categories enum value weeklyMeetings was added and response.Results was changed in Glean.Client.Search.RetrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.FeedRequest.Categories enum value weeklyMeetings was added and response.Results was changed in Glean.Client.Search.RetrieveFeed(). - Added weeklyMeetings category enum - Changed feed response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.36</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -266,19 +214,9 @@
             <link>https://developers.glean.com/changelog#api-client-go-0-11-35</link>
             <guid isPermaLink="false">2026-03-23-api-client-go-0-11-35</guid>
             <pubDate>Mon, 23 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>Added SourceCustomEntity to message citations in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added issues enum to Glean.Governance.Createfindingsexport() export type - Changed response.OverviewResponse in Glean.Client.Insights.Retrieve()</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Added SourceCustomEntity to message citations in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added issues enum to Glean.Governance.Createfindingsexport() export type - Changed response.OverviewResponse in Glean.Client.Insights.Retrieve()</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.35</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -445,19 +383,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-11</link>
             <guid isPermaLink="false">2026-03-16-api-client-python-0-12-11</guid>
             <pubDate>Mon, 16 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The response.chat field was added to glean.client.chat.create() and request.categories and response.results were changed in glean.client.search.retrieve_feed(). - Added chat field to chat create response - Changed feed request categories and response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The response.chat field was added to glean.client.chat.create() and request.categories and response.results were changed in glean.client.search.retrieve_feed(). - Added chat field to chat create response - Changed feed request categories and response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.11</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -468,19 +396,9 @@
             <link>https://developers.glean.com/changelog#api-client-java-0-12-26</link>
             <guid isPermaLink="false">2026-03-16-api-client-java-0-12-26</guid>
             <pubDate>Mon, 16 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The response.chat field was added to glean.client.chat.create() and request.feedRequest.categories and response.results were changed in glean.client.search.retrieveFeed(). - Added chat field to chat create response - Changed feed request categories and response results</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The response.chat field was added to glean.client.chat.create() and request.feedRequest.categories and response.results were changed in glean.client.search.retrieveFeed(). - Added chat field to chat create response - Changed feed request categories and response results</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.26</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -517,19 +435,9 @@
             <link>https://developers.glean.com/changelog#api-client-java-0-12-25</link>
             <guid isPermaLink="false">2026-03-11-api-client-java-0-12-25</guid>
             <pubDate>Wed, 11 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>Added tokenEndpointAuthMethod to action metadata auth fields in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added name field to the glean.client.agents.retrieveSchemas() response</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Added tokenEndpointAuthMethod to action metadata auth fields in glean.client.chat.create(), glean.client.chat.retrieve(), and glean.client.chat.createStream(). - Added name field to the glean.client.agents.retrieveSchemas() response</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25">https://github.com/gleanwork/api-client-java/releases/tag/v0.12.25</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -540,19 +448,9 @@
             <link>https://developers.glean.com/changelog#api-client-go-0-11-30</link>
             <guid isPermaLink="false">2026-03-11-api-client-go-0-11-30</guid>
             <pubDate>Wed, 11 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>Added TokenEndpointAuthMethod to action metadata auth fields in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added Name field to the Glean.Client.Agents.RetrieveSchemas() response</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-<li><strong>Added</strong></li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Added TokenEndpointAuthMethod to action metadata auth fields in Glean.Client.Chat.Create(), Glean.Client.Chat.Retrieve(), and Glean.Client.Chat.CreateStream(). - Added Name field to the Glean.Client.Agents.RetrieveSchemas() response</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.30</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -563,19 +461,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-9</link>
             <guid isPermaLink="false">2026-03-09-api-client-python-0-12-9</guid>
             <pubDate>Mon, 09 Mar 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Changed</strong>.</li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong> (Breaking ⚠️)</li>
-<li>: - <strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>Breaking changes to response types in glean.client.chat.create(), glean.client.search.query(), glean.client.search.recommendations(), glean.client.search.autocomplete(), glean.client.search.query_as_admin(), and glean.client.messages.retrieve(). - Added glean.datasources.get_datasource_instance_configuration() and glean.datasources.update_datasource_instance_configuration() - Added 404 error type to glean.client.agents.retrieve() - Changed snippet structures across search, chat, collections, and entity endpoints - Deprecated glean.indexing.people.bulk_index()</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Changed</strong>.</li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong> (Breaking ⚠️)</li>
-<li>: - <strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>Breaking changes to response types in glean.client.chat.create(), glean.client.search.query(), glean.client.search.recommendations(), glean.client.search.autocomplete(), glean.client.search.query_as_admin(), and glean.client.messages.retrieve(). - Added glean.datasources.get_datasource_instance_configuration() and glean.datasources.update_datasource_instance_configuration() - Added 404 error type to glean.client.agents.retrieve() - Changed snippet structures across search, chat, collections, and entity endpoints - Deprecated glean.indexing.people.bulk_index()</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.9</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -742,15 +630,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-8</link>
             <guid isPermaLink="false">2026-02-20-api-client-python-0-12-8</guid>
             <pubDate>Fri, 20 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: <strong>Changed</strong>.</li>
-<li>: <strong>Changed</strong></li>
-</ul>
+            <description><![CDATA[<p>The response.unauthorized_datasource_instances field was changed in glean.authentication.checkdatasourceauth(). - Review usage of this endpoint for compatibility with the updated response field</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: <strong>Changed</strong>.</li>
-<li>: <strong>Changed</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The response.unauthorized_datasource_instances field was changed in glean.authentication.checkdatasourceauth(). - Review usage of this endpoint for compatibility with the updated response field</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.8</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -852,19 +734,9 @@
             <link>https://developers.glean.com/changelog#api-client-typescript-0-14-5</link>
             <guid isPermaLink="false">2026-02-18-api-client-typescript-0-14-5</guid>
             <pubDate>Wed, 18 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Changed</strong>.</li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong> (Breaking ⚠️)</li>
-<li>: <strong>Changed</strong> (Breaking ⚠️)</li>
-</ul>
+            <description><![CDATA[<p>Breaking changes to response types in glean.client.chat.create() and glean.client.chat.retrieve(); changed messageType on chat messages in glean.client.chat.createStream(). - Added unauthorizedDatasourceInstances to response and error types in glean.client.search.query(), glean.client.search.queryAsAdmin(), glean.client.search.autocomplete(), glean.client.search.recommendations(), and glean.client.messages.retrieve()</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Changed</strong>.</li>
-<li>: - <strong>Changed</strong></li>
-<li><strong>Changed</strong> (Breaking ⚠️)</li>
-<li>: <strong>Changed</strong> (Breaking ⚠️)</li>
-</ul>
+            <content:encoded><![CDATA[<p>Breaking changes to response types in glean.client.chat.create() and glean.client.chat.retrieve(); changed messageType on chat messages in glean.client.chat.createStream(). - Added unauthorizedDatasourceInstances to response and error types in glean.client.search.query(), glean.client.search.queryAsAdmin(), glean.client.search.autocomplete(), glean.client.search.recommendations(), and glean.client.messages.retrieve()</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5">https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.5</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -927,15 +799,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-5</link>
             <guid isPermaLink="false">2026-02-10-api-client-python-0-12-5</guid>
             <pubDate>Tue, 10 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.feedback1.event enum value feedback_time_saved was added to glean.client.activity.feedback(). - Added feedback_time_saved enum to activity feedback events</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.feedback1.event enum value feedback_time_saved was added to glean.client.activity.feedback(). - Added feedback_time_saved enum to activity feedback events</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.5</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -959,15 +825,9 @@
             <link>https://developers.glean.com/changelog#api-client-go-0-11-25</link>
             <guid isPermaLink="false">2026-02-10-api-client-go-0-11-25</guid>
             <pubDate>Tue, 10 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>The request.Feedback1.Event enum value feedbackTimeSaved was added to Glean.Client.Activity.Feedback(). - Added feedbackTimeSaved enum to activity feedback events</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: - <strong>Added</strong>.</li>
-<li>: - <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The request.Feedback1.Event enum value feedbackTimeSaved was added to Glean.Client.Activity.Feedback(). - Added feedbackTimeSaved enum to activity feedback events</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.25</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -1004,15 +864,9 @@
             <link>https://developers.glean.com/changelog#api-client-python-0-12-3</link>
             <guid isPermaLink="false">2026-02-09-api-client-python-0-12-3</guid>
             <pubDate>Mon, 09 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>The response.tools field was added to glean.client.agents.retrieve_schemas(). - Added tools field to the agent schema retrieval response</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The response.tools field was added to glean.client.agents.retrieve_schemas(). - Added tools field to the agent schema retrieval response</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3">https://github.com/gleanwork/api-client-python/releases/tag/v0.12.3</a></p>
 ]]></content:encoded>
             <author>Glean</author>
@@ -1036,15 +890,9 @@
             <link>https://developers.glean.com/changelog#api-client-go-0-11-24</link>
             <guid isPermaLink="false">2026-02-09-api-client-go-0-11-24</guid>
             <pubDate>Mon, 09 Feb 2026 00:00:00 GMT</pubDate>
-            <description><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <description><![CDATA[<p>The response.Tools field was added to Glean.Client.Agents.RetrieveSchemas(). - Added Tools field to the agent schema retrieval response</p>
 ]]></description>
-            <content:encoded><![CDATA[<ul>
-<li>: <strong>Added</strong>.</li>
-<li>: <strong>Added</strong></li>
-</ul>
+            <content:encoded><![CDATA[<p>The response.Tools field was added to Glean.Client.Agents.RetrieveSchemas(). - Added Tools field to the agent schema retrieval response</p>
 <p>Full release notes: <a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24">https://github.com/gleanwork/api-client-go/releases/tag/v0.11.24</a></p>
 ]]></content:encoded>
             <author>Glean</author>


### PR DESCRIPTION
## Summary

- Fixes 18 changelog entries that contained garbage content (`- : - **Added**`) by rewriting them with accurate summaries extracted from the actual GitHub release notes
- Hardens the changelog summarizer to prevent this from happening again: adds `isGarbageBullet()` filter, extends `hasPlaceholderText()` to catch the broken pattern, and makes LLM mode throw on failure instead of silently producing garbage
- Root cause: the Glean Chat API LLM was echoing Speakeasy-structured release notes (method.path `**Added**`) back in mangled form, and `hasPlaceholderText()` didn't have a pattern to catch it

## Root cause investigation

Three independent agents confirmed:
- **CI timing analysis**: LLM was called in both broken (Feb 10) and working (Apr 13) runs (4-23s gaps per entry)
- **Code trace**: The heuristic path *cannot* produce `- : - **Added**` — only the LLM can
- **Git history**: `hasPlaceholderText()` existed but lacked the pattern to catch this specific garbage

## Test plan

- [x] `grep -rl "^- : " changelog/entries/` returns no results (all 18 fixed)
- [x] `pnpm build` passes (27/27 tasks successful)
- [x] Spot-checked fixed entries have meaningful content matching GitHub release notes
- [x] `summarizeWithGlean()` throws on missing credentials (tested locally)
- [x] `summarizeRelease()` throws when LLM mode returns null

🤖 Generated with [Claude Code](https://claude.com/claude-code)