### PR TITLE
docs(indexing): add Custom Metadata API documentation

### DIFF
--- a/docs/api-info/indexing/custom-metadata/authentication.mdx
+++ b/docs/api-info/indexing/custom-metadata/authentication.mdx
@@ -1,0 +1,34 @@
+---
+title: 'Authentication'
+icon: 'key-skeleton-left-right'
+---
+
+Custom Metadata requests require a Bearer token in the `Authorization` header. Tokens are **scoped**, so metadata-management permissions can be delegated independently of full indexing-token access.
+
+## Token scopes
+
+When creating a token via the [indexing token creation flow](/api-info/indexing/authentication/overview), set the scope to one of:
+
+- **Global scope** — `custommetadata:global_scope`. Manages schemas and metadata for **any** group.
+- **Group-specific scope** — `custommetadata:<group_name>`. Manages the schema and metadata for the named group only.
+
+A group-scoped token can manage metadata for that group across any document in Glean — it is not tied to a particular datasource.
+
+## Choosing a scope
+
+| Scenario | Recommended scope |
+| -------- | ----------------- |
+| One pipeline managing several metadata groups | `custommetadata:global_scope` |
+| Per-team or per-integration metadata pipelines that should be isolated | `custommetadata:<group_name>` |
+| Third-party or partner integrations | `custommetadata:<group_name>` (least privilege) |
+
+## Using the token
+
+Include the token as a Bearer credential on every request:
+
+```bash
+curl -H 'Authorization: Bearer <token>' \
+  https://<glean-instance-name>-be.glean.com/rest/api/index/custom-metadata/schema/<groupName>
+```
+
+Requests made with a token whose scope does not cover the target group return `401 Unauthorized`.

