### PR TITLE
fix(homepage): add bottom margin to carousel CTA button

### DIFF
--- a/src/components/Homepage/CarouselSection.module.css
+++ b/src/components/Homepage/CarouselSection.module.css
@@ -28,6 +28,7 @@
   display: flex !important;
   align-items: center !important;
   justify-content: center !important;
+  margin-bottom: 1.5rem;
 }
 
 /* PAGINATION BULLETS */


### PR DESCRIPTION
## Summary

In the stacked, mobile layout of the homepage carousel, the CTA button sat flush against the following code/image block with no spacing, which looked off.

This adds `margin-bottom: 1.5rem` to `.carouselButton`. In the stacked layout the button is the last element of the left column and the code block follows immediately in the next column, so the margin now provides the gap. On the wide side-by-side layout the button is at the bottom of its column, so the extra bottom margin is harmless.

**BEFORE:**

<img width="2144" height="2324" alt="2026-06-19 at 09 03 13@2x" src="https://github.com/user-attachments/assets/d81f2210-ee2f-4832-946b-3ed206135c44" />

**AFTER:**

<img width="2144" height="2324" alt="2026-06-19 at 09 03 04@2x" src="https://github.com/user-attachments/assets/5acb81d7-e420-4b3c-a092-ab76b344caee" />

<img width="4064" height="2324" alt="2026-06-19 at 09 02 37@2x" src="https://github.com/user-attachments/assets/544799d7-2fcf-459d-8c21-c704b44b407e" />

## Test plan

- [ ] Verify spacing below the CTA button on narrow screens (stacked layout)
- [ ] Verify wide side-by-side layout is unaffected