### PR TITLE
feat(link-checker): JSON output, AI-consumable artifacts, inline run summary

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           sparse-checkout: |
             scripts/check-links.sh
+            scripts/render-link-check-results.mjs
           sparse-checkout-cone-mode: false
 
       - name: Install dependencies
@@ -81,141 +82,104 @@ jobs:
 
       - name: Run link check
         id: link-check
+        # Pass user-controlled inputs via env (not shell interpolation) to
+        # eliminate workflow-injection risk from a maliciously-crafted base_url.
+        env:
+          BASE_URL: ${{ steps.params.outputs.base_url }}
+          CHECK_TYPE: ${{ steps.params.outputs.check_type }}
         run: |
-          base_url="${{ steps.params.outputs.base_url }}"
-          check_type="${{ steps.params.outputs.check_type }}"
+          echo "🔍 Running $CHECK_TYPE link check on $BASE_URL"
 
-          echo "🔍 Running $check_type link check on $base_url"
-
-          # Use `|| exit_code=$?` so bash -e does not kill the step before outputs
-          # are written. Without this, any non-zero exit from the script terminates
-          # the step immediately and all GITHUB_OUTPUT writes below are skipped —
-          # leaving downstream steps with no status to act on.
+          # check-links.sh now writes:
+          #   - link-check-results.json   (lychee's structured output)
+          #   - link-check-summary.md     (rendered, grouped by source page)
+          #   - link-check-fixme.md       (AI-actionable fix-me prompt)
+          # See scripts/render-link-check-results.mjs for the rendering.
           exit_code=0
-          if [ "$check_type" = "deep" ]; then
-            echo "deep_check=true" >> $GITHUB_OUTPUT
-            ./scripts/check-links.sh "$base_url" true > link-check-results.txt 2>&1 || exit_code=$?
+          if [ "$CHECK_TYPE" = "deep" ]; then
+            ./scripts/check-links.sh "$BASE_URL" true || exit_code=$?
           else
-            echo "deep_check=false" >> $GITHUB_OUTPUT
-            ./scripts/check-links.sh "$base_url" false > link-check-results.txt 2>&1 || exit_code=$?
+            ./scripts/check-links.sh "$BASE_URL" false || exit_code=$?
           fi
 
-          echo "exit_code=$exit_code" >> $GITHUB_OUTPUT
-
-          # Extract the lychee summary line (contains "Total") — more reliable than
-          # tail -n 1 which breaks if lychee emits trailing blank lines.
-          if [ -f link-check-results.txt ]; then
-            summary_line=$(grep -m1 "Total" link-check-results.txt || echo "")
-            echo "summary_line=$summary_line" >> $GITHUB_OUTPUT
-          fi
-
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
           if [ "$exit_code" -eq 0 ]; then
+            echo "status=success" >> "$GITHUB_OUTPUT"
             echo "✅ Link check passed!"
-            echo "status=success" >> $GITHUB_OUTPUT
           else
-            echo "status=failure" >> $GITHUB_OUTPUT
-            echo ""
-            echo "❌ Link check failed — broken links detected:"
-            echo "──────────────────────────────────────────────"
-            grep -E "\[ERROR\]|✗" link-check-results.txt | head -40 || grep -v "^\[" link-check-results.txt | tail -40
-            echo "──────────────────────────────────────────────"
-            echo "Full results are in the uploaded artifact."
+            echo "status=failure" >> "$GITHUB_OUTPUT"
+            echo "❌ Link check failed — see summary below."
           fi
 
       - name: Parse results
         id: parse-results
+        # Read counts directly from the JSON instead of regex-scraping a text
+        # summary. Defaults to 0 when fields are missing so downstream steps
+        # never see empty strings.
         run: |
