### PR TITLE
feat(mcp): add Supported MCP Hosts page

### DIFF
--- a/docs/guides/mcp/supported-hosts.mdx
+++ b/docs/guides/mcp/supported-hosts.mdx
@@ -1,0 +1,15 @@
+---
+title: 'Supported MCP Hosts'
+description: 'Every MCP host application that can connect to Glean, filterable by type and installability.'
+hide_table_of_contents: false
+---
+
+import { McpHostsList } from '@theme/McpHosts';
+
+Glean works with a wide range of MCP host applications — IDEs, CLIs, desktop apps, and web apps. Filter by how a host is installed (user-installable vs. admin-managed) or by client type, or search by name. Each card links to that host's official documentation.
+
+<McpHostsList />
+
+:::info
+This list covers the hosts we've explicitly tested and documented. Glean works with **any MCP-spec-compliant client** — in the MCP Configurator, choose **Custom** and connect using your Glean MCP server URL.
+:::

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "@docusaurus/utils-validation": "^3.10.0",
     "@gleanwork/api-client": "^0.13.4",
     "@gleanwork/docusaurus-theme-glean": "workspace:*",
-    "@gleanwork/mcp-config-schema": "^4.3.0",
+    "@gleanwork/mcp-config-schema": "^5.2.0",
     "@intercom/messenger-js-sdk": "^0.0.19",
     "@mdx-js/react": "^3.0.0",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.1.0",

--- a/packages/docusaurus-theme-glean/package.json
+++ b/packages/docusaurus-theme-glean/package.json
@@ -12,7 +12,8 @@
     "./Steps": "./src/theme/Steps/index.tsx",
     "./Frame": "./src/theme/Frame/index.tsx",
     "./Icons": "./src/theme/Icons/index.tsx",