--- a/docs/api-info/indexing/custom-metadata/indexing-metadata.mdx
+++ b/docs/api-info/indexing/custom-metadata/indexing-metadata.mdx
@@ -1,0 +1,85 @@
+---
+title: 'Indexing Metadata'
+icon: 'pen-field'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Once a [schema is defined](/api-info/indexing/custom-metadata/schema-management) for a metadata group, you can attach metadata values to individual documents.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `PUT` | `/document/{docId}/custom-metadata/{groupName}` | Add or replace all metadata for a `(docId, groupName)` pair |
+| `DELETE` | `/document/{docId}/custom-metadata/{groupName}` | Remove all metadata for a `(docId, groupName)` pair |
+
+`docId` is the unique Glean identifier of the document. You can obtain it via the Client API (for example, [Search](/api/client-api/search/search) or [Get Documents](/api/client-api/documents/getdocuments)).
+
+## Add or update metadata
+
+```
+PUT /document/{docId}/custom-metadata/{groupName}
+```
+
+Indexes custom metadata for the specified document and group.
+
+:::warning
+This call **replaces** all metadata for the `(docId, groupName)` pair. Any keys not present in the request are removed from the group on that document. To update a single key without losing others, include the full set of keys in the request body.
+:::
+
+### Request body
+
+```json
+{
+  "customMetadata": [
+    {
+      "name": "string",
+      "value": "string" | ["string", ...]
+    }
+  ]
+}
+```
+
+`value` is a string for `TEXT` and `PICKLIST` keys, and an array of strings for `TEXTLIST` and `MULTIPICKLIST` keys.
+
+### Example
+
+<Tabs>
+<TabItem value="curl" label="curl">
+
+```bash
+curl -X PUT https://customer-be.glean.com/rest/api/index/document/gdrive_abc123/custom-metadata/compliance \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "customMetadata": [
+      { "name": "status", "value": "Approved" },
+      { "name": "reviewDate", "value": "2026-03-15" },
+      { "name": "tags", "value": ["SOC2", "annual-review"] }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Remove metadata
+
+```
+DELETE /document/{docId}/custom-metadata/{groupName}
+```
+
+Removes all metadata for the specified group from the document. Metadata for **other** groups on the same document is unaffected.
+
+## Rate limits
+
+| Limit | Value |
+| ----- | ----- |
+| Sustained rate | 5 requests per second per group |
+| Burst | Up to 300 requests |
+
+Rate limits are enforced **per metadata group**, not per document. Distributing writes across multiple groups increases overall throughput.
+
+When the limit is exceeded, the API returns `429 Too Many Requests`. See [Error responses](/api-info/indexing/custom-metadata/overview#error-responses) for the full list of status codes.

--- a/docs/api-info/indexing/custom-metadata/overview.mdx
+++ b/docs/api-info/indexing/custom-metadata/overview.mdx
@@ -1,0 +1,57 @@
+---
+title: 'Overview'
+icon: 'send-backward'
+---
+
+The Custom Metadata API attaches structured metadata to any document already indexed in Glean — regardless of which datasource it came from. Unlike [Custom Properties](/api-info/indexing/datasource/custom-properties), which are tied to a custom datasource and require re-uploading the entire document, Custom Metadata can be updated independently and applied to documents from any source (native connectors, custom datasources, etc.).
+
+## Key concepts
+
+- **Document ID (`docId`)**: The unique Glean identifier for a document. You can obtain it via the Client API (for example, [Search](/api/client-api/search/search) or [Get Documents](/api/client-api/documents/getdocuments)).
+- **Metadata group**: A namespace that groups related metadata keys together. Each group has its own schema and access scope.
+- **Metadata schema**: Defines the keys allowed in a group, their property types, and indexing behavior.
+
+:::info
+Metadata group names and key names are case-insensitive and may only contain alphanumeric characters.
+:::
+
+## Base URL
+
+All Custom Metadata endpoints are served from the indexing backend:
+
+```
+https://<glean-instance-name>-be.glean.com/rest/api/index
+```
+
+Replace `<glean-instance-name>` with your Glean instance subdomain.
+
+## Workflow at a glance
+
+A typical end-to-end flow:
+
+1. **[Create a scoped token](/api-info/indexing/custom-metadata/authentication).** Generate a token with scope `custommetadata:<group_name>`, or `custommetadata:global_scope` if you manage multiple groups.
+2. **[Define the schema](/api-info/indexing/custom-metadata/schema-management).** `PUT /custom-metadata/schema/{groupName}` with the keys you want to track and their property types.
+3. **[Attach metadata to documents](/api-info/indexing/custom-metadata/indexing-metadata).** `PUT /document/{docId}/custom-metadata/{groupName}` for each document you want to enrich.
+4. **[Query](/api-info/indexing/custom-metadata/querying).** Use facets (`<groupName><keyName>:<value>`) in Search, or fetch all metadata via `getDocuments` with `includeFields: ["CUSTOM_METADATA"]`.
+
+## Error responses
+
+All Custom Metadata endpoints return errors in this shape:
+
+```json
+{
+  "error": "<reason>",
+  "message": "<details>"
+}
+```
+
+Common status codes:
+
+| Status | Reason |
+| ------ | ------ |
+| `400 Bad Request` | Invalid request body, unknown property type, or missing required field. |
+| `401 Unauthorized` | Invalid or missing authentication token, or token scope does not cover the target group. |
+| `404 Not Found` | The document or metadata group does not exist. |
+| `409 Conflict` | Schema update conflicts with an existing schema (for example, a property type change). |
+| `429 Too Many Requests` | Rate limit exceeded for the group. |
+| `500 Internal Server Error` | Unexpected server-side failure. |

--- a/docs/api-info/indexing/custom-metadata/querying.mdx
+++ b/docs/api-info/indexing/custom-metadata/querying.mdx
@@ -1,0 +1,35 @@
+---
+title: 'Querying'
+icon: 'magnifying-glass'
+---
+
+Once metadata is attached to documents, it becomes available for search and retrieval through the standard Client API.
+
+## Faceted search
+
+Each metadata key becomes a search facet of the form `<groupName><keyName>`. For example, given a group `address` with key `country`, this query returns documents tagged with `USA`:
+
+```
+addresscountry:USA
+```
+
+Facets follow standard Glean operator syntax and can be combined with other operators, including those produced by [Custom Properties](/api-info/indexing/datasource/custom-properties).
+
+## Full-text search
+
+When `skipIndexing` is `false` (the default), metadata values participate in full-text search. A document tagged with `status: Approved` matches a free-text query for `Approved`.
+
+Setting `skipIndexing: true` keeps the value retrievable on the document but excludes it from full-text matching — useful for internal-only fields you don't want surfacing through generic queries.
+
+## Fetching metadata via Get Documents
+
+Use the Client API [`getDocuments`](/api/client-api/documents/getdocuments) endpoint to fetch all metadata attached to a document:
+
+```json
+{
+  "ids": ["gdrive_abc123"],
+  "includeFields": ["CUSTOM_METADATA"]
+}
+```
+
+Custom metadata is returned in `Document.metadata.customData`, alongside any datasource-native metadata fields (such as `author`).

--- a/docs/api-info/indexing/custom-metadata/schema-management.mdx
+++ b/docs/api-info/indexing/custom-metadata/schema-management.mdx
@@ -1,0 +1,105 @@
+---
+title: 'Schema Management'
+icon: 'sitemap'
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+A metadata group must have a schema defined before metadata can be attached to documents in that group. The schema declares which keys are allowed, what type each key is, and whether the value participates in full-text search.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `PUT` | `/custom-metadata/schema/{groupName}` | Create or update a schema |
+| `GET` | `/custom-metadata/schema/{groupName}` | Retrieve the current schema |
+| `DELETE` | `/custom-metadata/schema/{groupName}` | Delete a schema |
+
+## Create or update a schema
+
+```
+PUT /custom-metadata/schema/{groupName}
+```
+
+Defines or updates the schema for a metadata group.
+
+### Request body
+
+```json
+{
+  "metadataKeys": [
+    {
+      "name": "string",
+      "propertyType": "TEXT" | "PICKLIST" | "TEXTLIST" | "MULTIPICKLIST",
+      "skipIndexing": false
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Description |
+| ----- | ---- | -------- | ----------- |
+| `name` | string | Yes | Key name. Alphanumeric, case-insensitive, max 50 characters. |
+| `propertyType` | enum | Yes | One of `TEXT`, `PICKLIST`, `TEXTLIST`, `MULTIPICKLIST`. See [Property types](#property-types). |
+| `skipIndexing` | boolean | No | Default `false`. When `true`, the key is stored on the document but not used for full-text search matching. |
+
+### Example
+
+<Tabs>
+<TabItem value="curl" label="curl">
+
+```bash
+curl -X PUT https://customer-be.glean.com/rest/api/index/custom-metadata/schema/compliance \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "metadataKeys": [
+      { "name": "status", "propertyType": "PICKLIST" },
+      { "name": "tags", "propertyType": "MULTIPICKLIST" },
+      { "name": "reviewDate", "propertyType": "TEXT" },
+      { "name": "internalNotes", "propertyType": "TEXT", "skipIndexing": true }
+    ]
+  }'
+```
+
+</TabItem>
+</Tabs>
+
+## Retrieve a schema
+
+```
+GET /custom-metadata/schema/{groupName}
+```
+
+Returns the current schema for the group, in the same shape as the `PUT` request body.
+
+## Delete a schema
+
+```
+DELETE /custom-metadata/schema/{groupName}
+```
+
+Deletes the schema for a metadata group. Existing metadata values previously attached to documents using this schema are retained until they are removed by a separate cleanup pass.
+
+## Property types
+
+| Type | Description | Search behavior |
+| ---- | ----------- | --------------- |
+| `TEXT` | Single-line free-form text. | Substring match on punctuation/whitespace boundaries. |
+| `PICKLIST` | Single value chosen from a small set of distinct values. | Exact-string match; suitable as a facet. |
+| `TEXTLIST` | Array of free-form text values. | Substring match per entry. |
+| `MULTIPICKLIST` | Array of picklist values. | Exact-string match per entry; suitable as a multi-select facet. |
+
+:::note
+`DATE`, `INT`, and `USERID` property types are **not** supported by the Custom Metadata API.
+:::
+
+## Schema limits
+
+| Limit | Value |
+| ----- | ----- |
+| Maximum metadata groups | 50 |
+| Maximum keys per group | 20 |
+| Maximum group name length | 50 characters |
+| Maximum key name length | 50 characters |

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1232,6 +1232,41 @@ const baseSidebars: SidebarsConfig = {
         },
         {
           type: 'category',
+          label: 'Custom Metadata (Any Datasource)',
+          link: {
+            type: 'doc',
+            id: 'api-info/indexing/custom-metadata/overview',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'api-info/indexing/custom-metadata/overview',
+              label: 'Overview',
+            },
+            {
+              type: 'doc',
+              id: 'api-info/indexing/custom-metadata/authentication',
+              label: 'Authentication',
+            },
+            {
+              type: 'doc',
+              id: 'api-info/indexing/custom-metadata/schema-management',
+              label: 'Schema Management',
+            },
+            {
+              type: 'doc',
+              id: 'api-info/indexing/custom-metadata/indexing-metadata',
+              label: 'Indexing Metadata',
+            },
+            {
+              type: 'doc',
+              id: 'api-info/indexing/custom-metadata/querying',
+              label: 'Querying',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Datasource',
           items: [
             {


### PR DESCRIPTION
## Summary

Adds documentation for the new Custom Metadata API to developers.glean.com. **Part 1 of 4** PRs supporting the Custom Metadata API GA on May 18, 2026.

This PR introduces the core API reference pages under a new **Custom Metadata (Any Datasource)** sidebar category in the Indexing API section. The category is placed above the existing Datasource section, with the parenthetical scope qualifier in the label to make it clear at a glance that the API works with any datasource — not just custom ones.

## Pages added

- **Overview** — intro, key concepts, base URL, workflow walkthrough, error reference
- **Authentication** — scoped tokens (`custommetadata:global_scope`, `custommetadata:<group>`)
- **Schema Management** — PUT/GET/DELETE schema, property types, schema limits
- **Indexing Metadata** — PUT/DELETE document metadata, rate limits
- **Querying** — facets, full-text search, getDocuments fetch

## Sidebar

- New **Custom Metadata (Any Datasource)** category under Indexing API, above the Datasource section
- Category click links directly to Overview (no expansion required)

## What's NOT in this PR (follow-ups)

- **PR 2** — Custom Properties vs Custom Metadata comparison page
- **PR 3** — cross-references from existing pages (custom-properties.mdx + Indexing API overview)
- **PR 4** — changelog entry (timed for May 18 GA rollout)

The Overview and Querying pages here have small forward-references to the comparison page deliberately omitted; PR 2 restores them.

## Test plan

- [x] `pnpm build` passes locally
- [x] Visual review of each new page in dev server
- [x] Sidebar renders the new category in the right position
- [x] Clicking the category label opens the Overview page

🤖 Generated with [Claude Code](https://claude.com/claude-code)