### PR TITLE
docs: remove Local MCP Server section from MCP guide

### DIFF
--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -1,7 +1,6 @@
 import React, { useMemo, useContext } from 'react';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import Admonition from '@theme/Admonition';
 import { CLIENT, MCPConfigRegistry } from '@gleanwork/mcp-config-schema/browser';
 import { clientNeedsMcpRemote } from '@gleanwork/mcp-config-schema';
 import { FeatureFlagsContext } from '@site/src/theme/Root';
@@ -49,22 +48,3 @@ For comprehensive guides on setting up and using Glean's MCP servers:
     Installation steps, supported hosts, usage examples by role, and troubleshooting tips for end users.
   </Card>
 </CardGroup>
-
-## Local MCP Server
-
-<Admonition type="info" title="Local MCP Server">
-  The local MCP server is not in active development and is not recommended for production use.
-</Admonition>
-
-You can also use Glean's open-source stdio MCP server:
-
-<Card title="@gleanwork/local-mcp-server" icon="GitHub" href="https://github.com/gleanwork/mcp-server/tree/main/packages/local-mcp-server">
-  Self-hosted MCP server implementation for Glean's search and chat
-  capabilities
-</Card>
-
-The local server is ideal for:
-- Development and testing
-- Air-gapped environments
-- Custom tool development
-- Full control over the server infrastructure


### PR DESCRIPTION
## Summary

- Deletes the "Local MCP Server" section from `docs/guides/mcp/RemoteMCPContent.mdx`.
- Removes the now-unused `@theme/Admonition` import.
- Aligns developers.glean.com with the removal of the local path from `@gleanwork/mcp-config-glean`.

## What's kept

- Changelog entries that mention `@gleanwork/local-mcp-server` — historical release notes.
- The generic "Local MCP Server" glossary entry in `docs/get-started/key-terms.mdx` — defines the protocol concept, doesn't advertise Glean's local server.

## Test plan

- [x] `grep -rn "local-mcp-server|local MCP server" docs/` returns only changelog + glossary hits
- [ ] Docusaurus build passes (verifying in CI)
- [ ] `/guides/mcp` renders cleanly without the section