-    "./Details": "./src/theme/Details/index.tsx"
+    "./Details": "./src/theme/Details/index.tsx",
+    "./McpHosts": "./src/theme/McpHosts/index.tsx"
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.0",
@@ -21,6 +22,7 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
+    "@gleanwork/mcp-config-schema": "^5.2.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "react-feather": "^2.0.10"

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostIcon.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostIcon.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { getClientIcon, type ClientId } from '@gleanwork/mcp-config-schema/browser';
+
+interface McpHostIconProps {
+  /** Registry client id — renders the icon shipped in @gleanwork/mcp-config-schema. */
+  clientId?: string;
+  /** Explicit image source (for hosts without a packaged icon). */
+  imgSrc?: string;
+  /** Accessible label / monogram source. */
+  alt: string;
+  size?: number;
+}
+
+/** All hex colors referenced anywhere in the SVG (attributes, `<style>` blocks, stops). */
+function hexColors(svg: string): string[] {
+  return (svg.match(/#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/g) ?? []).map((h) => h.toLowerCase());
+}
+
+/** A hex is "dark" when every channel is low — i.e. a near-black mark that vanishes in dark mode. */
+function isDark(hex: string): boolean {
+  const h = hex.slice(1);
+  const full = h.length === 3 ? h.replace(/(.)/g, '$1$1') : h;
+  const r = parseInt(full.slice(0, 2), 16);
+  const g = parseInt(full.slice(2, 4), 16);
+  const b = parseInt(full.slice(4, 6), 16);
+  return Math.max(r, g, b) < 0x60;
+}
+
+/**
+ * Decide whether a mark should adapt to the theme via `currentColor`.
+ * Preserve gradients and brand-colored marks; recolor only genuinely dark or
+ * color-less marks (which would otherwise disappear in dark mode).
+ */
+function shouldRecolor(svg: string): boolean {
+  if (/gradient|url\(#/i.test(svg)) return false;
+  const colors = hexColors(svg).filter((h) => h !== '#fff' && h !== '#ffffff');
+  if (colors.length === 0) return true;
+  return colors.every(isDark);
+}
+
+/** Rewrite dark/absent fills+strokes to `currentColor` (attributes, styles, and fill-less paths). */
+function recolor(svg: string): string {
+  return svg
+    .replace(/fill="(?!none")[^"]*"/gi, 'fill="currentColor"')
+    .replace(/stroke="(?!none")[^"]*"/gi, 'stroke="currentColor"')
+    .replace(/fill:\s*[^;"}]+/gi, 'fill:currentColor')
+    .replace(/stroke:\s*[^;"}]+/gi, 'stroke:currentColor')
+    .replace(/<path\b(?![^>]*\bfill=)/gi, '<path fill="currentColor"');
+}
+
+/** Make the root <svg> fill its (sized) container, merging into any existing root style. */
+function fitToBox(svg: string): string {
+  const sizing = 'width:100%;height:100%;display:block';
+  if (/<svg\b[^>]*\bstyle="/i.test(svg)) {
+    return svg.replace(/(<svg\b[^>]*\bstyle=")/i, `$1${sizing};`);
+  }
+  return svg.replace(/<svg\b/i, `<svg style="${sizing}"`);
+}
+
+export default function McpHostIcon({ clientId, imgSrc, alt, size = 24 }: McpHostIconProps) {
+  if (imgSrc) {
+    return (
+      <img
+        src={imgSrc}
+        alt={alt}
+        width={size}
+        height={size}
+        style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+      />
+    );
+  }
+
+  const raw = clientId ? getClientIcon(clientId as ClientId) : undefined;
+
+  if (!raw) {
+    return (
+      <span
+        aria-hidden
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: '100%',
+          height: '100%',
+          borderRadius: 6,
+          background: 'var(--ifm-color-emphasis-200)',
+          fontWeight: 600,
+        }}
+      >
+        {alt.charAt(0)}
+      </span>
+    );
+  }
+
+  const svg = fitToBox(shouldRecolor(raw) ? recolor(raw) : raw);
+
+  return (
+    <span
+      aria-hidden
+      style={{ display: 'inline-flex', width: '100%', height: '100%' }}
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+}

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostIcon.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostIcon.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { getClientIcon, type ClientId } from '@gleanwork/mcp-config-schema/browser';
+import {
+  getClientIcon,
+  type ClientId,
+} from '@gleanwork/mcp-config-schema/browser';
 
 interface McpHostIconProps {
   /** Registry client id — renders the icon shipped in @gleanwork/mcp-config-schema. */
@@ -13,7 +16,9 @@ interface McpHostIconProps {
 
 /** All hex colors referenced anywhere in the SVG (attributes, `<style>` blocks, stops). */
 function hexColors(svg: string): string[] {
-  return (svg.match(/#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/g) ?? []).map((h) => h.toLowerCase());
+  return (svg.match(/#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/g) ?? []).map((h) =>
+    h.toLowerCase(),
+  );
 }
 
 /** A hex is "dark" when every channel is low — i.e. a near-black mark that vanishes in dark mode. */
@@ -57,7 +62,12 @@ function fitToBox(svg: string): string {
   return svg.replace(/<svg\b/i, `<svg style="${sizing}"`);
 }
 
-export default function McpHostIcon({ clientId, imgSrc, alt, size = 24 }: McpHostIconProps) {
+export default function McpHostIcon({
+  clientId,
+  imgSrc,
+  alt,
+  size = 24,
+}: McpHostIconProps) {
   if (imgSrc) {
     return (
       <img

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.module.css
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.module.css
@@ -1,0 +1,96 @@
+.root {
+  margin: 1.5rem 0;
+}
+
+.filterBar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 1rem 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 10px;
+  background: var(--ifm-background-surface-color);
+}
+
+.facet {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.facetLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1 1 12rem;
+  min-width: 10rem;
+}
+
+.searchInput {
+  padding: 0.35rem 0.65rem;
+  font-size: 0.9rem;
+  color: var(--ifm-font-color-base);
+  background: var(--ifm-background-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 6px;
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--ifm-color-primary);
+  box-shadow: 0 0 0 2px var(--ifm-color-primary-lightest);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
+.count {
+  font-size: 0.85rem;
+  color: var(--ifm-color-emphasis-600);
+  white-space: nowrap;
+}
+
+.empty {
+  padding: 2rem 0;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.cardPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.cardPill {
+  padding: 0.2rem 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: var(--ifm-color-emphasis-700);
+  background: var(--ifm-color-emphasis-100);
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: 999px;
+}

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
@@ -45,7 +45,9 @@ function buildHosts(): McpHost[] {
     documentationUrl: c.documentationUrl,
   }));
   return [...fromRegistry, ...EXTRA_HOSTS].sort((a, b) =>
-    a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }),
+    a.displayName.localeCompare(b.displayName, undefined, {
+      sensitivity: 'base',
+    }),
   );
 }
 
@@ -67,7 +69,12 @@ interface ChipGroupProps<T extends string> {
   onChange: (value: T) => void;
 }
 
-function ChipGroup<T extends string>({ label, value, options, onChange }: ChipGroupProps<T>) {
+function ChipGroup<T extends string>({
+  label,
+  value,
+  options,
+  onChange,
+}: ChipGroupProps<T>) {
   return (
     <div className={styles.facet}>
       <span className={styles.facetLabel}>{label}</span>
@@ -103,7 +110,10 @@ export interface McpHostsListProps {
  * (plus a small set of extras) with live filtering by installability, client
  * type, and name. Each card links to the host's official documentation.
  */
-export default function McpHostsList({ defaultInstall = 'all', cols = 3 }: McpHostsListProps) {
+export default function McpHostsList({
+  defaultInstall = 'all',
+  cols = 3,
+}: McpHostsListProps) {
   const [install, setInstall] = useState<InstallFilter>(defaultInstall);
   const [type, setType] = useState<TypeFilter>('all');
   const [query, setQuery] = useState('');
@@ -126,7 +136,8 @@ export default function McpHostsList({ defaultInstall = 'all', cols = 3 }: McpHo
     );
   }, [install, type, query]);
 
-  const hasActiveFilters = install !== defaultInstall || type !== 'all' || query !== '';
+  const hasActiveFilters =
+    install !== defaultInstall || type !== 'all' || query !== '';
 
   return (
     <div className={styles.root}>
@@ -137,7 +148,12 @@ export default function McpHostsList({ defaultInstall = 'all', cols = 3 }: McpHo
           options={INSTALL_OPTIONS}
           onChange={setInstall}
         />
-        <ChipGroup<TypeFilter> label="Type" value={type} options={typeOptions} onChange={setType} />
+        <ChipGroup<TypeFilter>
+          label="Type"
+          value={type}
+          options={typeOptions}
+          onChange={setType}
+        />
         <div className={styles.search}>
           <span className={styles.facetLabel}>Search</span>
           <input

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
@@ -1,0 +1,197 @@
+import React, { useMemo, useState } from 'react';
+import clsx from 'clsx';
+import Card from '../Card';
+import CardGroup from '../CardGroup';
+import {
+  MCPConfigRegistry,
+  CLIENT_TYPES,
+  TYPE_LABELS,
+  type ClientType,
+} from '@gleanwork/mcp-config-schema/browser';
+import McpHostIcon from './McpHostIcon';
+import styles from './McpHostsList.module.css';
+
+interface McpHost {
+  id: string;
+  displayName: string;
+  types: readonly ClientType[];
+  userConfigurable: boolean;
+  documentationUrl?: string;
+}
+
+/**
+ * Hosts not (yet) in @gleanwork/mcp-config-schema but supported in docs.
+ * Merged into the registry-driven list so the grid stays complete.
+ */
+const EXTRA_HOSTS: McpHost[] = [
+  {
+    id: 'copilot-studio',
+    displayName: 'Microsoft Copilot Studio',
+    types: ['web'],
+    userConfigurable: false,
+    documentationUrl:
+      'https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent',
+  },
+];
+
+/** All supported hosts (registry + extras), sorted alphabetically by display name. */
+function buildHosts(): McpHost[] {
+  const registry = new MCPConfigRegistry();
+  const fromRegistry: McpHost[] = registry.getAllConfigs().map((c) => ({
+    id: c.id,
+    displayName: c.displayName,
+    types: c.types,
+    userConfigurable: c.userConfigurable,
+    documentationUrl: c.documentationUrl,
+  }));
+  return [...fromRegistry, ...EXTRA_HOSTS].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName, undefined, { sensitivity: 'base' }),
+  );
+}
+
+const HOSTS = buildHosts();
+
+type InstallFilter = 'all' | 'user' | 'admin';
+type TypeFilter = 'all' | ClientType;
+
+const INSTALL_OPTIONS: { value: InstallFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'user', label: 'User-installable' },
+  { value: 'admin', label: 'Admin-managed' },
+];
+
+interface ChipGroupProps<T extends string> {
+  label: string;
+  value: T;
+  options: { value: T; label: string }[];
+  onChange: (value: T) => void;
+}
+
+function ChipGroup<T extends string>({ label, value, options, onChange }: ChipGroupProps<T>) {
+  return (
+    <div className={styles.facet}>
+      <span className={styles.facetLabel}>{label}</span>
+      <div className={styles.chips} role="group" aria-label={label}>
+        {options.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            className={clsx(
+              'button button--sm',
+              value === opt.value ? 'button--primary' : 'button--secondary',
+            )}
+            aria-pressed={value === opt.value}
+            onClick={() => onChange(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export interface McpHostsListProps {
+  /** Pre-applies the installability filter (users can still change it). */
+  defaultInstall?: InstallFilter;
+  /** Cards per row. */
+  cols?: number;
+}
+
+/**
+ * Renders the full set of supported MCP hosts from @gleanwork/mcp-config-schema
+ * (plus a small set of extras) with live filtering by installability, client
+ * type, and name. Each card links to the host's official documentation.
+ */
+export default function McpHostsList({ defaultInstall = 'all', cols = 3 }: McpHostsListProps) {
+  const [install, setInstall] = useState<InstallFilter>(defaultInstall);
+  const [type, setType] = useState<TypeFilter>('all');
+  const [query, setQuery] = useState('');
+
+  const typeOptions: { value: TypeFilter; label: string }[] = useMemo(
+    () => [
+      { value: 'all', label: 'All' },
+      ...CLIENT_TYPES.map((t) => ({ value: t, label: TYPE_LABELS[t] })),
+    ],
+    [],
+  );
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return HOSTS.filter(
+      (h) =>
+        (install === 'all' || h.userConfigurable === (install === 'user')) &&
+        (type === 'all' || h.types.includes(type)) &&
+        (q === '' || h.displayName.toLowerCase().includes(q)),
+    );
+  }, [install, type, query]);
+
+  const hasActiveFilters = install !== defaultInstall || type !== 'all' || query !== '';
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.filterBar}>
+        <ChipGroup<InstallFilter>
+          label="Install"
+          value={install}
+          options={INSTALL_OPTIONS}
+          onChange={setInstall}
+        />
+        <ChipGroup<TypeFilter> label="Type" value={type} options={typeOptions} onChange={setType} />
+        <div className={styles.search}>
+          <span className={styles.facetLabel}>Search</span>
+          <input
+            type="search"
+            className={styles.searchInput}
+            placeholder="Filter by name…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Filter hosts by name"
+          />
+        </div>
+        <div className={styles.meta}>
+          <span className={styles.count}>
+            {visible.length} of {HOSTS.length}
+          </span>
+          {hasActiveFilters && (
+            <button
+              type="button"
+              className="button button--sm button--secondary"
+              onClick={() => {
+                setInstall(defaultInstall);
+                setType('all');
+                setQuery('');
+              }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className={styles.empty}>No hosts match the current filters.</p>
+      ) : (
+        <CardGroup cols={cols}>
+          {visible.map((host) => (
+            <Card
+              key={host.id}
+              title={host.displayName}
+              href={host.documentationUrl}
+              color="var(--ifm-font-color-base)"
+              icon={<McpHostIcon clientId={host.id} alt={host.displayName} />}
+            >
+              <span className={styles.cardPills}>
+                {host.types.map((t) => (
+                  <span key={t} className={styles.cardPill}>
+                    {TYPE_LABELS[t]}
+                  </span>
+                ))}
+              </span>
+            </Card>
+          ))}
+        </CardGroup>
+      )}
+    </div>
+  );
+}

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/index.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/index.tsx
@@ -1,0 +1,2 @@
+export { default as McpHostsList } from './McpHostsList';
+export type { McpHostsListProps } from './McpHostsList';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:*
         version: link:packages/docusaurus-theme-glean
       '@gleanwork/mcp-config-schema':
-        specifier: ^4.3.0
-        version: 4.3.0(zod@4.2.1)
+        specifier: ^5.2.0
+        version: 5.2.0(zod@4.2.1)
       '@intercom/messenger-js-sdk':
         specifier: ^0.0.19
         version: 0.0.19
@@ -280,6 +280,9 @@ importers:
       '@docusaurus/theme-common':
         specifier: ^3.0.0
         version: 3.9.2(@docusaurus/plugin-content-docs@3.10.0(@docusaurus/faster@3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(@rspack/core@1.7.11)(@swc/core@1.15.30)(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.30)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@gleanwork/mcp-config-schema':
+        specifier: ^5.2.0
+        version: 5.2.0(zod@4.2.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2665,6 +2668,12 @@ packages:
 
   '@gleanwork/mcp-config-schema@4.3.0':
     resolution: {integrity: sha512-qajPyFZoNYVhFJ0IBgSQDRaLFPL5ysgTjdzCJYx7SG1lygHHz220Fj5lC7wP2/ntJiCmiQv8jl7zAS5kOnDNgg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@gleanwork/mcp-config-schema@5.2.0':
+    resolution: {integrity: sha512-2ldjVVC+ZcgSPXcwahqqZralI0JgMNeHas234psL/KytK74CLXX0OKuLEdI4SUdcHLnnQQSgShvQqy2UYb+lPA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -14849,6 +14858,14 @@ snapshots:
       smol-toml: 1.6.1
       zod: 4.2.1
 
+  '@gleanwork/mcp-config-schema@5.2.0(zod@4.2.1)':
+    dependencies:
+      glob: 13.0.6
+      js-yaml: 4.1.1
+      mkdirp: 3.0.1
+      smol-toml: 1.6.1
+      zod: 4.2.1
+
   '@gleanwork/web-sdk@2.3.0-next.0': {}
 
   '@gwhitney/detect-indent@7.0.1': {}
@@ -17116,7 +17133,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -254,6 +254,11 @@ const baseSidebars: SidebarsConfig = {
             },
             {
               type: 'doc',
+              id: 'guides/mcp/supported-hosts',
+              label: 'Supported Hosts',
+            },
+            {
+              type: 'doc',
               id: 'guides/mcp/claude-code',
               label: 'Claude Code Plugin',
             },


### PR DESCRIPTION
## Summary

Adds a new **Supported MCP Hosts** page (`/guides/mcp/supported-hosts`) that lists every MCP host supported by Glean, driven by `@gleanwork/mcp-config-schema` v5.2 — with brand icons, type pills, and live filtering. The existing "Official IDE Plugins" homepage section is unchanged.

## What changed

- New `McpHostsList` + `McpHostIcon` theme components in `docusaurus-theme-glean` (`src/theme/McpHosts/`), so they travel with the theme toward a shared package later.
- New docs page + sidebar entry ("Supported Hosts" under MCP).
- Filtering by installability, client type, and name; Infima chips + result count + Clear.
- Brand icons (monochrome marks adapt to light/dark via `currentColor`; full-color preserved), type pills, and documentation links per card.
- Microsoft Copilot Studio included as a manual entry (monogram icon; not yet in the schema package).
- Bumped `@gleanwork/mcp-config-schema` to `^5.2.0` (root + theme package).
- Info callout: any MCP-spec-compliant client works via the Custom configurator option.

## Test plan

- Dev server / `docusaurus build` render verified.
- Light + dark verified: icons, type pills, filtering (18 hosts; Web -> 4 incl. Copilot Studio).

## Screenshots

<img width="1728" height="1646" alt="devsite-hosts-dark" src="https://github.com/user-attachments/assets/67a19416-98bd-429a-a450-81967231a994" />
<img width="1728" height="1646" alt="devsite-hosts-light" src="https://github.com/user-attachments/assets/e9e081ae-1f49-42e9-8c4a-fcaefa8c4eb6" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
