### PR TITLE
fix(sidebar): match category label by tag prefix

### DIFF
--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -178,6 +178,10 @@ function buildSlugToTagMap() {
   return map;
 }
 
+// Find the `items` array of the sidebar category whose label matches the
+// given tag. Falls back to a `<tag> (...)` prefix match so a category can
+// add a clarifying parenthetical (e.g. label "Custom Metadata (Any Datasource)"
+// for OpenAPI tag "Custom Metadata") without breaking auto-insertion.
 function findCategoryItemsByLabel(root, label) {
   let found = null;
   root.find(j.ObjectExpression).forEach((p) => {
@@ -196,7 +200,7 @@ function findCategoryItemsByLabel(root, label) {
         pr.type === 'ObjectProperty' &&
         pr.key?.name === 'label' &&
         pr.value?.type === 'StringLiteral' &&
-        pr.value?.value === label,
+        (pr.value.value === label || pr.value.value.startsWith(`${label} (`)),
     );
     if (!labelMatch) return;
     const itemsProp = props.find(

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1280,6 +1280,36 @@ const baseSidebars: SidebarsConfig = {
               id: 'api-info/indexing/custom-metadata/custom-properties-vs-custom-metadata',
               label: 'Custom Properties vs Custom Metadata',
             },
+            {
+              type: 'doc',
+              id: 'api/indexing-api/add-or-update-custom-metadata',
+              label: 'Add or update custom metadata',
+              className: 'api-method put',
+            },
+            {
+              type: 'doc',
+              id: 'api/indexing-api/create-or-update-metadata-schema',
+              label: 'Create or update metadata schema',
+              className: 'api-method put',
+            },
+            {
+              type: 'doc',
+              id: 'api/indexing-api/remove-custom-metadata',
+              label: 'Remove custom metadata',
+              className: 'api-method delete',
+            },
+            {
+              type: 'doc',
+              id: 'api/indexing-api/remove-metadata-schema',
+              label: 'Remove metadata schema',
+              className: 'api-method delete',
+            },
+            {
+              type: 'doc',
+              id: 'api/indexing-api/retrieve-metadata-schema',
+              label: 'Retrieve metadata schema',
+              className: 'api-method get',
+            },
           ],
         },
         {


### PR DESCRIPTION
## Summary

- Follow-up to #555: \`findCategoryItemsByLabel\` did exact-equality matching between the OpenAPI tag and the sidebar category label. That broke for the new \"Custom Metadata\" indexing API, where the sidebar category was authored with a clarifying parenthetical label — \"Custom Metadata (Any Datasource)\" — and the spec tag is plain \"Custom Metadata\".
- Allow a fall-through prefix match \`label.startsWith('${tag} (')\` so a category can keep its parenthetical scope qualifier without breaking auto-insertion. The required open-paren keeps the match restrictive — accidental matches against unrelated category labels are unlikely.
- Verified locally: with the latest upstream spec (which adds 5 \`/custom-metadata/*\` operations) the fixer now inserts all 5 entries into the existing \"Custom Metadata (Any Datasource)\" category. Without this fix it left them out and the docusaurus build complained that the entries were missing.

## Test plan

- [x] Local repro: regenerate \`docs/api/indexing-api/\` against latest live spec; \`pnpm sidebar:check\` reports 5 missing entries.
- [x] \`pnpm sidebar:fix\` with this change inserts all 5 under the \"Custom Metadata (Any Datasource)\" category.
- [x] Follow-up \`pnpm sidebar:check\` passes.
- [ ] CI passes on this PR.
- [ ] After merge, re-trigger \`Trigger Redeploy\`; the next regenerate PR should land cleanly without missing-entry build failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)