-          # Use the summary line that was already extracted
-          summary_line="${{ steps.link-check.outputs.summary_line }}"
-          
-          if [ -n "$summary_line" ]; then
-            # Parse the emoji-formatted summary line from lychee output
-            # Format: 🔍 15518 Total (in 20s) ✅ 13867 OK 🚫 0 Errors 👻 1644 Excluded 🔀 7 Redirects
-            
-            # Extract numbers before specific keywords
-            total_links=$(echo "$summary_line" | grep -o "[0-9,]* Total" | grep -o "[0-9,]*" | tr -d ',' || echo "0")
-            ok_links=$(echo "$summary_line" | grep -o "[0-9,]* OK" | grep -o "[0-9,]*" | tr -d ',' || echo "0")
-            errors=$(echo "$summary_line" | grep -o "[0-9,]* Errors" | grep -o "[0-9,]*" | tr -d ',' || echo "0")
-            excluded=$(echo "$summary_line" | grep -o "[0-9,]* Excluded" | grep -o "[0-9,]*" | tr -d ',' || echo "0")
-            redirects=$(echo "$summary_line" | grep -o "[0-9,]* Redirects" | grep -o "[0-9,]*" | tr -d ',' || echo "0")
-            
-            # Ensure values are not empty, default to 0
-            total_links="${total_links:-0}"
-            ok_links="${ok_links:-0}"
-            errors="${errors:-0}"
-            excluded="${excluded:-0}"
-            redirects="${redirects:-0}"
-            
-            echo "total_links=$total_links" >> $GITHUB_OUTPUT
-            echo "ok_links=$ok_links" >> $GITHUB_OUTPUT
-            echo "errors=$errors" >> $GITHUB_OUTPUT
-            echo "excluded=$excluded" >> $GITHUB_OUTPUT
-            echo "redirects=$redirects" >> $GITHUB_OUTPUT
-            
-            echo "Results Summary:"
-            echo "Total links checked: ${total_links}"
-            echo "OK links: ${ok_links}"
-            echo "Errors found: ${errors}"
-            echo "Links excluded: ${excluded}"
-            echo "Redirects followed: ${redirects}"
-            echo ""
-            echo "Lychee Summary: $summary_line"
-          else
-            # Fallback to zeros if no summary found
-            echo "total_links=0" >> $GITHUB_OUTPUT
-            echo "ok_links=0" >> $GITHUB_OUTPUT
-            echo "errors=0" >> $GITHUB_OUTPUT
-            echo "excluded=0" >> $GITHUB_OUTPUT
-            echo "redirects=0" >> $GITHUB_OUTPUT
-            echo "Warning: Could not parse lychee summary"
+          if [ ! -f link-check-results.json ]; then
+            echo "Warning: link-check-results.json not found"
+            for k in total ok errors excluded redirects; do
+              echo "${k}=0" >> "$GITHUB_OUTPUT"
+            done
+            exit 0
           fi
