### PR TITLE
Add link to Chat documentation for full list of functionality

### DIFF
--- a/docs/libraries/web-sdk/components/chat.mdx
+++ b/docs/libraries/web-sdk/components/chat.mdx
@@ -8,7 +8,7 @@ iconSet: 'glean'
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Glean Chat delivers personalized answers by integrating deep understanding of your company's content, employees, activities, and their interconnections. The system automatically tailors responses to each individual user's context and needs.
+Glean Chat delivers personalized answers by integrating deep understanding of your company's content, employees, activities, and their interconnections. The system automatically tailors responses to each individual user's context and needs. A complete list of Glean Chat's capabilities can be found in our [Chat documentation](https://docs.glean.com/user-guide/assistant/glean-chat).
 
 <Frame>
   ![Glean Chat Preview](../images/introduction/chat-preview-3.gif)


### PR DESCRIPTION
Want to convey that SDK Chat functionality is the same as `/chat` functionality 

### Screenshot
<img width="1023" height="209" alt="image" src="https://github.com/user-attachments/assets/5ed9eed0-ca32-4fe3-b054-c54b0781d5a4" />
