### PR TITLE
docs(indexing): cross-link Custom Metadata from existing pages

### DIFF
--- a/docs/api-info/indexing/datasource/custom-properties.mdx
+++ b/docs/api-info/indexing/datasource/custom-properties.mdx
@@ -9,6 +9,10 @@ import TabItem from '@theme/TabItem';
 
 In this document, we discuss how to define custom properties for a datasource and how to upload them with each document.
 
+:::tip
+Custom Properties are tied to a custom datasource and require re-uploading the full document on every change. If you want to enrich documents from **any** datasource (including native connectors like Google Drive, Confluence, or Jira) without re-indexing, see the [Custom Metadata API](/api-info/indexing/custom-metadata/overview). For a side-by-side comparison, see [Custom Properties vs Custom Metadata](/api-info/indexing/custom-metadata/custom-properties-vs-custom-metadata).
+:::
+
 ## What are custom properties?
 
 Fundamentally, a custom property is any additional information that is attached to a document. These properties can be used in 3 different ways:

--- a/docs/api-info/indexing/getting-started/overview.mdx
+++ b/docs/api-info/indexing/getting-started/overview.mdx
@@ -29,6 +29,10 @@ The Glean Indexing API enables organizations to make their custom content search
   <Card title="Permission Management" icon="Shield">
     Enforce fine-grained access controls ensuring users only see content they're authorized to access
   </Card>
+
+  <Card title="Custom Metadata (Any Datasource)" icon="Tag">
+    Attach structured metadata to documents from any datasource — native connectors and custom — without re-indexing
+  </Card>
 </CardGroup>
 
 ## Common Use Cases
@@ -38,6 +42,7 @@ The Glean Indexing API enables organizations to make their custom content search
 - **Custom Application Data**: Index structured data from internal applications and databases
 - **Document Repositories**: Make file servers, wikis, and document management systems searchable
 - **Organizational Data**: Push people information, team structures, and organizational knowledge into Glean
+- **Cross-Datasource Enrichment**: Tag and classify documents already indexed in Glean — from native connectors (Google Drive, Confluence, Jira, etc.) and custom datasources alike — using the [Custom Metadata API](../custom-metadata/overview), without re-indexing the source document
 
 ## How It Works
 
@@ -70,6 +75,7 @@ The Indexing API supports various types of content:
 - **User Information**: Employee profiles, organizational structures, and team data
 - **Groups & Teams**: Organizational units and membership information
 - **External Shortcuts**: Quick access links to frequently used external resources
+- **Custom Metadata**: Schema-defined key-value metadata attached to any document already indexed in Glean — see [Custom Metadata (Any Datasource)](../custom-metadata/overview)
 
 ## Quick Example
 
@@ -116,6 +122,33 @@ Here's how to create a datasource and index your first document:
   ```
 
   </TabItem>
+  <TabItem value="custom-metadata" label="Attach Custom Metadata">
+
+  Attach structured metadata to a document already indexed in Glean — from any datasource. First define the group schema, then attach values per document. See [Custom Metadata (Any Datasource)](../custom-metadata/overview) for full details.
+
+  ```bash
+  # 1. Define the metadata group schema
+  curl -X PUT https://customer-be.glean.com/rest/api/index/custom-metadata/schema/compliance \
+    -H 'Authorization: Bearer <custommetadata_token>' \
+    -d '{
+      "metadataKeys": [
+        { "name": "status", "propertyType": "PICKLIST" },
+        { "name": "tags", "propertyType": "MULTIPICKLIST" }
+      ]
+    }'
+
+  # 2. Attach metadata to a document (works with any datasource)
+  curl -X PUT https://customer-be.glean.com/rest/api/index/document/gdrive_abc123/custom-metadata/compliance \
+    -H 'Authorization: Bearer <custommetadata_token>' \
+    -d '{
+      "customMetadata": [
+        { "name": "status", "value": "Approved" },
+        { "name": "tags", "value": ["SOC2", "annual-review"] }
+      ]
+    }'
+  ```
+
+  </TabItem>
 </Tabs>
 
 ## Authentication & Permissions
@@ -143,6 +176,10 @@ Learn more in our [Authentication Guide](../authentication/overview).
 
   <Card title="Index Your First Document" icon="FileText" href="index-documents">
     Follow our step-by-step guide to index content and make it searchable
+  </Card>
+
+  <Card title="Enrich Documents with Custom Metadata" icon="Tag" href="../custom-metadata/overview">
+    Attach structured metadata to documents from any datasource — works with native connectors (Google Drive, Confluence, Jira, etc.) and custom datasources
   </Card>
 
   <Card title="Manage Authentication" icon="Shield" href="../authentication/overview">


### PR DESCRIPTION
## Summary

**Part 3 of 4** PRs supporting the Custom Metadata API GA. **Stacked on top of #541** (custom-metadata-comparison).

Surfaces the new Custom Metadata API on existing high-traffic pages so users discovering the Indexing API see it.

## Changes

### \`docs/api-info/indexing/datasource/custom-properties.mdx\`

Adds an info-tip near the top cross-linking to:
- The Custom Metadata API (works with any datasource, no re-indexing)
- The Custom Properties vs Custom Metadata comparison page

### \`docs/api-info/indexing/getting-started/overview.mdx\` (Indexing API Overview)

- **Key Capabilities** — new "Custom Metadata (Any Datasource)" tile
- **Common Use Cases** — new "Cross-Datasource Enrichment" bullet
- **Content Types** — new Custom Metadata entry
- **Quick Example** — new "Attach Custom Metadata" tab showing schema PUT + document metadata PUT
- **Next Steps** — new card linking to the Custom Metadata Overview

## Depends on

- #540 (custom-metadata-core)
- #541 (custom-metadata-comparison)

## Test plan

- [x] \`pnpm build\` passes locally
- [x] Visual review of cards/tiles/use-case bullet/quick-example tab
- [x] All cross-links navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)