### PR TITLE
feat(indexing): docId-based getDocument + per-doc timestamps

### DIFF
--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -151,10 +151,14 @@ export default class GleanSearchProvider {
       const fullTextList = doc.content?.fullTextList ?? [];
       const fullText = fullTextList.join('\n\n');
 
+      // Glean returns a document object even for non-existent URLs (with empty
+      // content). Treat empty content as a miss so the caller can fall back
+      // to the next lookup path or return null cleanly.
       if (!fullText) {
         console.warn(
-          `[Glean] No content returned for ${url} via ${label} (doc has content: ${!!doc.content}, fullTextList length: ${fullTextList.length})`,
+          `[Glean] Empty content for ${url} via ${label} (treating as miss)`,
         );
+        return null;
       }
 
       return {

--- a/api/glean-search-provider.mjs
+++ b/api/glean-search-provider.mjs
@@ -11,6 +11,34 @@
  */
 
 import { Glean } from '@gleanwork/api-client';
+import { v5 as uuidv5 } from 'uuid';
+
+const DATASOURCE = 'devdocs';
+
+function getObjectType(url) {
+  let pathname;
+  try {
+    pathname = new URL(url).pathname;
+  } catch {
+    pathname = url.startsWith('/') ? url : `/${url}`;
+  }
+
+  const isApiRoute =
+    pathname.startsWith('/api/client-api/') ||
+    pathname.startsWith('/api/indexing-api/');
+  if (!isApiRoute) {
+    return 'infoPage';
+  }
+
+  const lastSegment = pathname.replace(/\/+$/, '').split('/').pop() ?? '';
+  return lastSegment.includes('overview') ? 'infoPage' : 'apiReference';
+}
+
+function computeDocId(url) {
+  const objectType = getObjectType(url);
+  const uuid = uuidv5(url, uuidv5.URL);
+  return `CUSTOM_${DATASOURCE.toUpperCase()}_${objectType}_${uuid}`;
+}
 
 export default class GleanSearchProvider {
   name = 'glean';
@@ -80,26 +108,39 @@ export default class GleanSearchProvider {
   }
 
   /**
-   * Get a document by URL.
+   * Get a document. Tries the deterministic docId first (avoids stale URL→docId
+   * mappings in Glean's index), then falls back to URL lookup.
    */
   async getDocument(url) {
     if (!this.client) {
       throw new Error('[Glean] Provider not initialized');
     }
 
+    const docId = computeDocId(url);
+
+    let result = await this.#retrieve(url, { id: docId }, `id=${docId}`);
+    if (result) {
+      return result;
+    }
+
+    console.warn(
+      `[Glean] docId lookup returned no document for ${url} (id=${docId}); falling back to URL lookup`,
+    );
+    return this.#retrieve(url, { url }, `url=${url}`);
+  }
+
+  async #retrieve(url, documentSpec, label) {
     try {
       const response = await this.client.client.documents.retrieve({
-        documentSpecs: [{ url }],
+        documentSpecs: [documentSpec],
         includeFields: ['DOCUMENT_CONTENT'],
       });
 
-      // Response is a map keyed by document identifier
       const docs = response.documents;
       if (!docs) {
         return null;
       }
 
-      // Get the first (and only) document from the map
       const docKey = Object.keys(docs)[0];
       const doc = docs[docKey];
 
@@ -112,7 +153,7 @@ export default class GleanSearchProvider {
 
       if (!fullText) {
         console.warn(
-          `[Glean] No content returned for ${url} (doc has content: ${!!doc.content}, fullTextList length: ${fullTextList.length})`,
+          `[Glean] No content returned for ${url} via ${label} (doc has content: ${!!doc.content}, fullTextList length: ${fullTextList.length})`,
         );
       }
 
@@ -124,7 +165,10 @@ export default class GleanSearchProvider {
         headings: [],
       };
     } catch (error) {
-      console.error('[Glean] Get document error:', error.message || error);
+      console.error(
+        `[Glean] Get document error (${label}):`,
+        error.message || error,
+      );
       return null;
     }
   }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 import { openApiPluginOptions } from './openapi.config';
+import docTimestampsPlugin from './plugins/doc-timestamps';
 const redirects = [
   ...require('./redirects.json'),
   ...require('./permalinks.json'),
@@ -276,6 +277,7 @@ const config: Config = {
       },
     ],
     ['docusaurus-plugin-openapi-docs', openApiPluginOptions],
+    docTimestampsPlugin,
   ],
   themes: [
     'docusaurus-theme-openapi-docs',

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "react-tooltip": "^5.30.0",
     "sonner": "^2.0.7",
     "swiper": "^12.0.3",
+    "uuid": "^14.0.0",
     "zod": "^4.2.1"
   },
   "devDependencies": {

--- a/plugins/doc-timestamps/index.ts
+++ b/plugins/doc-timestamps/index.ts
@@ -1,0 +1,146 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import type { LoadContext, Plugin } from '@docusaurus/types';
+import type { LoadedContent as DocsLoadedContent } from '@docusaurus/plugin-content-docs';
+
+const execFileAsync = promisify(execFile);
+
+const SITE_PREFIX = '@site/';
+const COMMIT_MARKER = '__DOC_TS_COMMIT__';
+
+interface DocTimestamps {
+  createdAt: number;
+  lastUpdate: number;
+}
+
+function stripSitePrefix(source: string): string {
+  return source.startsWith(SITE_PREFIX)
+    ? source.slice(SITE_PREFIX.length)
+    : source;
+}
+
+async function isShallowClone(cwd: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--is-shallow-repository'],
+      { cwd },
+    );
+    return stdout.trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+async function collectGitTimestamps(
+  cwd: string,
+): Promise<Map<string, DocTimestamps>> {
+  const map = new Map<string, DocTimestamps>();
+
+  let stdout: string;
+  try {
+    const result = await execFileAsync(
+      'git',
+      [
+        'log',
+        '--no-renames',
+        `--format=${COMMIT_MARKER}%ct`,
+        '--name-only',
+        '--',
+        'docs/',
+      ],
+      { cwd, maxBuffer: 128 * 1024 * 1024 },
+    );
+    stdout = result.stdout;
+  } catch (err) {
+    console.warn(
+      `[doc-timestamps] git log failed (${(err as Error).message}); timestamps will be empty`,
+    );
+    return map;
+  }
+
+  // Each block after splitting on COMMIT_MARKER:
+  //   <ts>\n<file1>\n<file2>\n...
+  // Iteration is newest-first (git default), so the FIRST sighting of a file
+  // is the most recent commit (lastUpdate); the LAST sighting is the oldest
+  // commit (createdAt).
+  for (const block of stdout.split(COMMIT_MARKER)) {
+    const lines = block.split('\n').map((s) => s.trim()).filter(Boolean);
+    if (lines.length === 0) continue;
+    const ts = Number.parseInt(lines[0], 10);
+    if (!Number.isFinite(ts)) continue;
+    for (let i = 1; i < lines.length; i++) {
+      const file = lines[i];
+      const existing = map.get(file);
+      if (existing) {
+        existing.createdAt = ts;
+      } else {
+        map.set(file, { createdAt: ts, lastUpdate: ts });
+      }
+    }
+  }
+
+  return map;
+}
+
+export default function docTimestampsPlugin(
+  _context: LoadContext,
+): Plugin<undefined> {
+  return {
+    name: 'doc-timestamps',
+    async postBuild({ siteDir, outDir, plugins, siteConfig }) {
+      const docsPlugin = plugins.find(
+        (p) => p.name === 'docusaurus-plugin-content-docs',
+      );
+      const content = docsPlugin?.content as DocsLoadedContent | undefined;
+      if (!content) {
+        console.warn(
+          '[doc-timestamps] No content from docusaurus-plugin-content-docs; skipping',
+        );
+        return;
+      }
+
+      const docs = content.loadedVersions.flatMap((v) =>
+        v.docs.filter((d) => !d.draft && !d.unlisted),
+      );
+
+      const sourceByPermalink = new Map<string, string>();
+      for (const doc of docs) {
+        sourceByPermalink.set(doc.permalink, stripSitePrefix(doc.source));
+      }
+
+      if (await isShallowClone(siteDir)) {
+        console.warn(
+          '[doc-timestamps] Repository is a shallow clone; createdAt may reflect the shallow boundary, not the true first commit.',
+        );
+      }
+
+      const gitTimestamps = await collectGitTimestamps(siteDir);
+
+      const siteUrl = siteConfig.url.replace(/\/$/, '');
+      const out: Record<string, DocTimestamps> = {};
+      let untracked = 0;
+      for (const [permalink, sourcePath] of sourceByPermalink) {
+        const ts = gitTimestamps.get(sourcePath);
+        if (!ts) {
+          untracked += 1;
+          continue;
+        }
+        out[`${siteUrl}${permalink}`] = ts;
+      }
+
+      const outputPath = path.join(outDir, 'indexing', 'timestamps.json');
+      await fs.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.writeFile(outputPath, JSON.stringify(out, null, 2));
+      console.log(
+        `[doc-timestamps] Wrote ${Object.keys(out).length} entries to ${path.relative(siteDir, outputPath)}` +
+          (untracked > 0
+            ? ` (${untracked} doc(s) untracked by git, omitted)`
+            : ''),
+      );
+    },
+  };
+}

--- a/plugins/doc-timestamps/index.ts
+++ b/plugins/doc-timestamps/index.ts
@@ -68,7 +68,10 @@ async function collectGitTimestamps(
   // is the most recent commit (lastUpdate); the LAST sighting is the oldest
   // commit (createdAt).
   for (const block of stdout.split(COMMIT_MARKER)) {
-    const lines = block.split('\n').map((s) => s.trim()).filter(Boolean);
+    const lines = block
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
     if (lines.length === 0) continue;
     const ts = Number.parseInt(lines[0], 10);
     if (!Number.isFinite(ts)) continue;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       swiper:
         specifier: ^12.0.3
         version: 12.0.3
+      uuid:
+        specifier: ^14.0.0
+        version: 14.0.0
       zod:
         specifier: ^4.2.1
         version: 4.2.1
@@ -9597,6 +9600,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@8.3.2:
@@ -21777,6 +21784,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
+
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/scripts/indexing/data_client.py
+++ b/scripts/indexing/data_client.py
@@ -37,7 +37,34 @@ class DeveloperDocsDataClient:
         self.indexing_logger = indexing_logger
 
         self.docs_json_path = self.repo_root / "build" / "mcp" / "docs.json"
+        self.timestamps_path = self.repo_root / "build" / "indexing" / "timestamps.json"
         self.api_docs_dir = self.repo_root / "docs" / "api"
+        self._timestamps: Optional[dict[str, dict]] = None
+
+    def _load_timestamps(self) -> dict[str, dict]:
+        """Load timestamps map produced by the doc-timestamps Docusaurus plugin.
+
+        Returns an empty dict if the file is missing — connector then emits None
+        for created_at/updated_at and the SDK omits the fields from the upload.
+        """
+        if self._timestamps is not None:
+            return self._timestamps
+        if not self.timestamps_path.exists():
+            self._log(
+                f"  No timestamps file at {self.timestamps_path}; "
+                "documents will be indexed without created_at/updated_at"
+            )
+            self._timestamps = {}
+            return self._timestamps
+        try:
+            self._timestamps = json.loads(self.timestamps_path.read_text())
+            self._log(
+                f"  Loaded {len(self._timestamps)} timestamp entries from {self.timestamps_path}"
+            )
+        except (json.JSONDecodeError, OSError) as e:
+            self._log(f"  Failed to load timestamps file: {e}; continuing without")
+            self._timestamps = {}
+        return self._timestamps
 
     def _log(self, msg: str) -> None:
         if self.indexing_logger:
@@ -180,18 +207,20 @@ class DeveloperDocsDataClient:
 
     def _build_info_page(self, url: str, doc: dict) -> DocumentationPage:
         """Build a DocumentationPage from docs.json entry."""
+        ts = self._load_timestamps().get(url, {})
         return DocumentationPage(
             id=str(uuid.uuid5(uuid.NAMESPACE_URL, url)),
             title=doc.get("title", "Untitled"),
             content=doc.get("markdown", ""),
             url=url,
             page_type="info_page",
-            created_at=doc.get("createdAt"),
-            updated_at=doc.get("lastUpdate"),
+            created_at=ts.get("createdAt"),
+            updated_at=ts.get("lastUpdate"),
         )
 
     def _build_api_reference(self, url: str, doc: dict) -> ApiReferencePage:
         """Build an ApiReferencePage by combining docs.json with schema files."""
+        ts = self._load_timestamps().get(url, {})
         route = doc.get("route", "")
         api_group = self._route_to_api_group(route)
         slug = self._route_to_endpoint_slug(route)
@@ -227,8 +256,8 @@ class DeveloperDocsDataClient:
             curl_code_sample="",
             url=url,
             page_type="api_reference",
-            created_at=doc.get("createdAt"),
-            updated_at=doc.get("lastUpdate"),
+            created_at=ts.get("createdAt"),
+            updated_at=ts.get("lastUpdate"),
         )
 
     def get_source_data(

--- a/scripts/indexing/data_client.py
+++ b/scripts/indexing/data_client.py
@@ -186,6 +186,8 @@ class DeveloperDocsDataClient:
             content=doc.get("markdown", ""),
             url=url,
             page_type="info_page",
+            created_at=doc.get("createdAt"),
+            updated_at=doc.get("lastUpdate"),
         )
 
     def _build_api_reference(self, url: str, doc: dict) -> ApiReferencePage:
@@ -225,6 +227,8 @@ class DeveloperDocsDataClient:
             curl_code_sample="",
             url=url,
             page_type="api_reference",
+            created_at=doc.get("createdAt"),
+            updated_at=doc.get("lastUpdate"),
         )
 
     def get_source_data(

--- a/scripts/indexing/data_types.py
+++ b/scripts/indexing/data_types.py
@@ -1,4 +1,4 @@
-from typing import List, TypedDict
+from typing import List, Optional, TypedDict
 
 class DocumentationPage(TypedDict):
     """Type definition for full-page documentation data."""
@@ -8,10 +8,12 @@ class DocumentationPage(TypedDict):
     content: str
     url: str
     page_type: str
+    created_at: Optional[int]  # epoch seconds; None when source doesn't expose it
+    updated_at: Optional[int]
 
 class ApiReferencePage(TypedDict):
     """Type definition for API Reference data."""
-    
+
     id: str
     title: str
     tag: str # tag the endpoint belongs to (Activity, Announcements, etc.)
@@ -33,3 +35,5 @@ class ApiReferencePage(TypedDict):
     curl_code_sample: str
     url: str
     page_type: str
+    created_at: Optional[int]
+    updated_at: Optional[int]

--- a/scripts/indexing/developer_docs_connector.py
+++ b/scripts/indexing/developer_docs_connector.py
@@ -137,6 +137,8 @@ class DeveloperDocsConnector(BaseDatasourceConnector[Union[DocumentationPage, Ap
                 permissions=DocumentPermissionsDefinition(
                     allow_anonymous_access=True
                 ),
+                created_at=page.get("created_at"),
+                updated_at=page.get("updated_at"),
             )
             documents.append(document)
         return documents


### PR DESCRIPTION
## Summary

Three related improvements to how the developer docs are indexed and retrieved from Glean:

- **`api/glean-search-provider.mjs`** — `getDocument()` now computes the deterministic docId locally (`uuid5(NAMESPACE_URL, url)` prefixed with `CUSTOM_DEVDOCS_<objectType>_`) and looks up by id, falling back to URL on miss. Removes our reliance on Glean's URL→docId mapping staying current after datasource churn. Empty-content responses are now treated as misses so the fallback chain works and `docs_fetch` cleanly returns "not found" instead of "successful empty document."
- **`plugins/doc-timestamps/index.ts`** — new local Docusaurus plugin. `postBuild` walks `loadedVersions[].docs[]`, runs a single `git log` over `docs/` to collect first/last commit timestamps, and writes `build/indexing/timestamps.json` keyed by full URL. Skips drafts and unlisted docs; warns on shallow clones; omits files git doesn't track.
- **`scripts/indexing/`** — connector now plumbs `created_at`/`updated_at` through `transform()` to `DocumentDefinition` (epoch seconds; SDK omits `None`). Reads timestamps from the new `timestamps.json` sidecar.

Net effect: indexed docs will surface real "Updated" dates in the Glean search UI, recency-based ranking can apply, and `docs_fetch` resolves devdocs URLs reliably regardless of what state Glean's URL→docId index is in.

## Why this approach

- **Local plugin over external plugin update** — the alternative was extending the published `docusaurus-plugin-mcp-server` to include `createdAt`/`lastUpdate` in its `docs.json`. Felt patchy because Docusaurus only natively exposes `lastUpdate` (via git), not `createdAt`. Doing both in a local plugin keeps it cohesive and avoids an external release cycle.
- **DocId computation in the search provider, not via the MCP tool contract** — the LLM never sees opaque docIds; it only gets URLs from `docs_search` results. Computing the docId server-side from the URL works for any URL the LLM might reach for (including out-of-band ones the user pastes), with no MCP tool schema changes.

## Test plan

- [x] `pnpm build` writes `build/indexing/timestamps.json` with 221 entries (matches the 221 docs the MCP plugin processes)
- [x] Connector dry-run loads the timestamps file and applies them to 218/221 docs (3 stragglers are non-`docs/` routes: `/changelog`, `/deprecations`, `/guides/mcp` — handled gracefully via `None`)
- [x] JS `uuidv5(url, uuidv5.URL)` produces byte-identical output to Python `uuid.uuid5(uuid.NAMESPACE_URL, url)` across representative URLs
- [x] Live probe against `glean-public-external` backend: docId path returns full content for real URLs (8889 / 1957 chars), empty-content guard correctly turns the bogus-URL case into `null`
- [ ] After merge: trigger `Index Developer Docs` workflow and confirm `getdocuments` by docId returns real `metadata.createTime` / `metadata.updateTime` instead of 1970

🤖 Generated with [Claude Code](https://claude.com/claude-code)