### PR TITLE
chore(changelog): 2026-04-28

### DIFF
--- a/changelog/entries/2026-04-15-api-client-go-0-11-42.md
+++ b/changelog/entries/2026-04-15-api-client-go-0-11-42.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-go v0.11.42'
+categories: ['API Clients']
+---
+
+Added `FeedbackUserCount` to `client.insights.retrieve()` and `IssueFilter` to `governance.createfindingsexport()`. Changed `Issues` on `client.activity.feedback()`, `response` on `governance.createfindingsexport()`, and `Exports` on `governance.listfindingsexports()`.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-go/releases/tag/v0.11.42

--- a/changelog/entries/2026-04-15-api-client-java-0-12-37.md
+++ b/changelog/entries/2026-04-15-api-client-java-0-12-37.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-java v0.12.37'
+categories: ['API Clients']
+---
+
+Added `feedbackUserCount` to `client.insights.retrieve()` and `issueFilter` to `governance.createfindingsexport()`. Changed `response` on `governance.createfindingsexport()` and `exports` on `governance.listfindingsexports()`.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-java/releases/tag/v0.12.37

--- a/changelog/entries/2026-04-15-api-client-python-0-12-22.md
+++ b/changelog/entries/2026-04-15-api-client-python-0-12-22.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-python v0.12.22'
+categories: ['API Clients']
+---
+
+Added `feedback_user_count` to `client.insights.retrieve()` and `issue_filter` to `governance.createfindingsexport()`. Changed `response` on `governance.createfindingsexport()` and `exports` on `governance.listfindingsexports()`.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-python/releases/tag/v0.12.22

--- a/changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
+++ b/changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
@@ -1,0 +1,10 @@
+---
+title: 'api-client-typescript v0.14.18'
+categories: ['API Clients']
+---
+
+Added `feedbackUserCount` to `client.insights.retrieve()` and `issueFilter` to `governance.createfindingsexport()`. Changed `issues` on `client.activity.feedback()`, `response` on `governance.createfindingsexport()`, and `exports` on `governance.listfindingsexports()`.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/api-client-typescript/releases/tag/v0.14.18


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-04-28.

Files:
- changelog/entries/2026-04-15-api-client-java-0-12-37.md
- changelog/entries/2026-04-15-api-client-python-0-12-22.md
- changelog/entries/2026-04-15-api-client-typescript-0-14-18.md
- changelog/entries/2026-04-15-api-client-go-0-11-42.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-config-schema, decision: skip, reason: no newer release than latest entry}
- {repo: configure-mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-java, decision: skip, reason: v0.12.38 has no structured API changes}
- {repo: api-client-python, decision: skip, reason: v0.12.24 has no structured API changes}
- {repo: api-client-typescript, decision: skip, reason: v0.14.19 has no structured API changes}
- {repo: api-client-go, decision: skip, reason: v0.11.43 has no structured API changes}
- {repo: open-api, decision: skip, reason: no new open-api commits}

Errors:
- {repo: glean-indexing-sdk, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}