+
+          total=$(jq -r '.total // 0' link-check-results.json)
+          ok=$(jq -r '.successful // 0' link-check-results.json)
+          errors=$(jq -r '.errors // 0' link-check-results.json)
+          excluded=$(jq -r '.excludes // 0' link-check-results.json)
+          redirects=$(jq -r '.redirects // 0' link-check-results.json)
+
+          {
+            echo "total=$total"
+            echo "ok=$ok"
+            echo "errors=$errors"
+            echo "excluded=$excluded"
+            echo "redirects=$redirects"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "Total: $total | OK: $ok | Errors: $errors | Excluded: $excluded | Redirects: $redirects"
 
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: link-check-results-${{ steps.params.outputs.check_type }}
-          path: link-check-results.txt
+          # Bundle all three artifacts: the raw JSON (for downstream tooling
+          # and AI agents), the rendered markdown summary (so reviewers can
+          # read the failure without unzipping), and the AI fix-me prompt
+          # (drop into a Claude/GPT context to attempt automated fixes).
+          path: |
+            link-check-results.json
+            link-check-summary.md
+            link-check-fixme.md
           retention-days: 30
+          if-no-files-found: warn
 
       - name: Create job summary
         if: always()
+        # Inline the rendered markdown summary directly so reviewers see the
+        # broken-link table on the run page — no clicking through to artifacts.
         run: |
-          echo "# Link Check Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Check Type:** ${{ steps.params.outputs.check_type }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Base URL:** ${{ steps.params.outputs.base_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Status:** ${{ steps.link-check.outputs.status }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          # Display the lychee summary with all metrics
-          if [ -n "${{ steps.link-check.outputs.summary_line }}" ]; then
-            echo "## Summary" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.link-check.outputs.summary_line }}" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          if [ "${{ steps.link-check.outputs.status }}" = "failure" ]; then
-            echo "## ❌ Broken Links Found" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The following errors were detected:" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            grep -E "\[ERROR\]|✗" link-check-results.txt | head -40 >> $GITHUB_STEP_SUMMARY || true
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "📄 Full results are available in the uploaded artifact." >> $GITHUB_STEP_SUMMARY
-          elif [ "${{ steps.link-check.outputs.status }}" = "success" ]; then
-            echo "## ✅ All Links Working" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "No broken links were found! 🎉" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "**Check Type:** ${CHECK_TYPE}"
+            echo "**Base URL:** ${BASE_URL}"
+            echo "**Status:** ${STATUS}"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -f link-check-summary.md ]; then
+            cat link-check-summary.md >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "## ⚠️ Link Check Did Not Complete" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "The link check step failed before producing results. Check the step log for details." >> $GITHUB_STEP_SUMMARY
+            echo "## ⚠️ Link Check Did Not Complete" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No \`link-check-summary.md\` was produced. Check the run log for details." >> "$GITHUB_STEP_SUMMARY"
           fi
+        env:
+          CHECK_TYPE: ${{ steps.params.outputs.check_type }}
+          BASE_URL: ${{ steps.params.outputs.base_url }}
+          STATUS: ${{ steps.link-check.outputs.status }}
 
       - name: Create GitHub issue for broken links
         if: always() && steps.link-check.outputs.status == 'failure' && github.event_name == 'schedule'
@@ -223,51 +187,55 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const results = fs.readFileSync('link-check-results.txt', 'utf8');
-            const errors = results.split('\n').filter(line => line.includes('[ERROR]') || line.includes('\u2717'));
-            
-            const issueBody = `
-            # 🔗 Broken Links Detected
-            
-            The nightly link check found **${{ steps.parse-results.outputs.errors }}** broken links on the site.
-            
-            ## Summary
-            - **Total Links Checked:** ${{ steps.parse-results.outputs.total_links }}
-            - **OK Links:** ${{ steps.parse-results.outputs.ok_links }}
-            - **Errors Found:** ${{ steps.parse-results.outputs.errors }}
-            - **Links Excluded:** ${{ steps.parse-results.outputs.excluded }}
-            - **Redirects Followed:** ${{ steps.parse-results.outputs.redirects }}
-            - **Check Type:** ${{ steps.params.outputs.check_type }}
-            - **Base URL:** ${{ steps.params.outputs.base_url }}
-            
-            ## ❌ Broken Links
-            
-            \`\`\`
-            ${errors.slice(0, 30).join('\n')}
-            ${errors.length > 30 ? '\n... and ' + (errors.length - 30) + ' more errors' : ''}
-            \`\`\`
-            
-            ## Next Steps
-            
-            1. Review the full results in the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            2. Fix or exclude the broken links
-            3. Run \`pnpm links:check:deep\` locally to verify fixes
-            
-            ---
-            
-            *This issue was automatically created by the nightly link checker.*
-            `;
-            
+            const summary = fs.existsSync('link-check-summary.md')
+              ? fs.readFileSync('link-check-summary.md', 'utf8')
+              : '_(no summary produced)_';
+            const fixmePresent = fs.existsSync('link-check-fixme.md');
+
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const errors = process.env.ERRORS;
+            const checkType = process.env.CHECK_TYPE;
+            const baseUrl = process.env.BASE_URL;
+
+            const issueBody = [
+              '# \ud83d\udd17 Broken Links Detected',
+              '',
+              `The nightly link check found **${errors}** broken links.`,
+              '',
+              `**Check Type:** ${checkType}`,
+              `**Base URL:** ${baseUrl}`,
+              '',
+              summary,
+              '',
+              '## Next Steps',
+              '',
+              `1. Inspect the [workflow run](${runUrl}) \u2014 the full per-page table is in the run summary.`,
+              `2. Download the run's artifact (\`link-check-results.json\` for tooling, \`link-check-fixme.md\` for an AI-actionable prompt${fixmePresent ? '' : ' [missing this run]'}).`,
+              '3. Fix or exclude the broken links \u2014 see `scripts/check-links.sh` for the exclusion conventions.',
+              '4. Verify locally: `pnpm links:check:local`.',
+              '',
+              '---',
+              '',
+              '_This issue was automatically created by the nightly link checker._',
+            ].join('\n');
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: `Broken Links Detected (${{ steps.parse-results.outputs.errors }} errors)`,
+              title: `Broken Links Detected (${errors} errors)`,
               body: issueBody,
               labels: ['bug', 'documentation', 'automated']
             });
