### PR TITLE
fix(theme): import Schema helpers from theme package for openapi-docs v5

### DIFF
--- a/src/theme/Schema/index.tsx
+++ b/src/theme/Schema/index.tsx
@@ -13,7 +13,7 @@ import clsx from 'clsx';
 import {
   getQualifierMessage,
   getSchemaName,
-} from 'docusaurus-plugin-openapi-docs/lib/markdown/schema';
+} from 'docusaurus-theme-openapi-docs/lib/markdown/schema';
 import { SchemaObject } from 'docusaurus-plugin-openapi-docs/lib/openapi/types';
 
 // eslint-disable-next-line import/no-extraneous-dependencies


### PR DESCRIPTION
## Summary
- `/api/indexing-api/bulk-index-employees` was crashing on production with `TypeError: (0, em.getQualifierMessage) is not a function`.
- Root cause: the v5.0.1 bump of `docusaurus-plugin-openapi-docs` removed `getQualifierMessage` from `lib/markdown/schema`; it now lives only in `docusaurus-theme-openapi-docs/lib/markdown/schema`. Our swizzled `src/theme/Schema/index.tsx` still imported from the old plugin path, so the symbol silently resolved to `undefined` and any schema whose render path hit the call (e.g. the `allOf`/object shape in bulk-index-employees) crashed. Simpler schemas like `/index-employee` didn't trip the code path, which is why only some pages broke.
- Fix: one-line import swap in the swizzle to pull both helpers from the theme package.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm exec docusaurus serve` — `/api/indexing-api/bulk-index-employees` renders schema, params, and response sections with no `getQualifierMessage` error in the console
- [x] `/api/indexing-api/index-employee` still renders (no regression on the previously-working pages)
- [ ] After deploy, confirm production page loads clean

## Follow-up (not in this PR)
Reaching into `/lib/` of an upstream package is the pattern that broke here. Worth a separate hardening pass to either inline the two small helpers into a local util or refresh the swizzle against v5 upstream and keep the Glean customizations as a thinner wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)