### PR TITLE
fix(indexing): add Playwright page timeout and workflow timeout

### DIFF
--- a/.github/workflows/index-developer-docs.yml
+++ b/.github/workflows/index-developer-docs.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   run-indexer:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/scripts/indexing/data_clients.py
+++ b/scripts/indexing/data_clients.py
@@ -601,7 +601,7 @@ class DeveloperDocsDataClient(BaseAsyncStreamingDataClient[Union[DocumentationPa
 
         async def _scrape_single_page_with_page(url: str, page) -> ApiReferencePage:
             try:
-                await page.goto(url, wait_until="networkidle")
+                await page.goto(url, wait_until="networkidle", timeout=60000)
             except Exception as e:
                 raise RuntimeError(f"Failed to load {url}: {e}") from e
 


### PR DESCRIPTION
## Summary

- Adds 60s timeout to `page.goto(url, wait_until="networkidle", timeout=60000)` in the Playwright scraper — prevents infinite hangs on pages with persistent network activity
- Adds `timeout-minutes: 45` to the indexing workflow — prevents 6h runs when something stalls

## Root cause

`wait_until="networkidle"` waits for zero network connections for 500ms. Pages with analytics pings, WebSocket connections, or polling requests never reach network idle, causing Playwright to wait forever. The last 4 scheduled indexing runs were all cancelled after 6 hours because of this.

## Test plan

- [ ] CI indexing run completes within 45 minutes
- [ ] Pages that previously caused hangs now timeout after 60s and report errors instead of stalling

🤖 Generated with [Claude Code](https://claude.com/claude-code)