+        env:
+          ERRORS: ${{ steps.parse-results.outputs.errors }}
+          CHECK_TYPE: ${{ steps.params.outputs.check_type }}
+          BASE_URL: ${{ steps.params.outputs.base_url }}
 
       - name: Fail workflow if links are broken
         if: always() && steps.link-check.outputs.status == 'failure'
+        env:
+          ERRORS: ${{ steps.parse-results.outputs.errors }}
         run: |
-          echo "❌ Link check failed with ${{ steps.parse-results.outputs.errors }} broken links"
-          exit 1 
+          echo "Link check failed with ${ERRORS} broken links"
+          exit 1
+

--- a/scripts/check-links.sh
+++ b/scripts/check-links.sh
@@ -126,9 +126,18 @@ mv "${url_list}.pages" "$url_list"
 # ── Build lychee command with appropriate options ─────────────────────────────
 # Use an array to properly handle arguments and avoid word splitting issues
 # This prevents problems with spaces and special characters in arguments
+#
+# OUTPUT: We always write structured JSON to RESULTS_JSON below. The companion
+# script `scripts/render-link-check-results.mjs` reads it to produce the
+# human-readable summary (and the AI-actionable fix-me prompt). Doing this in
+# two passes keeps lychee responsible for the network work and keeps the
+# rendering decoupled and easy to evolve.
+RESULTS_JSON="${RESULTS_JSON:-link-check-results.json}"
 lychee_cmd=(
   lychee
-  --verbose                # Show detailed progress
+  --no-progress            # Quiet stdout; structured output goes to file
+  --format json
+  --output "$RESULTS_JSON"
   --max-redirects 10       # Follow up to 10 redirects
   --max-concurrency 8      # Limit concurrent requests to avoid rate limiting
 )
@@ -208,16 +217,33 @@ if [ "$DEEP_CHECK" = "true" ]; then
     --include-fragments
     --include-verbatim
   )
-  
+
   echo "Restricting to base URL: $BASE_URL"
   lychee_cmd+=( --base-url "$BASE_URL" )
-  
+
   # Pass URLs directly to lychee (not as a file) so it crawls their content
   echo "Found $(wc -l < "$url_list") pages to crawl..."
-  "${lychee_cmd[@]}" $(cat "$url_list")
+  # Use `|| lychee_exit=$?` so set -e doesn't abort before we render results.
+  # When lychee finds broken links it exits non-zero; we still want to print
+  # the summary and re-exit with that same code at the end.
+  lychee_exit=0
+  "${lychee_cmd[@]}" $(cat "$url_list") || lychee_exit=$?
 else
   echo "Running sitemap-only link check..."
-  "${lychee_cmd[@]}" "$url_list"
+  lychee_exit=0
+  "${lychee_cmd[@]}" "$url_list" || lychee_exit=$?
 fi
 
 rm -rf "$tmp_dir"
+
+# ── Render the JSON results into human + AI artifacts ────────────────────────
+# Always run, even on lychee failure — the failure case is precisely when the
+# rendered summary is most valuable (the workflow log otherwise shows nothing
+# actionable; see scripts/render-link-check-results.mjs).
+if [ -f "$RESULTS_JSON" ]; then
+  node "$(dirname "$0")/render-link-check-results.mjs" "$RESULTS_JSON" \
+    --summary-md link-check-summary.md \
+    --fixme-md link-check-fixme.md
+fi
+
+exit "$lychee_exit"

