### PR TITLE
chore(changelog): 2026-04-22

### DIFF
--- a/changelog/entries/2026-04-15-api-client-go-0-11-42.md
+++ b/changelog/entries/2026-04-15-api-client-go-0-11-42.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.42'
+categories: ['API Clients']
+---
+
+3 fields changed, 2 fields added across activity feedback, insights retrieve, governance createfindingsexport, governance listfindingsexports endpoints. - changed Issues in activity feedback - added FeedbackUserCount in insights retrieve - added IssueFilter in governance createfindingsexport
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.42

--- a/changelog/entries/2026-04-15-api-client-java-0-12-37.md
+++ b/changelog/entries/2026-04-15-api-client-java-0-12-37.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.37'
+categories: ['API Clients']
+---
+
+2 fields added, 2 fields changed across insights retrieve, governance createfindingsexport, governance listfindingsexports endpoints. - added feedbackUserCount in insights retrieve - added issueFilter in governance createfindingsexport - changed response in governance createfindingsexport
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.37

--- a/changelog/entries/2026-04-15-api-client-python-0-12-22.md
+++ b/changelog/entries/2026-04-15-api-client-python-0-12-22.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.22'
+categories: ['API Clients']
+---
+
+2 fields added, 2 fields changed across insights retrieve, governance createfindingsexport, governance listfindingsexports endpoints. - added feedback_user_count in insights retrieve - added issue_filter in governance createfindingsexport - changed response in governance createfindingsexport
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.22

--- a/changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
+++ b/changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.18'
+categories: ['API Clients']
+---
+
+3 fields changed, 2 fields added across activity feedback, insights retrieve, governance createfindingsexport, governance listfindingsexports endpoints. - changed issues in activity feedback - added feedbackUserCount in insights retrieve - added issueFilter in governance createfindingsexport
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.18

--- a/changelog/entries/2026-04-20-api-client-go-0-11-43.md
+++ b/changelog/entries/2026-04-20-api-client-go-0-11-43.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.43'
+categories: ['API Clients']
+---
+
+Released api-client-go v0.11.43 generated from updated OpenAPI spec using Speakeasy CLI.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.43

--- a/changelog/entries/2026-04-20-api-client-java-0-12-38.md
+++ b/changelog/entries/2026-04-20-api-client-java-0-12-38.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.38'
+categories: ['API Clients']
+---
+
+Released api-client-java v0.12.38 generated from updated OpenAPI spec using Speakeasy CLI.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.38

--- a/changelog/entries/2026-04-20-api-client-python-0-12-24.md
+++ b/changelog/entries/2026-04-20-api-client-python-0-12-24.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.24'
+categories: ['API Clients']
+---
+
+Released api-client-python v0.12.24 generated from updated OpenAPI spec using Speakeasy CLI.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.24

--- a/changelog/entries/2026-04-20-api-client-typescript-0-14-19.md
+++ b/changelog/entries/2026-04-20-api-client-typescript-0-14-19.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.19'
+categories: ['API Clients']
+---
+
+Released api-client-typescript v0.14.19 generated from updated OpenAPI spec using Speakeasy CLI.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.19


### PR DESCRIPTION
Adds 8 changelog entries generated on 2026-04-22.

Files:
- changelog/entries/2026-04-20-api-client-java-0-12-38.md
- changelog/entries/2026-04-15-api-client-java-0-12-37.md
- changelog/entries/2026-04-20-api-client-python-0-12-24.md
- changelog/entries/2026-04-15-api-client-python-0-12-22.md
- changelog/entries/2026-04-20-api-client-typescript-0-14-19.md
- changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
- changelog/entries/2026-04-20-api-client-go-0-11-43.md
- changelog/entries/2026-04-15-api-client-go-0-11-42.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: glean-indexing-sdk, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: open-api, decision: skip, reason: no new open-api commits}