### PR TITLE
[MCP] Add retrieval interface guidance to Client API getting started (DOCS-1251)

### DIFF
--- a/docs/api-info/client/getting-started/choosing-a-retrieval-interface.mdx
+++ b/docs/api-info/client/getting-started/choosing-a-retrieval-interface.mdx
@@ -1,0 +1,27 @@
+---
+title: 'Choosing a Retrieval Interface'
+icon: 'git-branch'
+iconSet: 'feather'
+---
+
+# Choosing a retrieval interface
+
+Glean offers more than one way to retrieve enterprise knowledge, and the right choice depends on what you are building. Each interface is designed for a different use case, so matching the interface to what you're building — rather than, for example, calling the Search API from an LLM-based application — gives you the best results.
+
+| Interface               | Use it for                                                                       | Query to send                    |
+| :---------------------- | :------------------------------------------------------------------------------- | :------------------------------- |
+| Search API              | Programmatic access to Glean search, such as building a custom search experience | Query in the request body (POST) |
+| Glean MCP `search` tool | LLM-based applications                                                           | The LLM-rewritten query          |
+| Glean MCP `chat` tool   | End-to-end chat experiences                                                      | The original user query          |
+
+- The **Search API** provides programmatic access to Glean search — building a custom search experience is one example. Do not use it to retrieve context for LLM-based applications; use the Glean MCP tools instead.
+- The **Glean MCP `search` tool** is for LLM-based applications. Send the query your LLM has rewritten for retrieval, not the raw user input.
+- The **Glean MCP `chat` tool** is for end-to-end chat experiences. Send the original user query rather than a rewritten one.
+
+The `search` and `chat` tools are the two most relevant to this choice; the Glean MCP server also exposes other tools, such as document retrieval, code search, and people lookup.
+
+:::info
+
+For a full overview of the Glean MCP server and its available tools, see the [MCP documentation](https://docs.glean.com/administration/platform/mcp/about).
+
+:::

--- a/docs/api-info/client/getting-started/choosing-a-retrieval-interface.mdx
+++ b/docs/api-info/client/getting-started/choosing-a-retrieval-interface.mdx
@@ -4,7 +4,7 @@ icon: 'git-branch'
 iconSet: 'feather'
 ---
 
-# Choosing a retrieval interface
+# Choose a retrieval interface
 
 Glean offers more than one way to retrieve enterprise knowledge, and the right choice depends on what you are building. Each interface is designed for a different use case, so matching the interface to what you're building — rather than, for example, calling the Search API from an LLM-based application — gives you the best results.
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -459,6 +459,11 @@ const baseSidebars: SidebarsConfig = {
               id: 'api-info/client/getting-started/basic-usage',
               label: 'Basic Usage',
             },
+            {
+              type: 'doc',
+              id: 'api-info/client/getting-started/choosing-a-retrieval-interface',
+              label: 'Choosing a retrieval interface',
+            },
           ],
         },
         {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -462,7 +462,7 @@ const baseSidebars: SidebarsConfig = {
             {
               type: 'doc',
               id: 'api-info/client/getting-started/choosing-a-retrieval-interface',
-              label: 'Choosing a retrieval interface',
+              label: 'Choose a retrieval interface',
             },
           ],
         },


### PR DESCRIPTION
## Summary

Adds a **Choosing a retrieval interface** page to the Client API → Getting Started section, documenting when to use the Search API versus the Glean MCP `search` and `chat` tools.

**Why:** Developers have repeatedly called the Search API from LLM-based applications instead of the Glean MCP tools. This page makes the right choice explicit for the developer audience.

## What's in this PR

| File | Change |
| :--- | :--- |
| `docs/api-info/client/getting-started/choosing-a-retrieval-interface.mdx` | New page: Search API → programmatic search; MCP `search` → LLM apps (rewritten query); MCP `chat` → end-to-end chat (original query). Cross-links to MCP docs. |
| `sidebars.ts` | Adds the page after Basic Usage in the Getting Started category under Client API. |

## Placement

Placed inside **Getting Started → Client API** (after Basic Usage) — where a developer first learning the API will encounter it before reaching for the Search API in the wrong context.

This is the developers.glean.com companion to glean-docs PR #966 (DOCS-1251).

## Sourcing (verified — nothing assumed)

- The three-way guidance and the table are carried over from the reviewed text in glean-docs #966, which took it from the DOCS-1251 requirement and the Glean MCP server usage guidelines.
- "Search API takes its query in the request body (POST)" reflects review confirmation on #966 that the Search API is a POST endpoint.