### PR TITLE
chore(changelog): 2026-06-09

### DIFF
--- a/changelog/entries/2026-06-05-api-client-go-0-12-0.md
+++ b/changelog/entries/2026-06-05-api-client-go-0-12-0.md
@@ -1,0 +1,72 @@
+---
+title: 'api-client-go v0.12.0'
+categories: ['API Clients']
+---
+
+Api-client-go v0.12.0 includes 3 additions, 54 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error.ErrorCode.Enum(corruptItem)` to `client.collections.create()`.
+- Added `error.ErrorCode.Enum(corruptItem)` to `client.collections.delete()`.
+- Added `error.ErrorCode.Enum(corruptItem)` to `client.collections.update()`.
+- Changed `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.chat.create()`.
+- Changed `response` on `client.chat.create()`.
+- Changed `response` on `client.collections.additems()`.
+- Changed `request.Feedback1.Category` on `client.activity.feedback()`.
+- Changed `request.CreateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.UpdateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.CreateAnswerRequest.Data.AddedRoles[].Person.RelatedDocuments[]` on `client.answers.create()`.
+- Changed `response` on `client.answers.create()`.
+- Changed `request.EditAnswerRequest.AddedRoles[].Person.RelatedDocuments[]` on `client.answers.update()`.
+- Changed `response` on `client.answers.update()`.
+- Changed `response.AnswerResult.Answer` on `client.answers.retrieve()`.
+- Changed `response.AnswerResults[].Answer` on `client.answers.list()`.
+- Changed `response.ChatResult.Chat.CreatedBy.RelatedDocuments[]` on `client.chat.retrieve()`.
+- Changed `response.ChatResults[].Chat.CreatedBy.RelatedDocuments[]` on `client.chat.list()`.
+- Changed `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.chat.createstream()`.
+- Changed `request.CreateCollectionRequest.AddedRoles[].Person.RelatedDocuments[]` on `client.collections.create()`.
+- Changed `response.union(class (0))` on `client.collections.create()`.
+- Changed `response.Collection` on `client.collections.deleteitem()`.
+- Changed `request.EditCollectionRequest.AddedRoles[].Person.RelatedDocuments[]` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.Collection` on `client.collections.updateitem()`.
+- Changed `response` on `client.collections.retrieve()`.
+- Changed `response.Collections[]` on `client.collections.list()`.
+- Changed `response.Documents.Map<DocumentOrError>.union(Document).Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.documents.retrieve()`.
+- Changed `response.Documents[].Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.documents.retrievebyfacets()`.
+- Changed `request.InsightsRequest` on `client.insights.retrieve()`.
+- Changed `response` on `client.insights.retrieve()`.
+- Changed `response.SearchResponse.Results[].StructuredResults[]` on `client.messages.retrieve()`.
+- Changed `response.Attribution.RelatedDocuments[]` on `client.pins.update()`.
+- Changed `response.Pin.Attribution.RelatedDocuments[]` on `client.pins.retrieve()`.
+- Changed `response.Pins[].Attribution.RelatedDocuments[]` on `client.pins.list()`.
+- Changed `response.Attribution.RelatedDocuments[]` on `client.pins.create()`.
+- Changed `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.search.queryasadmin()`.
+- Changed `response.Results[].StructuredResults[]` on `client.search.queryasadmin()`.
+- Changed `response.Results[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.search.autocomplete()`.
+- Changed `request.FeedRequest.Categories[]` on `client.search.retrievefeed()`.
+- Changed `response.Results[]` on `client.search.retrievefeed()`.
+- Changed `request.RecommendationsRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.search.recommendations()`.
+- Changed `response.Results[].StructuredResults[]` on `client.search.recommendations()`.
+- Changed `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].Answer` on `client.search.query()`.
+- Changed `response.Results[].StructuredResults[]` on `client.search.query()`.
+- Changed `response.Results[].RelatedDocuments[]` on `client.entities.list()`.
+- Changed `response.Results[].RelatedDocuments[]` on `client.entities.readpeople()`.
+- Changed `request.CreateShortcutRequest.Data.AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.Shortcut.AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.Shortcut.AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.retrieve()`.
+- Changed `response.Shortcuts[].AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.list()`.
+- Changed `request.UpdateShortcutRequest.AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.Shortcut.AddedRoles[].Person.RelatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.Metadata.LastVerifier.RelatedDocuments[]` on `client.verification.addreminder()`.
+- Changed `response.Documents[].Metadata.LastVerifier.RelatedDocuments[]` on `client.verification.list()`.
+- Changed `response.Metadata.LastVerifier.RelatedDocuments[]` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.12.0)

