### PR TITLE
docs(changelog): beta /debug/{datasource}/document/events endpoint

### DIFF
--- a/changelog/entries/2026-05-12-document-lifecycle-events-troubleshooting-endpoint.md
+++ b/changelog/entries/2026-05-12-document-lifecycle-events-troubleshooting-endpoint.md
@@ -12,4 +12,4 @@ New endpoint `/debug/{datasource}/document/events` (beta) introduced to retrieve
 - Added endpoint `/debug/{datasource}/document/events` (beta) to retrieve lifecycle events for a specific document.
   - Request requires `objectType` and `docId`; optional `startDate` (up to 30 days back, defaults to 7) and `maxEvents` (up to 100, defaults to 20).
   - Response returns `lifeCycleEvents`, each with an `event` (`UPLOADED`, `INDEXED`, `DELETION_REQUESTED`, or `DELETED`) and a `timestamp`.
-  - Rate limited to 1 request per minute per datasource. Beta — may undergo breaking changes without prior notice.
+  - Rate limited to 1 request per minute per datasource.

--- a/changelog/entries/2026-05-12-document-lifecycle-events-troubleshooting-endpoint.md
+++ b/changelog/entries/2026-05-12-document-lifecycle-events-troubleshooting-endpoint.md
@@ -1,0 +1,15 @@
+---
+title: 'Beta: Document Lifecycle Events Troubleshooting Endpoint'
+categories: ['API']
+---
+
+New endpoint `/debug/{datasource}/document/events` (beta) introduced to retrieve lifecycle events (upload, index, deletion requested, deletion) for a specific document.
+
+{/* truncate */}
+
+## Changes
+
+- Added endpoint `/debug/{datasource}/document/events` (beta) to retrieve lifecycle events for a specific document.
+  - Request requires `objectType` and `docId`; optional `startDate` (up to 30 days back, defaults to 7) and `maxEvents` (up to 100, defaults to 20).
+  - Response returns `lifeCycleEvents`, each with an `event` (`UPLOADED`, `INDEXED`, `DELETION_REQUESTED`, or `DELETED`) and a `timestamp`.
+  - Rate limited to 1 request per minute per datasource. Beta — may undergo breaking changes without prior notice.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1599,6 +1599,12 @@ const baseSidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'api/indexing-api/beta-get-document-lifecycle-events',
+              label: 'Beta: Get document lifecycle events\n',
+              className: 'api-method post',
+            },
+            {
+              type: 'doc',
               id: 'api/indexing-api/beta-get-information-of-a-batch-of-documents',
               label: 'Beta: Get information of a batch of documents\n',
               className: 'api-method post',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1599,12 +1599,6 @@ const baseSidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
-              id: 'api/indexing-api/beta-get-document-lifecycle-events',
-              label: 'Beta: Get document lifecycle events\n',
-              className: 'api-method post',
-            },
-            {
-              type: 'doc',
               id: 'api/indexing-api/beta-get-information-of-a-batch-of-documents',
               label: 'Beta: Get information of a batch of documents\n',
               className: 'api-method post',


### PR DESCRIPTION
## Summary
- Adds a changelog entry announcing the new beta troubleshooting endpoint `POST /debug/{datasource}/document/events`, which returns lifecycle events (`UPLOADED`, `INDEXED`, `DELETION_REQUESTED`, `DELETED`) for a specific document.

## Test plan
- [ ] `pnpm changelog:compile:json` regenerates `src/data/changelog.json` cleanly with this entry included.
- [ ] `pnpm build` succeeds and the entry shows on the changelog page with the **Noteworthy** badge.
- [ ] Title, date (2026-05-12), and category (`API`) render as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)