--- a/scripts/render-link-check-results.mjs
+++ b/scripts/render-link-check-results.mjs
@@ -175,12 +175,8 @@ if (args['fixme-md']) {
   lines.push('');
   lines.push('## Triage rubric');
   lines.push('');
-  lines.push(
-    '| Category | What it means | Suggested action |',
-  );
-  lines.push(
-    '| --- | --- | --- |',
-  );
+  lines.push('| Category | What it means | Suggested action |');
+  lines.push('| --- | --- | --- |');
   lines.push(
     '| `broken` (404, 410) | Target page is gone | Find the source `.mdx` file (`grep -rn "<URL>" docs/`), update the link to the new location or remove it. |',
   );

--- a/scripts/render-link-check-results.mjs
+++ b/scripts/render-link-check-results.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+
+/**
+ * render-link-check-results.mjs
+ *
+ * Reads lychee's JSON output (link-check-results.json) and produces:
+ *   - A human-readable summary on stdout
+ *   - A markdown summary grouped by source page (--summary-md FILE)
+ *   - An AI-actionable fix-me prompt with full context (--fixme-md FILE)
+ *
+ * Why all three:
+ *   - stdout output keeps `pnpm links:check` useful at the terminal
+ *   - The markdown file goes into $GITHUB_STEP_SUMMARY so failing runs show
+ *     the broken-link list inline (no clicking through to artifacts)
+ *   - The fixme file is a self-contained prompt an agent can be pointed at
+ *     to attempt fixes — it includes status codes, source URLs, suggested
+ *     remediation categories, and pointers to the project files an agent
+ *     would edit
+ *
+ * Usage:
+ *   node scripts/render-link-check-results.mjs <results.json> [options]
+ *
+ * Options:
+ *   --summary-md FILE   Write the grouped-by-source markdown to FILE
+ *   --fixme-md FILE     Write the AI-actionable fix-me prompt to FILE
+ *   --quiet             Suppress stdout summary
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { parseArgs } from 'node:util';
+
+const { values: args, positionals } = parseArgs({
+  options: {
+    'summary-md': { type: 'string' },
+    'fixme-md': { type: 'string' },
+    quiet: { type: 'boolean', default: false },
+  },
+  allowPositionals: true,
+});
+
+const jsonPath = positionals[0];
+if (!jsonPath) {
+  console.error('Usage: render-link-check-results.mjs <results.json> [opts]');
+  process.exit(2);
+}
+if (!fs.existsSync(jsonPath)) {
+  console.error(`Results file not found: ${jsonPath}`);
+  process.exit(2);
+}
+
+const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+
+// ── Build a unified error list from lychee's source-keyed map ──────────────
+// lychee's `error_map` shape: { "<source-path-or-url>": [{ url, status: { text, code? } }, ...] }
+// The "source" is whichever input lychee was given that contained the broken
+// link — for our deep-mode runs that's a page URL like
+// `https://developers.glean.com/foo`; for sitemap-only it's a path on disk.
+const errorMap = data.error_map ?? {};
+const sources = Object.keys(errorMap).sort();
+const totalErrorLinks = sources.reduce(
+  (acc, src) => acc + errorMap[src].length,
+  0,
+);
+
+function statusFor(entry) {
+  const s = entry.status ?? {};
+  if (s.code) return `${s.code} ${s.text ?? ''}`.trim();
+  return s.text ?? 'error';
+}
+
+// Group status codes into an action category so the fix-me prompt can suggest
+// a remediation strategy without an LLM having to infer it from raw codes.
+function category(entry) {
+  const code = entry.status?.code;
+  const text = (entry.status?.text ?? '').toLowerCase();
+  if (code === 404 || code === 410) return 'broken'; // page is gone — fix or remove
+  if (code === 429) return 'rate-limited'; // transient — usually retry / exclude host
+  if (code === 401 || code === 403) return 'auth-required'; // exclude or use a public mirror
+  if (code && code >= 500 && code < 600) return 'server-error'; // upstream issue, often transient
+  if (text.includes('timeout') || text.includes('connection')) return 'network';
+  return 'other';
+}
+
+// ── stdout summary ──────────────────────────────────────────────────────────
+if (!args.quiet) {
+  console.log('');
+  console.log('Link check summary');
+  console.log('──────────────────');
+  console.log(`  Total links checked: ${data.total ?? '?'}`);
+  console.log(`  OK:                  ${data.successful ?? '?'}`);
+  console.log(`  Errors:              ${data.errors ?? '?'}`);
+  console.log(`  Excluded:            ${data.excludes ?? '?'}`);
+  console.log(`  Redirects:           ${data.redirects ?? '?'}`);
+  console.log(`  Duration:            ${data.duration_secs ?? '?'}s`);
+  if (totalErrorLinks > 0) {
+    console.log('');
+    console.log(
+      `❌ ${totalErrorLinks} broken link${totalErrorLinks === 1 ? '' : 's'} across ${sources.length} source page${sources.length === 1 ? '' : 's'}:`,
+    );
+    for (const src of sources) {
+      console.log(`  ${src}`);
+      for (const entry of errorMap[src]) {
+        console.log(`    └─ ${statusFor(entry)}  ${entry.url}`);
+      }
+    }
+  } else {
+    console.log('');
+    console.log('✅ No broken links.');
+  }
+}
+
+// ── Markdown summary (grouped by source) ───────────────────────────────────
+if (args['summary-md']) {
+  const lines = [];
+  lines.push('# Link check results');
+  lines.push('');
+  lines.push('| Total | OK | Errors | Excluded | Redirects | Duration |');
+  lines.push('| --- | --- | --- | --- | --- | --- |');
+  lines.push(
+    `| ${data.total ?? '?'} | ${data.successful ?? '?'} | **${data.errors ?? '?'}** | ${data.excludes ?? '?'} | ${data.redirects ?? '?'} | ${data.duration_secs ?? '?'}s |`,
+  );
+  lines.push('');
+
+  if (totalErrorLinks === 0) {
+    lines.push('✅ No broken links found.');
+  } else {
+    lines.push(
+      `## ❌ ${totalErrorLinks} broken link${totalErrorLinks === 1 ? '' : 's'} across ${sources.length} source page${sources.length === 1 ? '' : 's'}`,
+    );
+    lines.push('');
+    for (const src of sources) {
+      const errs = errorMap[src];
+      lines.push(`### \`${src}\``);
+      lines.push('');
+      lines.push('| Status | URL |');
+      lines.push('| --- | --- |');
+      for (const entry of errs) {
+        const url = entry.url.replace(/\|/g, '\\|');
+        lines.push(`| \`${statusFor(entry)}\` | ${url} |`);
+      }
+      lines.push('');
+    }
+  }
+  fs.writeFileSync(args['summary-md'], lines.join('\n'), 'utf8');
+}
+
+// ── AI fix-me prompt ───────────────────────────────────────────────────────
+// Self-contained: an agent can be handed this file and have everything it
+// needs to investigate and propose fixes. Encodes project-specific knowledge
+// (where to add exclusions, how to verify locally) so the agent doesn't have
+// to rediscover it.
+if (args['fixme-md']) {
+  const lines = [];
+  lines.push('# Link checker failures — fix request');
+  lines.push('');
+  lines.push(
+    'You are an AI agent looking at the output of the nightly link checker for the Glean developer site. Your job is to triage each broken link and either (a) fix it in the source content, (b) add an exclusion to `scripts/check-links.sh` if it cannot be checked automatically, or (c) flag it as a transient/upstream issue requiring no code change.',
+  );
+  lines.push('');
+  lines.push('## How the checker is wired');
+  lines.push('');
+  lines.push(
+    '- The workflow is `.github/workflows/link-checker.yml`. It runs `scripts/check-links.sh` which invokes `lychee` against the production sitemap.',
+  );
+  lines.push(
+    '- Permanent exclusions (auth-required hosts, example domains, internal-only sites) live in `scripts/check-links.sh` in the `lychee_cmd+=(...)` blocks. Each exclusion has an inline comment explaining why.',
+  );
+  lines.push(
+    '- Temporary exclusions go in the marked `# ── TEMPORARY EXCLUSIONS ──` block in the same script, with a `# REASON: ... (added YYYY-MM-DD)` comment.',
+  );
+  lines.push(
+    '- Local verification: `pnpm links:check:local` (does a production build, serves on port 8888, and runs the checker).',
+  );
+  lines.push('');
+  lines.push('## Triage rubric');
+  lines.push('');
+  lines.push(
+    '| Category | What it means | Suggested action |',
+  );
+  lines.push(
+    '| --- | --- | --- |',
+  );
+  lines.push(
+    '| `broken` (404, 410) | Target page is gone | Find the source `.mdx` file (`grep -rn "<URL>" docs/`), update the link to the new location or remove it. |',
+  );
+  lines.push(
+    '| `rate-limited` (429) | Host blocked us | Usually transient. If the host repeatedly rate-limits, add a permanent exclusion for that host. |',
+  );
+  lines.push(
+    '| `auth-required` (401, 403) | Host requires login | Add a permanent exclusion in `scripts/check-links.sh`. |',
+  );
+  lines.push(
+    '| `server-error` (5xx) | Upstream is broken | Usually transient. If repeated across runs, exclude the host or open an issue with the host. |',
+  );
+  lines.push(
+    '| `network` / `other` | Timeout, DNS, etc. | Re-run the check. If persistent, exclude the host.',
+  );
+  lines.push('');
+
+  if (totalErrorLinks === 0) {
+    lines.push('## Failures');
+    lines.push('');
+    lines.push('_No broken links — nothing to fix._');
+  } else {
+    lines.push(
+      `## Failures (${totalErrorLinks} broken link${totalErrorLinks === 1 ? '' : 's'} across ${sources.length} source page${sources.length === 1 ? '' : 's'})`,
+    );
+    lines.push('');
+    for (const src of sources) {
+      const errs = errorMap[src];
+      // Try to derive the .mdx file path. Site URLs map to docs/<path>.mdx
+      // (or docs/<path>/index.mdx). The agent should still grep, but this
+      // hint helps narrow the search.
+      const sourceHint = src.startsWith('http')
+        ? src.replace(/^https?:\/\/[^/]+\/?/, '').replace(/\/$/, '') ||
+          '<homepage>'
+        : src;
+      lines.push(`### Source: \`${src}\``);
+      lines.push('');
+      lines.push(
+        `_Likely lives at_ \`docs/${sourceHint}.mdx\` _or_ \`docs/${sourceHint}/index.mdx\``,
+      );
+      lines.push('');
+      for (const entry of errs) {
+        lines.push(
+          `- **${statusFor(entry)}** \`${category(entry)}\` — \`${entry.url}\``,
+        );
+      }
+      lines.push('');
+    }
+  }
+  fs.writeFileSync(args['fixme-md'], lines.join('\n'), 'utf8');
+}


### PR DESCRIPTION
## Summary

Today's link-checker workflow makes failures opaque. When the nightly run trips, the workflow log shows ~40 grep-matched lines and the actual content (which page contains which broken link) lives in an uploaded artifact behind two click-throughs. There's no source attribution, no triage hints, and the lychee text-summary parsing is fragile.

Phase 1 of two PRs to make link-check failures self-explanatory and AI-consumable.

### What changes

1. **`scripts/check-links.sh`** invokes lychee with `--format json --output link-check-results.json --no-progress`. Lychee's `error_map` is keyed by source page URL with structured status codes — no more regex scraping.

2. **`scripts/render-link-check-results.mjs`** (new) reads the JSON and produces three artifacts:
   - **Stdout summary** — keeps `pnpm links:check` useful at the terminal.
   - **`link-check-summary.md`** — markdown grouped by source page, with per-page tables of broken URLs.
   - **`link-check-fixme.md`** — a self-contained AI-actionable prompt: the failures, a triage rubric (broken / rate-limited / auth-required / server-error / network), and pointers to where exclusions belong in `check-links.sh`, how to verify locally, etc. Drop into a Claude/GPT context to attempt automated fixes.

3. **`.github/workflows/link-checker.yml`**:
   - Reads counts from the JSON via `jq` (no more regex-scraping).
   - **Inlines the markdown summary directly into `$GITHUB_STEP_SUMMARY`**, so reviewers see the broken-link tables on the run page — no clicking through to artifacts.
   - Uploads all three artifacts (JSON, summary, fixme).
   - Hardens user-input handling: `workflow_dispatch` inputs (`base_url`, `check_type`) flow through `env:` rather than shell-interpolated `${{ }}`, closing the workflow-injection vector flagged by the security guidance.

### Test plan

- [x] Renderer test against synthetic JSON with 4 broken links across 2 pages — stdout, summary.md, and fixme.md all render correctly with grouped output.
- [x] `bash -n scripts/check-links.sh` and `node --check scripts/render-link-check-results.mjs` both pass.
- [x] `yq eval '.jobs."link-check".steps | length'` parses cleanly (13 steps).
- [ ] Trigger the workflow manually and verify the run page shows the inlined summary table.
- [ ] Verify a failing run produces the fixme.md artifact correctly.

### Follow-up (separate PR)

Phase 2 adds a skill (`.claude/skills/fix-broken-links/SKILL.md` or extension to `AGENTS.md`) so an AI agent pointed at a failing run knows the project conventions for adding exclusions, finding source files, and verifying fixes. The fixme.md from this PR becomes the agent's input; the skill becomes its operating manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)