--- a/changelog/entries/2026-06-05-api-client-java-0-13-0.md
+++ b/changelog/entries/2026-06-05-api-client-java-0-13-0.md
@@ -1,0 +1,72 @@
+---
+title: 'api-client-java v0.13.0'
+categories: ['API Clients']
+---
+
+Api-client-java v0.13.0 includes 3 additions, 54 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `errorCode.enum(corruptItem)` to `client.collections.create()`.
+- Added `errorCode.enum(corruptItem)` to `client.collections.delete()`.
+- Added `errorCode.enum(corruptItem)` to `client.collections.update()`.
+- Changed `response` on `client.collections.additems()`.
+- Changed `request.feedback1.category` on `client.activity.feedback()`.
+- Changed `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.createAnswerRequest.data.addedRoles[].person.relatedDocuments[]` on `client.answers.create()`.
+- Changed `response` on `client.answers.create()`.
+- Changed `request.editAnswerRequest.addedRoles[].person.relatedDocuments[]` on `client.answers.update()`.
+- Changed `response` on `client.answers.update()`.
+- Changed `response.answerResult.answer` on `client.answers.retrieve()`.
+- Changed `response.answerResults[].answer` on `client.answers.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.chat.create()`.
+- Changed `response.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.chat.create()`.
+- Changed `response.chatResult.chat.createdBy.relatedDocuments[]` on `client.chat.retrieve()`.
+- Changed `response.chatResults[].chat.createdBy.relatedDocuments[]` on `client.chat.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.chat.createstream()`.
+- Changed `request.createCollectionRequest.addedRoles[].person.relatedDocuments[]` on `client.collections.create()`.
+- Changed `response.union(class (0))` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.deleteitem()`.
+- Changed `request.editCollectionRequest.addedRoles[].person.relatedDocuments[]` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.updateitem()`.
+- Changed `response` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.documents.retrievebyfacets()`.
+- Changed `request.insightsRequest` on `client.insights.retrieve()`.
+- Changed `response` on `client.insights.retrieve()`.
+- Changed `response.searchResponse.results[].structuredResults[]` on `client.messages.retrieve()`.
+- Changed `response.attribution.relatedDocuments[]` on `client.pins.update()`.
+- Changed `response.pin.attribution.relatedDocuments[]` on `client.pins.retrieve()`.
+- Changed `response.pins[].attribution.relatedDocuments[]` on `client.pins.list()`.
+- Changed `response.attribution.relatedDocuments[]` on `client.pins.create()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.queryasadmin()`.
+- Changed `response.results[].structuredResults[]` on `client.search.queryasadmin()`.
+- Changed `response.results[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.autocomplete()`.
+- Changed `request.feedRequest.categories[]` on `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+- Changed `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.recommendations()`.
+- Changed `response.results[].structuredResults[]` on `client.search.recommendations()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.query()`.
+- Changed `response.results[].structuredResults[]` on `client.search.query()`.
+- Changed `response.results[].relatedDocuments[]` on `client.entities.list()`.
+- Changed `response.results[].relatedDocuments[]` on `client.entities.readpeople()`.
+- Changed `request.createShortcutRequest.data.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[].addedRoles[].person.relatedDocuments[]` on `client.shortcuts.list()`.
+- Changed `request.updateShortcutRequest.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[]` on `client.verification.addreminder()`.
+- Changed `response.documents[].metadata.lastVerifier.relatedDocuments[]` on `client.verification.list()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[]` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.0)

