### PR TITLE
refactor(indexing): ApiRoute dataclass + extensive pytest suite

### DIFF
--- a/scripts/indexing/data_client.py
+++ b/scripts/indexing/data_client.py
@@ -7,8 +7,9 @@ Instead of scraping the live site with Playwright, this reads from:
 - docs/api/**/*.ParamsDetails.json — query/path parameters
 """
 
+from dataclasses import dataclass
 from typing import Union, List, Optional, TYPE_CHECKING
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 import uuid
 import json
 import logging
@@ -19,6 +20,42 @@ if TYPE_CHECKING:
     from indexing_logger import IndexingLogger
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ApiRoute:
+    """Parsed representation of a /api/* route.
+
+    Two route shapes:
+      - Nested (client-api): /api/client-api/<group>/<slug>
+      - Flat (indexing-api): /api/indexing-api/<slug>
+    """
+
+    api: str            # "client-api" | "indexing-api"
+    group: Optional[str]  # tag/group name, or None for flat routes
+    slug: str           # endpoint identifier
+
+    @classmethod
+    def parse(cls, route: str) -> Optional["ApiRoute"]:
+        """Parse a route string. Returns None if the shape isn't recognized."""
+        parts = PurePosixPath(route).parts
+        # Absolute path: parts[0] == "/", parts[1] should be "api"
+        if len(parts) < 4 or parts[0] != "/" or parts[1] != "api":
+            return None
+        if len(parts) == 4:
+            return cls(api=parts[2], group=None, slug=parts[3])
+        if len(parts) == 5:
+            return cls(api=parts[2], group=parts[3], slug=parts[4])
+        return None
+
+    @property
+    def schema_dir(self) -> str:
+        """Relative directory under docs/api/ that holds this endpoint's schema files."""
+        return f"{self.api}/{self.group}" if self.group else self.api
+
+    @property
+    def is_overview(self) -> bool:
+        return "overview" in self.slug
 
 
 class DeveloperDocsDataClient:
@@ -72,22 +109,8 @@ class DeveloperDocsDataClient:
 
     def _is_api_reference(self, route: str) -> bool:
         """Check if a route is an API reference page (not an overview)."""
-        if not (route.startswith("/api/client-api/") or route.startswith("/api/indexing-api/")):
-            return False
-        slug = route.rstrip("/").split("/")[-1]
-        return "overview" not in slug
-
-    def _route_to_api_group(self, route: str) -> str:
-        """Extract API group from route: /api/client-api/activity/feedback -> client-api/activity"""
-        parts = route.strip("/").split("/")
-        if len(parts) >= 3:
-            return f"{parts[1]}/{parts[2]}"
-        return ""
-
-    def _route_to_endpoint_slug(self, route: str) -> str:
-        """Extract endpoint slug from route: /api/client-api/activity/feedback -> feedback"""
-        parts = route.strip("/").split("/")
-        return parts[-1] if parts else ""
+        parsed = ApiRoute.parse(route)
+        return parsed is not None and not parsed.is_overview
 
     def _simplify_schema(self, schema: dict, max_depth: int = 2, depth: int = 0) -> dict:
         """Simplify a JSON schema by limiting nesting depth."""
@@ -118,9 +141,9 @@ class DeveloperDocsDataClient:
 
         return result
 
-    def _load_request_schema(self, api_group: str, slug: str) -> str:
+    def _load_request_schema(self, route: ApiRoute) -> str:
         """Load and format the request schema for an endpoint."""
-        path = self.api_docs_dir / api_group / f"{slug}.RequestSchema.json"
+        path = self.api_docs_dir / route.schema_dir / f"{route.slug}.RequestSchema.json"
         if not path.exists():
             return ""
         try:
@@ -139,9 +162,9 @@ class DeveloperDocsDataClient:
         except (json.JSONDecodeError, OSError):
             return ""
 
-    def _load_status_codes(self, api_group: str, slug: str) -> tuple[List[str], str]:
+    def _load_status_codes(self, route: ApiRoute) -> tuple[List[str], str]:
         """Load response status codes and the success response body schema."""
-        path = self.api_docs_dir / api_group / f"{slug}.StatusCodes.json"
+        path = self.api_docs_dir / route.schema_dir / f"{route.slug}.StatusCodes.json"
         if not path.exists():
             return [], ""
         try:
@@ -167,9 +190,9 @@ class DeveloperDocsDataClient:
         except (json.JSONDecodeError, OSError):
             return [], ""
 
-    def _load_params(self, api_group: str, slug: str) -> tuple[str, str]:
+    def _load_params(self, route: ApiRoute) -> tuple[str, str]:
         """Load query and path parameters. Returns (query_params, path_params) as JSON strings."""
-        path = self.api_docs_dir / api_group / f"{slug}.ParamsDetails.json"
+        path = self.api_docs_dir / route.schema_dir / f"{route.slug}.ParamsDetails.json"
         if not path.exists():
             return "", ""
         try:
@@ -198,13 +221,6 @@ class DeveloperDocsDataClient:
                 break
         return method, endpoint
 
-    def _extract_tag_from_route(self, route: str) -> str:
-        """Extract API tag from route: /api/client-api/activity/feedback -> activity"""
-        parts = route.strip("/").split("/")
-        if len(parts) >= 3:
-            return parts[2]
-        return ""
-
     def _build_info_page(self, url: str, doc: dict) -> DocumentationPage:
         """Build a DocumentationPage from docs.json entry."""
         ts = self._load_timestamps().get(url, {})
@@ -221,23 +237,22 @@ class DeveloperDocsDataClient:
     def _build_api_reference(self, url: str, doc: dict) -> ApiReferencePage:
         """Build an ApiReferencePage by combining docs.json with schema files."""
         ts = self._load_timestamps().get(url, {})
-        route = doc.get("route", "")
-        api_group = self._route_to_api_group(route)
-        slug = self._route_to_endpoint_slug(route)
+        route = ApiRoute.parse(doc.get("route", ""))
+        if route is None:
+            raise ValueError(f"_build_api_reference called with non-API route: {doc.get('route')!r}")
         markdown = doc.get("markdown", "")
 
         method, endpoint = self._extract_method_and_endpoint(markdown)
-        tag = self._extract_tag_from_route(route)
         description = doc.get("description", "")
 
-        request_body = self._load_request_schema(api_group, slug)
-        response_codes, response_body = self._load_status_codes(api_group, slug)
-        query_params, path_params = self._load_params(api_group, slug)
+        request_body = self._load_request_schema(route)
+        response_codes, response_body = self._load_status_codes(route)
+        query_params, path_params = self._load_params(route)
 
         return ApiReferencePage(
             id=str(uuid.uuid5(uuid.NAMESPACE_URL, url)),
             title=doc.get("title", "Untitled"),
-            tag=tag,
+            tag=route.group or "",
             endpoint=endpoint,
             method=method,
             description=description,

--- a/scripts/indexing/pyproject.toml
+++ b/scripts/indexing/pyproject.toml
@@ -7,3 +7,8 @@ dependencies = [
     "glean-indexing-sdk>=1.0.0b2",
     "python-dotenv",
 ]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+]

--- a/scripts/indexing/tests/conftest.py
+++ b/scripts/indexing/tests/conftest.py
@@ -1,0 +1,195 @@
+"""Pytest fixtures for indexing-script tests.
+
+The fixtures build a self-contained fake repo on disk under tmp_path with the
+specific files the data client expects:
+
+    <repo>/build/mcp/docs.json
+    <repo>/build/indexing/timestamps.json
+    <repo>/docs/api/client-api/<group>/<slug>.{RequestSchema,StatusCodes,ParamsDetails}.json
+    <repo>/docs/api/indexing-api/<slug>.{RequestSchema,StatusCodes,ParamsDetails}.json
+
+This lets us exercise the real file-loading paths without depending on a
+checked-out build/ tree or the actual API specs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Make the indexing scripts importable as plain modules.
+INDEXING_DIR = Path(__file__).parent.parent
+if str(INDEXING_DIR) not in sys.path:
+    sys.path.insert(0, str(INDEXING_DIR))
+
+
+def _write_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+# Sample JSON-Schema fragments used across tests. Kept tiny but exercising
+# enough shape for _simplify_schema to do something interesting.
+SIMPLE_REQUEST_SCHEMA = {
+    "title": "FeedbackRequest",
+    "body": {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": ["event"],
+                    "properties": {
+                        "event": {
+                            "type": "string",
+                            "description": "What happened.",
+                            "enum": ["CLICK", "VIEW"],
+                        },
+                        "trackingTokens": {
+                            "type": "array",
+                            "description": "Server-generated tokens.",
+                            "items": {"type": "string"},
+                        },
+                    },
+                }
+            }
+        }
+    },
+}
+
+ALLOF_REQUEST_SCHEMA = {
+    "title": "DatasourceConfig",
+    "body": {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "description": "Datasource config.",
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                                "name": {"type": "string", "description": "Datasource name."},
+                                "displayName": {"type": "string", "description": "Display name."},
+                            },
+                        }
+                    ],
+                }
+            }
+        }
+    },
+}
+
+STATUS_CODES = {
+    "responses": {
+        "200": {
+            "description": "OK",
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "id": {"type": "string", "description": "Document id."}
+                        },
+                    }
+                }
+            },
+        },
+        "400": {"description": "Bad Request"},
+        "401": {"description": "Not Authorized"},
+    }
+}
+
+PARAMS_DETAILS = {
+    "parameters": [
+        {
+            "name": "feedback",
+            "in": "query",
+            "description": "URL-encoded feedback.",
+            "required": False,
+            "schema": {"type": "string"},
+        },
+        {
+            "name": "datasourceId",
+            "in": "path",
+            "description": "Datasource id.",
+            "required": True,
+            "schema": {"type": "string"},
+        },
+    ]
+}
+
+
+def _build_repo(tmp_path: Path) -> Path:
+    """Materialize a minimal fake repo on disk."""
+    api = tmp_path / "docs" / "api"
+
+    # client-api endpoint: /api/client-api/activity/feedback
+    _write_json(api / "client-api" / "activity" / "feedback.RequestSchema.json", SIMPLE_REQUEST_SCHEMA)
+    _write_json(api / "client-api" / "activity" / "feedback.StatusCodes.json", STATUS_CODES)
+    _write_json(api / "client-api" / "activity" / "feedback.ParamsDetails.json", PARAMS_DETAILS)
+
+    # indexing-api endpoint (flat): /api/indexing-api/add-or-update-datasource
+    _write_json(api / "indexing-api" / "add-or-update-datasource.RequestSchema.json", ALLOF_REQUEST_SCHEMA)
+    _write_json(api / "indexing-api" / "add-or-update-datasource.StatusCodes.json", STATUS_CODES)
+
+    # docs.json — three pages: one info, one nested API ref, one flat API ref
+    docs_json = {
+        "https://developers.glean.com/guides/getting-started": {
+            "title": "Getting Started",
+            "description": "Welcome to Glean.",
+            "route": "/guides/getting-started",
+            "markdown": "# Getting Started\n\nWelcome.",
+        },
+        "https://developers.glean.com/api/client-api/activity/feedback": {
+            "title": "Report client activity",
+            "description": "Report events.",
+            "route": "/api/client-api/activity/feedback",
+            "markdown": "# Report client activity\n\nPOST\n/rest/api/v1/feedback\n\nDescription.",
+        },
+        "https://developers.glean.com/api/indexing-api/add-or-update-datasource": {
+            "title": "Add or update datasource",
+            "description": "Add or update.",
+            "route": "/api/indexing-api/add-or-update-datasource",
+            "markdown": "# Add or update datasource\n\nPOST\n/api/index/v1/adddatasource\n\nDescription.",
+        },
+        # An overview page that should be classified as an info page, not API
+        "https://developers.glean.com/api/client-api/search/overview": {
+            "title": "Search Overview",
+            "description": "Overview.",
+            "route": "/api/client-api/search/overview",
+            "markdown": "# Search Overview",
+        },
+    }
+    _write_json(tmp_path / "build" / "mcp" / "docs.json", docs_json)
+
+    # timestamps.json — covers two of the three pages; the indexing-api page is
+    # intentionally omitted to test the missing-key path.
+    timestamps = {
+        "https://developers.glean.com/guides/getting-started": {
+            "createdAt": 1700000000,
+            "lastUpdate": 1735689600,
+        },
+        "https://developers.glean.com/api/client-api/activity/feedback": {
+            "createdAt": 1700000001,
+            "lastUpdate": 1735689601,
+        },
+    }
+    _write_json(tmp_path / "build" / "indexing" / "timestamps.json", timestamps)
+
+    return tmp_path
+
+
+@pytest.fixture
+def fake_repo(tmp_path: Path) -> Path:
+    """Path to a freshly-built fake repo for one test."""
+    return _build_repo(tmp_path)
+
+
+@pytest.fixture
+def empty_repo(tmp_path: Path) -> Path:
+    """A repo with no build/ output — for testing missing-file fallbacks."""
+    return tmp_path

--- a/scripts/indexing/tests/test_api_route.py
+++ b/scripts/indexing/tests/test_api_route.py
@@ -1,0 +1,115 @@
+"""Unit tests for the ApiRoute dataclass."""
+
+from __future__ import annotations
+
+import pytest
+
+from data_client import ApiRoute
+
+
+class TestApiRouteParseClientApi:
+    """Nested 5-segment routes: /api/client-api/<group>/<slug>"""
+
+    def test_parses_typical_endpoint(self) -> None:
+        r = ApiRoute.parse("/api/client-api/activity/feedback")
+        assert r is not None
+        assert r.api == "client-api"
+        assert r.group == "activity"
+        assert r.slug == "feedback"
+
+    def test_schema_dir_includes_group(self) -> None:
+        r = ApiRoute.parse("/api/client-api/activity/feedback")
+        assert r is not None
+        assert r.schema_dir == "client-api/activity"
+
+    def test_overview_endpoint_marked_as_overview(self) -> None:
+        r = ApiRoute.parse("/api/client-api/search/overview")
+        assert r is not None
+        assert r.is_overview is True
+
+    def test_non_overview_endpoint_is_not_overview(self) -> None:
+        r = ApiRoute.parse("/api/client-api/activity/feedback")
+        assert r is not None
+        assert r.is_overview is False
+
+    def test_slug_containing_overview_substring_is_treated_as_overview(self) -> None:
+        # By design: "overview in slug" check is a substring match. Document the
+        # behavior so it's stable.
+        r = ApiRoute.parse("/api/client-api/search/search-overview-page")
+        assert r is not None
+        assert r.is_overview is True
+
+
+class TestApiRouteParseIndexingApi:
+    """Flat 4-segment routes: /api/indexing-api/<slug>"""
+
+    def test_parses_typical_endpoint(self) -> None:
+        r = ApiRoute.parse("/api/indexing-api/add-or-update-datasource")
+        assert r is not None
+        assert r.api == "indexing-api"
+        assert r.group is None
+        assert r.slug == "add-or-update-datasource"
+
+    def test_schema_dir_omits_group(self) -> None:
+        r = ApiRoute.parse("/api/indexing-api/add-or-update-datasource")
+        assert r is not None
+        assert r.schema_dir == "indexing-api"
+
+    def test_authentication_overview_recognized_as_overview(self) -> None:
+        r = ApiRoute.parse("/api/indexing-api/authentication-overview")
+        assert r is not None
+        assert r.is_overview is True
+
+    def test_non_overview_indexing_endpoint(self) -> None:
+        r = ApiRoute.parse("/api/indexing-api/bulk-index-documents")
+        assert r is not None
+        assert r.is_overview is False
+
+
+class TestApiRouteParseUnrecognized:
+    """Routes that don't match either API shape return None."""
+
+    @pytest.mark.parametrize(
+        "route",
+        [
+            "",
+            "/",
+            "/guides/mcp",
+            "/get-started/authentication",
+            "/api",
+            "/api/",
+            "/api/client-api",                   # missing slug
+            "/api/client-api/",                  # missing slug, trailing slash
+            "/api/client-api/activity/feedback/extra",  # too deep
+            "/changelog",
+            "//api//client-api//activity//feedback",  # double slashes
+            "not-even-a-path",
+        ],
+    )
+    def test_returns_none(self, route: str) -> None:
+        assert ApiRoute.parse(route) is None
+
+
+class TestApiRouteFrozen:
+    """The dataclass is frozen — equality and hashability matter."""
+
+    def test_equal_when_fields_match(self) -> None:
+        a = ApiRoute(api="client-api", group="activity", slug="feedback")
+        b = ApiRoute(api="client-api", group="activity", slug="feedback")
+        assert a == b
+
+    def test_not_equal_when_group_differs(self) -> None:
+        a = ApiRoute(api="client-api", group="activity", slug="feedback")
+        b = ApiRoute(api="client-api", group="search", slug="feedback")
+        assert a != b
+
+    def test_hashable(self) -> None:
+        # frozen=True implies hashable; allow use as dict keys / set members.
+        a = ApiRoute(api="client-api", group="activity", slug="feedback")
+        b = ApiRoute(api="client-api", group="activity", slug="feedback")
+        assert {a, b} == {a}
+
+    def test_immutable(self) -> None:
+        r = ApiRoute(api="client-api", group="activity", slug="feedback")
+        with pytest.raises(Exception):  # FrozenInstanceError; type varies by Python
+            r.slug = "other"  # type: ignore[misc]

--- a/scripts/indexing/tests/test_data_client.py
+++ b/scripts/indexing/tests/test_data_client.py
@@ -1,0 +1,439 @@
+"""Tests for DeveloperDocsDataClient.
+
+Strategy: build a minimal fake repo on disk via the `fake_repo` fixture (see
+conftest.py), point the client at it, and exercise the real file-loading +
+parsing paths. No mocking of the filesystem.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from data_client import ApiRoute, DeveloperDocsDataClient
+
+
+@pytest.fixture
+def client(fake_repo: Path) -> DeveloperDocsDataClient:
+    return DeveloperDocsDataClient(repo_root=str(fake_repo))
+
+
+class TestSimplifySchema:
+    """_simplify_schema flattens deeply-nested JSON Schema into a small dict."""
+
+    def test_keeps_basic_keys(self) -> None:
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {"type": "string", "description": "foo", "enum": ["A", "B"]}
+        )
+        assert out == {"type": "string", "description": "foo", "enum": ["A", "B"]}
+
+    def test_drops_unknown_keys(self) -> None:
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {"type": "string", "x-internal": "secret", "$id": "#/foo"}
+        )
+        assert "x-internal" not in out
+        assert "$id" not in out
+
+    def test_recurses_into_properties(self) -> None:
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "n"},
+                    "age": {"type": "integer", "description": "a"},
+                },
+            }
+        )
+        assert out["properties"]["name"] == {"type": "string", "description": "n"}
+        assert out["properties"]["age"] == {"type": "integer", "description": "a"}
+
+    def test_recurses_into_items(self) -> None:
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {"type": "array", "items": {"type": "string", "description": "s"}}
+        )
+        assert out["items"] == {"type": "string", "description": "s"}
+
+    def test_truncates_at_max_depth(self) -> None:
+        # max_depth=2: nodes at depth 2 should be collapsed to a stub.
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {
+                "type": "object",
+                "properties": {
+                    "outer": {
+                        "type": "object",
+                        "properties": {
+                            "inner": {
+                                "type": "object",
+                                "description": "deeply nested",
+                                "properties": {
+                                    "leaf": {"type": "string"},
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+            max_depth=2,
+        )
+        # outer is at depth 1, inner is at depth 2 — should be a stub
+        inner = out["properties"]["outer"]["properties"]["inner"]
+        assert inner == {"type": "object", "description": "deeply nested"}
+
+    def test_merges_allof(self) -> None:
+        c = DeveloperDocsDataClient()
+        out = c._simplify_schema(
+            {
+                "description": "wrapper",
+                "allOf": [
+                    {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {"name": {"type": "string"}},
+                    }
+                ],
+            }
+        )
+        # allOf merging should surface the inner type/required/properties.
+        assert out["type"] == "object"
+        assert out["required"] == ["name"]
+        assert "name" in out["properties"]
+
+
+class TestLoadRequestSchema:
+    """_load_request_schema reads <slug>.RequestSchema.json from schema_dir."""
+
+    def test_loads_client_api_schema(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="client-api", group="activity", slug="feedback")
+        body = client._load_request_schema(route)
+        # Should produce a JSON string with the simplified shape.
+        parsed = json.loads(body)
+        assert parsed["type"] == "object"
+        assert parsed["required"] == ["event"]
+        assert "event" in parsed["properties"]
+
+    def test_loads_indexing_api_flat_schema(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="indexing-api", group=None, slug="add-or-update-datasource")
+        body = client._load_request_schema(route)
+        # The fixture uses allOf — make sure it merged into something useful.
+        parsed = json.loads(body)
+        assert parsed["type"] == "object"
+        assert "name" in parsed["properties"]
+
+    def test_returns_empty_when_file_missing(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="client-api", group="activity", slug="nonexistent")
+        assert client._load_request_schema(route) == ""
+
+    def test_returns_empty_when_file_malformed(
+        self, client: DeveloperDocsDataClient, fake_repo: Path
+    ) -> None:
+        bad = fake_repo / "docs" / "api" / "client-api" / "activity" / "broken.RequestSchema.json"
+        bad.write_text("{ this is not valid json")
+        route = ApiRoute(api="client-api", group="activity", slug="broken")
+        assert client._load_request_schema(route) == ""
+
+    def test_truncates_oversized_schema(
+        self, client: DeveloperDocsDataClient, fake_repo: Path
+    ) -> None:
+        huge = {
+            "body": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                f"prop_{i}": {
+                                    "type": "string",
+                                    "description": "x" * 200,
+                                }
+                                for i in range(500)
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        path = fake_repo / "docs" / "api" / "client-api" / "activity" / "huge.RequestSchema.json"
+        path.write_text(json.dumps(huge))
+        route = ApiRoute(api="client-api", group="activity", slug="huge")
+        body = client._load_request_schema(route)
+        assert len(body) <= client.MAX_SCHEMA_CHARS + len("\n... (truncated)")
+        assert body.endswith("... (truncated)")
+
+
+class TestLoadStatusCodes:
+    def test_loads_codes_with_descriptions(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="client-api", group="activity", slug="feedback")
+        codes, body = client._load_status_codes(route)
+        assert codes == [
+            "200: OK",
+            "400: Bad Request",
+            "401: Not Authorized",
+        ]
+        # Success body schema should be populated since the fixture has 200 with a schema.
+        assert body
+        assert "id" in body
+
+    def test_returns_empty_when_file_missing(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="client-api", group="activity", slug="missing")
+        assert client._load_status_codes(route) == ([], "")
+
+    def test_handles_201_as_success(
+        self, client: DeveloperDocsDataClient, fake_repo: Path
+    ) -> None:
+        # Some endpoints return 201 instead of 200 — confirm that fallback works.
+        path = fake_repo / "docs" / "api" / "client-api" / "activity" / "created.StatusCodes.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "responses": {
+                        "201": {
+                            "description": "Created",
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "string"},
+                                        },
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            )
+        )
+        route = ApiRoute(api="client-api", group="activity", slug="created")
+        codes, body = client._load_status_codes(route)
+        assert codes == ["201: Created"]
+        assert "id" in body
+
+
+class TestLoadParams:
+    def test_separates_query_and_path_params(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="client-api", group="activity", slug="feedback")
+        query, path = client._load_params(route)
+        # Both are JSON strings.
+        q = json.loads(query)
+        p = json.loads(path)
+        assert "feedback" in q
+        assert q["feedback"]["in"] == "query"
+        assert "datasourceId" in p
+        assert p["datasourceId"]["in"] == "path"
+
+    def test_returns_empty_when_file_missing(self, client: DeveloperDocsDataClient) -> None:
+        route = ApiRoute(api="indexing-api", group=None, slug="add-or-update-datasource")
+        assert client._load_params(route) == ("", "")
+
+
+class TestExtractMethodAndEndpoint:
+    """_extract_method_and_endpoint pulls METHOD + path from API ref markdown."""
+
+    def test_finds_post(self) -> None:
+        c = DeveloperDocsDataClient()
+        method, endpoint = c._extract_method_and_endpoint(
+            "# Title\n\nPOST\n/rest/api/v1/feedback\n\nbody"
+        )
+        assert method == "POST"
+        assert endpoint == "/rest/api/v1/feedback"
+
+    @pytest.mark.parametrize("verb", ["GET", "POST", "PUT", "DELETE", "PATCH"])
+    def test_recognizes_each_verb(self, verb: str) -> None:
+        c = DeveloperDocsDataClient()
+        method, endpoint = c._extract_method_and_endpoint(f"{verb}\n/v1/x")
+        assert method == verb
+        assert endpoint == "/v1/x"
+
+    def test_returns_empty_on_no_match(self) -> None:
+        c = DeveloperDocsDataClient()
+        method, endpoint = c._extract_method_and_endpoint("# Title\n\nNo HTTP verb here.")
+        assert method == ""
+        assert endpoint == ""
+
+    def test_picks_first_verb(self) -> None:
+        c = DeveloperDocsDataClient()
+        method, endpoint = c._extract_method_and_endpoint("GET\n/first\n\nPOST\n/second")
+        assert method == "GET"
+        assert endpoint == "/first"
+
+
+class TestLoadTimestamps:
+    def test_loads_existing_file(self, client: DeveloperDocsDataClient) -> None:
+        ts = client._load_timestamps()
+        assert "https://developers.glean.com/guides/getting-started" in ts
+        assert (
+            ts["https://developers.glean.com/guides/getting-started"]["createdAt"]
+            == 1700000000
+        )
+
+    def test_caches_after_first_load(self, client: DeveloperDocsDataClient, fake_repo: Path) -> None:
+        first = client._load_timestamps()
+        # Mutate the on-disk file; cache should win on the second call.
+        (fake_repo / "build" / "indexing" / "timestamps.json").write_text("{}")
+        second = client._load_timestamps()
+        assert first is second  # same object identity = cache hit
+
+    def test_empty_when_file_missing(self, empty_repo: Path) -> None:
+        c = DeveloperDocsDataClient(repo_root=str(empty_repo))
+        assert c._load_timestamps() == {}
+
+    def test_empty_when_file_malformed(self, fake_repo: Path) -> None:
+        # Overwrite with junk.
+        (fake_repo / "build" / "indexing" / "timestamps.json").write_text("not json")
+        c = DeveloperDocsDataClient(repo_root=str(fake_repo))
+        assert c._load_timestamps() == {}
+
+
+class TestIsApiReference:
+    """_is_api_reference uses ApiRoute.parse + is_overview."""
+
+    @pytest.mark.parametrize(
+        "route,expected",
+        [
+            ("/api/client-api/activity/feedback", True),
+            ("/api/indexing-api/add-or-update-datasource", True),
+            ("/api/client-api/search/overview", False),    # overview => info
+            ("/api/indexing-api/authentication-overview", False),
+            ("/guides/mcp", False),                         # not an api route
+            ("/", False),
+            ("", False),
+            ("/api/client-api", False),                     # missing slug
+        ],
+    )
+    def test_classification(
+        self, client: DeveloperDocsDataClient, route: str, expected: bool
+    ) -> None:
+        assert client._is_api_reference(route) is expected
+
+
+class TestBuildInfoPage:
+    def test_includes_timestamps_when_present(self, client: DeveloperDocsDataClient) -> None:
+        url = "https://developers.glean.com/guides/getting-started"
+        page = client._build_info_page(
+            url,
+            {"title": "Getting Started", "markdown": "# Hi"},
+        )
+        assert page["url"] == url
+        assert page["page_type"] == "info_page"
+        assert page["title"] == "Getting Started"
+        assert page["created_at"] == 1700000000
+        assert page["updated_at"] == 1735689600
+
+    def test_id_is_deterministic_uuid5(self, client: DeveloperDocsDataClient) -> None:
+        import uuid as uuid_lib
+
+        url = "https://developers.glean.com/guides/getting-started"
+        page = client._build_info_page(url, {"title": "x", "markdown": ""})
+        expected = str(uuid_lib.uuid5(uuid_lib.NAMESPACE_URL, url))
+        assert page["id"] == expected
+
+    def test_omits_timestamps_when_url_not_in_map(
+        self, client: DeveloperDocsDataClient
+    ) -> None:
+        url = "https://developers.glean.com/some/other/page"
+        page = client._build_info_page(url, {"title": "Other", "markdown": ""})
+        assert page["created_at"] is None
+        assert page["updated_at"] is None
+
+
+class TestBuildApiReference:
+    def test_client_api_endpoint_has_full_data(self, client: DeveloperDocsDataClient) -> None:
+        url = "https://developers.glean.com/api/client-api/activity/feedback"
+        page = client._build_api_reference(
+            url,
+            {
+                "title": "Report client activity",
+                "description": "Report events.",
+                "route": "/api/client-api/activity/feedback",
+                "markdown": "# Report client activity\n\nPOST\n/rest/api/v1/feedback",
+            },
+        )
+        assert page["page_type"] == "api_reference"
+        assert page["tag"] == "activity"
+        assert page["method"] == "POST"
+        assert page["endpoint"] == "/rest/api/v1/feedback"
+        # Schema files were written by the fixture, so all four should be populated.
+        assert page["request_body"]
+        assert page["response_codes"]
+        assert page["request_query_parameters"]
+        assert page["request_path_parameters"]
+        # Timestamps from the fixture's timestamps.json
+        assert page["created_at"] == 1700000001
+        assert page["updated_at"] == 1735689601
+
+    def test_indexing_api_endpoint_has_empty_tag(self, client: DeveloperDocsDataClient) -> None:
+        url = "https://developers.glean.com/api/indexing-api/add-or-update-datasource"
+        page = client._build_api_reference(
+            url,
+            {
+                "title": "Add or update datasource",
+                "description": "Add or update.",
+                "route": "/api/indexing-api/add-or-update-datasource",
+                "markdown": "# Add or update datasource\n\nPOST\n/api/index/v1/adddatasource",
+            },
+        )
+        assert page["tag"] == ""
+        assert page["request_body"]
+        assert page["response_codes"]
+        # The fixture's timestamps.json doesn't include this URL.
+        assert page["created_at"] is None
+        assert page["updated_at"] is None
+
+    def test_raises_on_unrecognized_route(self, client: DeveloperDocsDataClient) -> None:
+        with pytest.raises(ValueError, match="non-API route"):
+            client._build_api_reference(
+                "https://developers.glean.com/guides/mcp",
+                {"title": "x", "route": "/guides/mcp", "markdown": ""},
+            )
+
+
+class TestGetSourceData:
+    """Integration: walks docs.json end-to-end and dispatches to the right builder."""
+
+    def test_returns_all_pages_with_correct_types(
+        self, client: DeveloperDocsDataClient
+    ) -> None:
+        pages = client.get_source_data()
+        # Fixture has 4 entries: 1 info + 1 nested API + 1 flat API + 1 overview (info)
+        assert len(pages) == 4
+        info_pages = [p for p in pages if p["page_type"] == "info_page"]
+        api_pages = [p for p in pages if p["page_type"] == "api_reference"]
+        assert len(info_pages) == 2  # getting-started + search/overview
+        assert len(api_pages) == 2
+
+    def test_overview_routed_as_info_page(self, client: DeveloperDocsDataClient) -> None:
+        pages = client.get_source_data()
+        overview = next(
+            p for p in pages if p["url"].endswith("/api/client-api/search/overview")
+        )
+        assert overview["page_type"] == "info_page"
+
+    def test_raises_when_docs_json_missing(self, empty_repo: Path) -> None:
+        c = DeveloperDocsDataClient(repo_root=str(empty_repo))
+        with pytest.raises(RuntimeError, match="docs.json not found"):
+            c.get_source_data()
+
+    def test_pages_carry_timestamps_when_known(self, client: DeveloperDocsDataClient) -> None:
+        pages = client.get_source_data()
+        feedback = next(
+            p for p in pages if p["url"].endswith("/api/client-api/activity/feedback")
+        )
+        assert feedback["created_at"] == 1700000001
+        assert feedback["updated_at"] == 1735689601
+
+    def test_pages_lacking_timestamps_get_none(self, client: DeveloperDocsDataClient) -> None:
+        pages = client.get_source_data()
+        # The fixture's add-or-update-datasource entry has no timestamp row.
+        au = next(
+            p for p in pages
+            if p["url"].endswith("/api/indexing-api/add-or-update-datasource")
+        )
+        assert au["created_at"] is None
+        assert au["updated_at"] is None

--- a/scripts/indexing/uv.lock
+++ b/scripts/indexing/uv.lock
@@ -35,6 +35,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -69,11 +78,19 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "glean-indexing-sdk", specifier = ">=1.0.0b2" },
     { name = "python-dotenv" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.0.3" }]
 
 [[package]]
 name = "glean-indexing-sdk"
@@ -133,6 +150,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -230,6 +256,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -366,12 +410,93 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replaces three brittle string-splitting route helpers with a single frozen `ApiRoute` dataclass that parses both API route shapes (nested client-api and flat indexing-api) into named fields.
- Updates the three schema-loading methods (`_load_request_schema`, `_load_status_codes`, `_load_params`) to take an `ApiRoute` instead of two strings, eliminating the class of bug where callers could pass mismatched group/slug pairs.
- Adds `pytest` as a dev dep and 72 tests under `scripts/indexing/tests/` — pure unit tests for `ApiRoute` plus integration tests against a synthetic on-disk fake repo (no mocking).

## Why

The previous helpers (`_route_to_api_group`, `_route_to_endpoint_slug`, `_extract_tag_from_route`) used `route.strip("/").split("/")` with magic positional indexes:

```python
def _route_to_api_group(self, route: str) -> str:
    parts = route.strip("/").split("/")
    if len(parts) >= 3:
        return f"{parts[1]}/{parts[2]}"   # treats slug as directory for 3-segment indexing-api routes
    return ""
```

That's exactly what let the indexing-api flat-route bug slip through — the connector was looking up `docs/api/indexing-api/<slug>/<slug>.RequestSchema.json` (wrong) instead of `docs/api/indexing-api/<slug>.RequestSchema.json` (right), so all 44 indexing-api endpoints indexed with empty schemas.

The dataclass makes the two shapes structural rather than length-based:

```python
ApiRoute(api="client-api", group="activity", slug="feedback")  # nested
ApiRoute(api="indexing-api", group=None, slug="add-or-update-datasource")  # flat
```

Single source of truth for route parsing; impossible to index out of bounds; trivially testable in isolation.

## Test coverage

72 tests across two files, all green in 0.12s.

Tests use a real on-disk `tmp_path` fake repo (synthetic `docs.json`, `timestamps.json`, schema JSON files) — no mocking — so they exercise the same code paths as production.

## Test plan

- [x] `uv run pytest tests/` from `scripts/indexing/` — 72 passed
- [x] `uv sync --dev` resolves pytest cleanly
- [ ] CI (no Python tests in CI today; happy to wire pytest into the indexing workflow as a follow-up if you want)

🤖 Generated with [Claude Code](https://claude.com/claude-code)