### PR TITLE
chore(deps): group @docusaurus/* prod and dev deps together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,5 +14,14 @@ updates:
       docusaurus:
         patterns:
           - "@docusaurus/*"
+        # Without this, the group defaults to production-only and silently
+        # excludes @docusaurus/* dev deps (faster, types, theme-mermaid, etc.),
+        # so they land in the dev-dependencies group while production
+        # @docusaurus/* packages get a separate PR — version skew.
+        dependency-type: "production-and-development"
       dev-dependencies:
         dependency-type: "development"
+        # Keep @docusaurus/* dev deps in the docusaurus group above so all
+        # @docusaurus/* packages bump together.
+        exclude-patterns:
+          - "@docusaurus/*"


### PR DESCRIPTION
## Summary

- The \`docusaurus\` group in \`.github/dependabot.yml\` had no explicit \`dependency-type\`, which defaults to **production-only** per GitHub's dependabot docs.
- That silently excluded \`@docusaurus/*\` devDependencies (faster, types, theme-mermaid, module-type-aliases, tsconfig) from the docusaurus group; they fell into the \`dev-dependencies\` catch-all instead.
- Result: a recent dependabot PR bumped \`@docusaurus/faster\` and \`@docusaurus/types\` to 3.10.1 alongside unrelated dev-dep updates, while production \`@docusaurus/*\` packages (\`core\`, \`plugin-content-docs\`, \`theme-classic\`, \`preset-classic\`, etc.) stayed at 3.10.0 — version skew within a tightly-coupled package family.
- Adding \`dependency-type: "production-and-development"\` to the docusaurus group fixes this; \`exclude-patterns: ["@docusaurus/*"]\` on the dev-dependencies group is belt-and-suspenders so the docusaurus group definitely wins.

## Test plan

- [ ] Wait for dependabot's next run; confirm any \`@docusaurus/*\` updates open as a single docusaurus-group PR covering both prod and dev packages.
- [ ] Confirm dev-dependencies-group PRs no longer include \`@docusaurus/*\` packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)