### PR TITLE
chore(changelog): 2026-05-06

### DIFF
--- a/changelog/entries/2026-05-02-mcp-config-schema-5-0-0.md
+++ b/changelog/entries/2026-05-02-mcp-config-schema-5-0-0.md
@@ -1,0 +1,10 @@
+---
+title: 'mcp-config-schema v5.0.0'
+categories: ['MCP']
+---
+
+MCP config and schema now drop the local MCP path and add support for pinning cliVersion. - Breaking change in and - Local MCP path support was removed - pin support was added
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/mcp-config/releases/tag/v5.0.0

--- a/changelog/entries/2026-05-04-configure-mcp-server-3-2-0.md
+++ b/changelog/entries/2026-05-04-configure-mcp-server-3-2-0.md
@@ -1,0 +1,10 @@
+---
+title: 'configure-mcp-server v3.2.0'
+categories: ['MCP']
+---
+
+MCP now shows a friendly error when no local MCP server is configured. - Improved the experience for missing local MCP server configuration.
+
+{/* truncate */}
+
+Full release notes: https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.2.0

--- a/changelog/entries/2026-05-05-rest-api-changes-open-api.md
+++ b/changelog/entries/2026-05-05-rest-api-changes-open-api.md
@@ -1,0 +1,10 @@
+---
+title: 'REST API: changes (endpoints) 2026-05-05'
+categories: ['API']
+---
+
+1 endpoint added
+
+{/* truncate */}
+
+Added endpoint: /people/{person_id}/photo


### PR DESCRIPTION
Adds 3 changelog entries generated on 2026-05-06.

Files:
- changelog/entries/2026-05-02-mcp-config-schema-5-0-0.md
- changelog/entries/2026-05-04-configure-mcp-server-3-2-0.md
- changelog/entries/2026-05-05-rest-api-changes-open-api.md

Skipped:
- {repo: glean-agent-toolkit, decision: skip, reason: no newer release than latest entry}
- {repo: mcp-server, decision: skip, reason: no newer release than latest entry}
- {repo: langchain-glean, decision: skip, reason: no newer release than latest entry}
- {repo: api-client-java, decision: skip, reason: v0.12.38 has no structured API changes}
- {repo: api-client-python, decision: skip, reason: v0.12.24 has no structured API changes}
- {repo: api-client-typescript, decision: skip, reason: v0.14.19 has no structured API changes}
- {repo: api-client-go, decision: skip, reason: v0.11.43 has no structured API changes}

Errors:
- {repo: glean-indexing-sdk, reason: LLM summarization failed — check that GLEAN_API_TOKEN is valid and not expired. Set summarization.mode to "heuristic" in config.yml to use the fallback summarizer.}