### PR TITLE
feat(indexing): add disable_stale_deletion_check workflow input

### DIFF
--- a/.github/workflows/index-developer-docs.yml
+++ b/.github/workflows/index-developer-docs.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: boolean
         default: false
+      disable_stale_deletion_check:
+        description: 'Bypass 20% stale-deletion safeguard (use for one-off cleanup runs only)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-indexer:
@@ -53,6 +58,7 @@ jobs:
           GLEAN_INDEXING_API_TOKEN: ${{ secrets.GLEAN_INDEXING_API_TOKEN }}
           GLEAN_INSTANCE: ${{ secrets.GLEAN_INSTANCE }}
           DRY_RUN: ${{ inputs.dry_run }}
+          DISABLE_STALE_DELETION_CHECK: ${{ inputs.disable_stale_deletion_check }}
         run: uv run main.py
 
       - name: Force reindex

--- a/scripts/indexing/main.py
+++ b/scripts/indexing/main.py
@@ -13,12 +13,15 @@ if env_path.exists():
 
 from data_client import DeveloperDocsDataClient
 from developer_docs_connector import DeveloperDocsConnector
-from glean.indexing.models import IndexingMode
+from glean.indexing.models import ConnectorOptions, IndexingMode
 from indexing_logger import create_logger
 
 
 def main():
     dry_run = os.getenv("DRY_RUN", "").lower() in ("true", "1", "yes")
+    disable_stale_deletion_check = os.getenv(
+        "DISABLE_STALE_DELETION_CHECK", ""
+    ).lower() in ("true", "1", "yes")
     log_format = os.getenv("LOG_FORMAT", "stdout")
     indexing_logger = create_logger(format=log_format, verbose=True)
 
@@ -49,7 +52,16 @@ def main():
                 indexing_logger.log("Dry run complete. No data was uploaded to Glean.")
         else:
             connector.configure_datasource()
-            connector.index_data(mode=IndexingMode.FULL)
+            if disable_stale_deletion_check:
+                indexing_logger.log(
+                    "WARNING: stale document deletion safeguard is DISABLED for this run"
+                )
+            connector.index_data(
+                mode=IndexingMode.FULL,
+                options=ConnectorOptions(
+                    disable_stale_deletion_check=disable_stale_deletion_check
+                ),
+            )
 
             summary = indexing_logger.finish()
 

--- a/scripts/indexing/pyproject.toml
+++ b/scripts/indexing/pyproject.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 description = "Indexing scripts for Glean developer documentation"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "glean-indexing-sdk>=1.0.0b1",
+    "glean-indexing-sdk>=1.0.0b2",
     "python-dotenv",
 ]

--- a/scripts/indexing/uv.lock
+++ b/scripts/indexing/uv.lock
@@ -71,22 +71,22 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "glean-indexing-sdk", specifier = ">=1.0.0b1" },
+    { name = "glean-indexing-sdk", specifier = ">=1.0.0b2" },
     { name = "python-dotenv" },
 ]
 
 [[package]]
 name = "glean-indexing-sdk"
-version = "1.0.0b1"
+version = "1.0.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "glean-api-client" },
     { name = "jinja2" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/7c/1c14bda3b2e56b30651d9ed1d9b00823422039bccb823c561853445ed329/glean_indexing_sdk-1.0.0b1.tar.gz", hash = "sha256:98486e8e5e90abdcc367c06f1a8178d5ac28a2b495f1b10097a4f694e5a11f63", size = 134740, upload-time = "2026-03-05T21:40:30.976Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/9e/2ad25fbde5b8b43bdfdf848561a1bf635695cb7d02f8a03f32a917abb743/glean_indexing_sdk-1.0.0b2.tar.gz", hash = "sha256:8f6e1d6fddf373ac034880ac6ce125931fd6fa5c595d7905266dfaf2aacb1c45", size = 137940, upload-time = "2026-04-23T21:41:36.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/38/b5a10ac934361aa113faef716d79680c36cc0fb8d80e771dffedfeeaa882/glean_indexing_sdk-1.0.0b1-py3-none-any.whl", hash = "sha256:dce71f11f87867e539e21c72845fea18126ef04cd1e8abdbfbdbfb6e1152118e", size = 52668, upload-time = "2026-03-05T21:40:29.577Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7a/694df19c21a2f2925f807e360ef42d5e73a546a59650879b5cf48bd89b6b/glean_indexing_sdk-1.0.0b2-py3-none-any.whl", hash = "sha256:0e4a816a5431b8cc738bc40dea11ea50e7a9e4ffadc09be0c1e0c021db17db4f", size = 53003, upload-time = "2026-04-23T21:41:34.831Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `disable_stale_deletion_check` boolean input to the `Index Developer Docs` workflow_dispatch and threads it through `ConnectorOptions` into `index_data()` so we can bypass Glean's 20% stale-deletion safeguard for one-off cleanup runs without touching code
- Bumps `glean-indexing-sdk` pin from `>=1.0.0b1` to `>=1.0.0b2` (the version that introduced `ConnectorOptions` via [SDK PR #17](https://github.com/gleanwork/glean-indexing-sdk/pull/17))
- Logs a clear warning when the safeguard is disabled so it's visible in the workflow run output
- Defaults to `false` — scheduled cron runs keep the safeguard active

## Why

The previous indexing connector generated document IDs from URLs **with** fragments; the current connector uses URLs **without** fragments. Both sets of documents now coexist in Glean and `getDocuments` by URL keeps returning the old, contentless ones. Cleanup is blocked by the 20% safeguard because the entire old set qualifies as stale in a single run. This input lets us trigger a one-off cleanup run that bypasses the safeguard.

## Test plan

- [x] `uv sync` resolves `glean-indexing-sdk==1.0.0b2`
- [x] `ConnectorOptions(disable_stale_deletion_check=True)` constructs cleanly with the new SDK
- [x] Env var parser: `""`, `"false"`, `"0"`, `"no"` → `False`; `"true"`, `"1"`, `"yes"` → `True` (so cron's empty value keeps the safeguard active)
- [ ] Trigger workflow_dispatch with `disable_stale_deletion_check=false` — should behave identically to today
- [ ] Trigger workflow_dispatch with `disable_stale_deletion_check=true` — warning should appear in logs, and afterwards `getDocuments` by old API ref URLs should return the new full-content documents (not empty stale ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)