--- a/changelog/entries/2026-06-05-api-client-java-0-13-1.md
+++ b/changelog/entries/2026-06-05-api-client-java-0-13-1.md
@@ -1,0 +1,16 @@
+---
+title: 'api-client-java v0.13.1'
+categories: ['API Clients']
+---
+
+Api-client-java v0.13.1 includes 1 addition.
+
+{/* truncate */}
+
+## Changes
+
+- Added `response.status[202]` to `client.chat.create()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.1)

--- a/changelog/entries/2026-06-05-api-client-python-0-13-0.md
+++ b/changelog/entries/2026-06-05-api-client-python-0-13-0.md
@@ -1,0 +1,72 @@
+---
+title: 'api-client-python v0.13.0'
+categories: ['API Clients']
+---
+
+Api-client-python v0.13.0 includes 3 additions, 54 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error_code.enum(corrupt_item)` to `client.collections.create()`.
+- Added `error_code.enum(corrupt_item)` to `client.collections.delete()`.
+- Added `error_code.enum(corrupt_item)` to `client.collections.update()`.
+- Changed `response` on `client.collections.add_items()`.
+- Changed `request.feedback1.category` on `client.activity.feedback()`.
+- Changed `request.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.data.added_roles[].person.related_documents[]` on `client.answers.create()`.
+- Changed `response` on `client.answers.create()`.
+- Changed `request.added_roles[].person.related_documents[]` on `client.answers.update()`.
+- Changed `response` on `client.answers.update()`.
+- Changed `response.answer_result.answer` on `client.answers.retrieve()`.
+- Changed `response.answer_results[].answer` on `client.answers.list()`.
+- Changed `request.messages[].citations[].source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.chat.create()`.
+- Changed `response.messages[].citations[].source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.chat.create()`.
+- Changed `response.chat_result.chat.created_by.related_documents[]` on `client.chat.retrieve()`.
+- Changed `response.chat_results[].chat.created_by.related_documents[]` on `client.chat.list()`.
+- Changed `request.messages[].citations[].source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.chat.create_stream()`.
+- Changed `request.added_roles[].person.related_documents[]` on `client.collections.create()`.
+- Changed `response.union(class (0))` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.delete_item()`.
+- Changed `request.added_roles[].person.related_documents[]` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.update_item()`.
+- Changed `response` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.related_documents[].results[].structured_results[].answer` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.related_documents[].results[].structured_results[].answer` on `client.documents.retrieve_by_facets()`.
+- Changed `request` on `client.insights.retrieve()`.
+- Changed `response` on `client.insights.retrieve()`.
+- Changed `response.search_response.results[].structured_results[]` on `client.messages.retrieve()`.
+- Changed `response.attribution.related_documents[]` on `client.pins.update()`.
+- Changed `response.pin.attribution.related_documents[]` on `client.pins.retrieve()`.
+- Changed `response.pins[].attribution.related_documents[]` on `client.pins.list()`.
+- Changed `response.attribution.related_documents[]` on `client.pins.create()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.search.query_as_admin()`.
+- Changed `response.results[].structured_results[]` on `client.search.query_as_admin()`.
+- Changed `response.results[].document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.search.autocomplete()`.
+- Changed `request.categories[]` on `client.search.retrieve_feed()`.
+- Changed `response.results[]` on `client.search.retrieve_feed()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.search.recommendations()`.
+- Changed `response.results[].structured_results[]` on `client.search.recommendations()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[].structured_results[].answer` on `client.search.query()`.
+- Changed `response.results[].structured_results[]` on `client.search.query()`.
+- Changed `response.results[].related_documents[]` on `client.entities.list()`.
+- Changed `response.results[].related_documents[]` on `client.entities.read_people()`.
+- Changed `request.data.added_roles[].person.related_documents[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.added_roles[].person.related_documents[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.added_roles[].person.related_documents[]` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[].added_roles[].person.related_documents[]` on `client.shortcuts.list()`.
+- Changed `request.added_roles[].person.related_documents[]` on `client.shortcuts.update()`.
+- Changed `response.shortcut.added_roles[].person.related_documents[]` on `client.shortcuts.update()`.
+- Changed `response.metadata.last_verifier.related_documents[]` on `client.verification.add_reminder()`.
+- Changed `response.documents[].metadata.last_verifier.related_documents[]` on `client.verification.list()`.
+- Changed `response.metadata.last_verifier.related_documents[]` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.13.0)

--- a/changelog/entries/2026-06-05-api-client-typescript-0-15-0.md
+++ b/changelog/entries/2026-06-05-api-client-typescript-0-15-0.md
@@ -1,0 +1,72 @@
+---
+title: 'api-client-typescript v0.15.0'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.15.0 includes 3 additions, 54 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `errorCode.enum(corruptItem)` to `client.collections.create()`.
+- Added `errorCode.enum(corruptItem)` to `client.collections.delete()`.
+- Added `errorCode.enum(corruptItem)` to `client.collections.update()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.chat.create()`.
+- Changed `response` on `client.chat.create()`.
+- Changed `response` on `client.collections.additems()`.
+- Changed `request.feedback1.category` on `client.activity.feedback()`.
+- Changed `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.createAnswerRequest.data.addedRoles[].person.relatedDocuments[]` on `client.answers.create()`.
+- Changed `response` on `client.answers.create()`.
+- Changed `request.editAnswerRequest.addedRoles[].person.relatedDocuments[]` on `client.answers.update()`.
+- Changed `response` on `client.answers.update()`.
+- Changed `response.answerResult.answer` on `client.answers.retrieve()`.
+- Changed `response.answerResults[].answer` on `client.answers.list()`.
+- Changed `response.chatResult.chat.createdBy.relatedDocuments[]` on `client.chat.retrieve()`.
+- Changed `response.chatResults[].chat.createdBy.relatedDocuments[]` on `client.chat.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.chat.createstream()`.
+- Changed `request.createCollectionRequest.addedRoles[].person.relatedDocuments[]` on `client.collections.create()`.
+- Changed `response.union(class (0))` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.deleteitem()`.
+- Changed `request.editCollectionRequest.addedRoles[].person.relatedDocuments[]` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.updateitem()`.
+- Changed `response` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.documents.retrievebyfacets()`.
+- Changed `request.insightsRequest` on `client.insights.retrieve()`.
+- Changed `response` on `client.insights.retrieve()`.
+- Changed `response.searchResponse.results[].structuredResults[]` on `client.messages.retrieve()`.
+- Changed `response.attribution.relatedDocuments[]` on `client.pins.update()`.
+- Changed `response.pin.attribution.relatedDocuments[]` on `client.pins.retrieve()`.
+- Changed `response.pins[].attribution.relatedDocuments[]` on `client.pins.list()`.
+- Changed `response.attribution.relatedDocuments[]` on `client.pins.create()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.queryasadmin()`.
+- Changed `response.results[].structuredResults[]` on `client.search.queryasadmin()`.
+- Changed `response.results[].document.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.autocomplete()`.
+- Changed `request.feedRequest.categories[]` on `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+- Changed `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.recommendations()`.
+- Changed `response.results[].structuredResults[]` on `client.search.recommendations()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].answer` on `client.search.query()`.
+- Changed `response.results[].structuredResults[]` on `client.search.query()`.
+- Changed `response.results[].relatedDocuments[]` on `client.entities.list()`.
+- Changed `response.results[].relatedDocuments[]` on `client.entities.readpeople()`.
+- Changed `request.createShortcutRequest.data.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.create()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[].addedRoles[].person.relatedDocuments[]` on `client.shortcuts.list()`.
+- Changed `request.updateShortcutRequest.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.shortcut.addedRoles[].person.relatedDocuments[]` on `client.shortcuts.update()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[]` on `client.verification.addreminder()`.
+- Changed `response.documents[].metadata.lastVerifier.relatedDocuments[]` on `client.verification.list()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[]` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.15.0)

--- a/changelog/entries/2026-06-06-mcp-config-5-1-0.md
+++ b/changelog/entries/2026-06-06-mcp-config-5-1-0.md
@@ -1,0 +1,26 @@
+---
+title: 'mcp-config v5.1.0'
+categories: ['MCP']
+---
+
+Mcp-config v5.1.0: `mcp-config-glean`, `mcp-config-schema`: add Linear as MCP client configuration.
+
+{/* truncate */}
+
+## Changes
+
+- `mcp-config-glean`, `mcp-config-schema`: add Linear as MCP client configuration.
+- `mcp-config-schema`: add per-client host icons.
+- `mcp-config-schema`: add Antigravity CLI MCP client configuration.
+- Other.
+- Realign @eslint/js to v9 (restore npm install/publish).
+- `mcp-config-schema`: generate client constants from configs (single source of truth).
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.1.0)
+- [PR #106](https://github.com/gleanwork/mcp-config/pull/106)
+- [PR #112](https://github.com/gleanwork/mcp-config/pull/112)
+- [PR #110](https://github.com/gleanwork/mcp-config/pull/110)
+- [PR #118](https://github.com/gleanwork/mcp-config/pull/118)
+- [PR #111](https://github.com/gleanwork/mcp-config/pull/111)

--- a/changelog/entries/2026-06-07-mcp-config-5-2-0.md
+++ b/changelog/entries/2026-06-07-mcp-config-5-2-0.md
@@ -1,0 +1,17 @@
+---
+title: 'mcp-config v5.2.0'
+categories: ['MCP']
+---
+
+Mcp-config v5.2.0: `mcp-config-schema`: add client type classification (CLIENT_TYPES, TYPE_LABELS).
+
+{/* truncate */}
+
+## Changes
+
+- `mcp-config-schema`: add client type classification (CLIENT_TYPES, TYPE_LABELS).
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.2.0)
+- [PR #120](https://github.com/gleanwork/mcp-config/pull/120)

--- a/changelog/entries/2026-06-09-rest-api-changes-open-api.md
+++ b/changelog/entries/2026-06-09-rest-api-changes-open-api.md
@@ -1,0 +1,21 @@
+---
+title: 'REST API: changes (endpoints) 2026-06-09'
+categories: ['API']
+---
+
+1 endpoint added.
+
+{/* truncate */}
+
+## Changes
+
+- Added endpoint: /agents
+
+## Source
+
+- [open-api 04d057a](https://github.com/gleanwork/open-api/commit/04d057a1ee884ee7cd054bc62ae2048c76d90b02)
+- [open-api 289f5ff](https://github.com/gleanwork/open-api/commit/289f5ffa635cf440780bf159fdd194f4421a4888)
+- [open-api 4d68227](https://github.com/gleanwork/open-api/commit/4d68227a532a587e419c4f5aa32ec3b0779f071a)
+- [open-api 89b5b21](https://github.com/gleanwork/open-api/commit/89b5b2118a970f00492d39b262f0e87ecc7a14a1)
+- [open-api 96940dd](https://github.com/gleanwork/open-api/commit/96940dd45ce8c10d244f30c1230264ffe3717ad9)
+- [open-api adae527](https://github.com/gleanwork/open-api/commit/adae527852da72eaabde4953bea307550c8be02f)


### PR DESCRIPTION
Adds 8 changelog entries generated on 2026-06-09.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.13.1 | speakeasy | `changelog/entries/2026-06-05-api-client-java-0-13-1.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.1) |
| api-client-java | v0.13.0 | speakeasy | `changelog/entries/2026-06-05-api-client-java-0-13-0.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.0) |
| api-client-python | v0.13.0 | speakeasy | `changelog/entries/2026-06-05-api-client-python-0-13-0.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.13.0) |
| api-client-typescript | v0.15.0 | speakeasy | `changelog/entries/2026-06-05-api-client-typescript-0-15-0.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.15.0) |
| api-client-go | v0.12.0 | speakeasy | `changelog/entries/2026-06-05-api-client-go-0-12-0.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.12.0) |
| mcp-config | v5.2.0 | lerna-changelog | `changelog/entries/2026-06-07-mcp-config-5-2-0.md` | [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.2.0)<br />[PR #120](https://github.com/gleanwork/mcp-config/pull/120) |
| mcp-config | v5.1.0 | lerna-changelog | `changelog/entries/2026-06-06-mcp-config-5-1-0.md` | [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.1.0)<br />[PR #106](https://github.com/gleanwork/mcp-config/pull/106)<br />[PR #112](https://github.com/gleanwork/mcp-config/pull/112)<br />[PR #110](https://github.com/gleanwork/mcp-config/pull/110)<br />[PR #118](https://github.com/gleanwork/mcp-config/pull/118)<br />[PR #111](https://github.com/gleanwork/mcp-config/pull/111) |
| open-api | 2026-06-09 | openapi | `changelog/entries/2026-06-09-rest-api-changes-open-api.md` | [open-api 04d057a](https://github.com/gleanwork/open-api/commit/04d057a1ee884ee7cd054bc62ae2048c76d90b02)<br />[open-api 289f5ff](https://github.com/gleanwork/open-api/commit/289f5ffa635cf440780bf159fdd194f4421a4888)<br />[open-api 4d68227](https://github.com/gleanwork/open-api/commit/4d68227a532a587e419c4f5aa32ec3b0779f071a)<br />[open-api 89b5b21](https://github.com/gleanwork/open-api/commit/89b5b2118a970f00492d39b262f0e87ecc7a14a1)<br />[open-api 96940dd](https://github.com/gleanwork/open-api/commit/96940dd45ce8c10d244f30c1230264ffe3717ad9)<br />[open-api adae527](https://github.com/gleanwork/open-api/commit/adae527852da72eaabde4953bea307550c8be02f) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |