### PR TITLE
fix(sidebar): remove orphan entries during sidebar:fix

### DIFF
--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -216,25 +216,23 @@ function findCategoryItemsByLabel(root, label) {
 function removeOrphanEntries(root, orphanedIds) {
   if (orphanedIds.size === 0) return 0;
   let removed = 0;
-  root
-    .find(j.ObjectProperty, { key: { name: 'items' } })
-    .forEach((p) => {
-      const arr = p.node.value;
-      if (arr.type !== 'ArrayExpression') return;
-      const before = arr.elements.length;
-      arr.elements = arr.elements.filter((el) => {
-        if (!el || el.type !== 'ObjectExpression') return true;
-        const idProp = el.properties.find(
-          (prop) =>
-            prop.type === 'ObjectProperty' &&
-            prop.key?.name === 'id' &&
-            prop.value?.type === 'StringLiteral',
-        );
-        if (!idProp) return true;
-        return !orphanedIds.has(idProp.value.value);
-      });
-      removed += before - arr.elements.length;
+  root.find(j.ObjectProperty, { key: { name: 'items' } }).forEach((p) => {
+    const arr = p.node.value;
+    if (arr.type !== 'ArrayExpression') return;
+    const before = arr.elements.length;
+    arr.elements = arr.elements.filter((el) => {
+      if (!el || el.type !== 'ObjectExpression') return true;
+      const idProp = el.properties.find(
+        (prop) =>
+          prop.type === 'ObjectProperty' &&
+          prop.key?.name === 'id' &&
+          prop.value?.type === 'StringLiteral',
+      );
+      if (!idProp) return true;
+      return !orphanedIds.has(idProp.value.value);
     });
+    removed += before - arr.elements.length;
+  });
   return removed;
 }
 

--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -209,6 +209,35 @@ function findCategoryItemsByLabel(root, label) {
   return found;
 }
 
+// Remove sidebar entries whose `id` is in `orphanedIds` (typically because the
+// upstream OpenAPI spec renamed or removed the operation, leaving the entry
+// pointing at a doc that no longer exists). Operates on every `items: [...]`
+// array in the AST so nested categories are handled.
+function removeOrphanEntries(root, orphanedIds) {
+  if (orphanedIds.size === 0) return 0;
+  let removed = 0;
+  root
+    .find(j.ObjectProperty, { key: { name: 'items' } })
+    .forEach((p) => {
+      const arr = p.node.value;
+      if (arr.type !== 'ArrayExpression') return;
+      const before = arr.elements.length;
+      arr.elements = arr.elements.filter((el) => {
+        if (!el || el.type !== 'ObjectExpression') return true;
+        const idProp = el.properties.find(
+          (prop) =>
+            prop.type === 'ObjectProperty' &&
+            prop.key?.name === 'id' &&
+            prop.value?.type === 'StringLiteral',
+        );
+        if (!idProp) return true;
+        return !orphanedIds.has(idProp.value.value);
+      });
+      removed += before - arr.elements.length;
+    });
+  return removed;
+}
+
 function insertEntry(root, doc, slugToTag) {
   const segments = doc.docId.split('/');
   const overviewId = segments.slice(0, -1).join('/') + '/overview';
@@ -307,7 +336,7 @@ if (args.check) {
   process.exit(1);
 }
 
-if (missing.length === 0) {
+if (missing.length === 0 && orphaned.length === 0) {
   console.log('✓ sidebars.ts is already complete — nothing to do.');
   process.exit(0);
 }
@@ -327,6 +356,9 @@ for (const doc of missing) {
   }
 }
 
+const orphanedSet = new Set(orphaned);
+const removedCount = removeOrphanEntries(root, orphanedSet);
+
 const transformed = root.toSource();
 const prettierConfig = await prettier.resolveConfig(SIDEBARS_PATH);
 const formatted = await prettier.format(transformed, {
@@ -335,11 +367,22 @@ const formatted = await prettier.format(transformed, {
 });
 fs.writeFileSync(SIDEBARS_PATH, formatted, 'utf8');
 
-console.log(
-  `✓ Inserted ${missing.length - warnings.length} entry(ies) into sidebars.ts:`,
-);
-for (const doc of missing) {
-  console.log(`  + ${doc.docId}  "${doc.label}"`);
+if (missing.length > 0) {
+  console.log(
+    `✓ Inserted ${missing.length - warnings.length} entry(ies) into sidebars.ts:`,
+  );
+  for (const doc of missing) {
+    console.log(`  + ${doc.docId}  "${doc.label}"`);
+  }
+}
+
+if (removedCount > 0) {
+  console.log(
+    `\n✓ Removed ${removedCount} orphan entry(ies) from sidebars.ts (no corresponding .api.mdx / .mdx file):`,
+  );
+  for (const id of orphaned) {
+    console.log(`  - ${id}`);
+  }
 }
 
 if (warnings.length > 0) {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1134,18 +1134,6 @@ const baseSidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
-              id: 'api/client-api/tools/authorize-action',
-              label: 'Start the OAuth authorization flow for an action pack.',
-              className: 'api-method post',
-            },
-            {
-              type: 'doc',
-              id: 'api/client-api/tools/get-action-auth-status',
-              label: 'Get end-user authentication status for an action pack.',
-              className: 'api-method get',
-            },
-            {
-              type: 'doc',
               id: 'api/client-api/tools/authorize-action-pack',
               label: 'Start the OAuth authorization flow for an action pack.',
               className: 'api-method post',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1134,6 +1134,18 @@ const baseSidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'api/client-api/tools/authorize-action',
+              label: 'Start the OAuth authorization flow for an action pack.',
+              className: 'api-method post',
+            },
+            {
+              type: 'doc',
+              id: 'api/client-api/tools/get-action-auth-status',
+              label: 'Get end-user authentication status for an action pack.',
+              className: 'api-method get',
+            },
+            {
+              type: 'doc',
               id: 'api/client-api/tools/authorize-action-pack',
               label: 'Start the OAuth authorization flow for an action pack.',
               className: 'api-method post',


### PR DESCRIPTION
## Summary

- Follow-up to #551: sidebar drift was being handled in only one direction. The fixer would add entries for newly-discovered endpoints, but if upstream renamed or removed an endpoint, the stale entry was left in \`sidebars.ts\` and Docusaurus would reject the file during build with \`Invalid sidebar file at "sidebars.ts"\`.
- This is the failure mode that's currently blocking #553 (the latest regenerate PR): upstream renamed two \`tools\` endpoints to their \`*-action-pack\` variants, but \`sidebars.ts\` on \`main\` still has entries for the old names.
- This change adds \`removeOrphanEntries()\` to \`sync-api-sidebar.mjs\` and calls it from \`--fix\` so the regenerate workflow keeps \`sidebars.ts\` in sync with the actual \`.api.mdx\` files in both directions. It also drops the two currently-orphaned \`tools/authorize-action\` and \`tools/get-action-auth-status\` entries inline so #553 (and any future regenerate PR) can build cleanly without a separate cleanup step.

## Test plan

- [x] \`pnpm sidebar:check\` on a clean main: passes (no missing, no orphans).
- [x] After regenerating \`docs/api/client-api/\` from upstream live spec (which has the renames): \`sidebar:check\` warns about 2 orphans, \`sidebar:fix\` removes them, follow-up \`sidebar:check\` passes.
- [x] Diff in \`sidebars.ts\` matches the 2 expected removals exactly — no other edits.
- [ ] CI passes on this PR.
- [ ] After merge, rebase or re-run #553's CI; it should now build successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)