### PR TITLE
fix: update broken anchor links to authentication page

### DIFF
--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -114,7 +114,7 @@ X-Glean-ActAs: user@company.com
 
 ### Quick Test Commands
 
-Replace `<instance>` with your Glean instance name ([how to find](/get-started/authentication#finding-your-glean-instance)):
+Replace `<instance>` with your Glean instance name ([how to find](/get-started/authentication#finding-your-server-url)):
 
 <Tabs>
 <TabItem value="oauth" label="OAuth">

--- a/docs/api-info/indexing/authentication/overview.mdx
+++ b/docs/api-info/indexing/authentication/overview.mdx
@@ -236,7 +236,7 @@ Authorization: Bearer <indexing_api_token>
 
 ### Example Requests
 
-Replace `instance` with your Glean instance name ([how to find](/get-started/authentication#finding-your-glean-instance)):
+Replace `instance` with your Glean instance name ([how to find](/get-started/authentication#finding-your-server-url)):
 
 <Tabs>
 <TabItem value="index-document" label="Index Document">


### PR DESCRIPTION
## Summary

- Updates 2 broken anchor links from `#finding-your-glean-instance` to `#finding-your-server-url`
- The authentication page was updated to reference server URLs instead of instance names, but these two pages still referenced the old anchor
- This was causing 444 "errors" in the nightly link checker (same broken fragment counted from every page that references it)

## Test plan

- [x] `pnpm build` passes with no broken anchor warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)