### PR TITLE
fix(homepage): keep IDE plugin cards side-by-side and spaced

### DIFF
--- a/src/components/Homepage/IDEPluginSection.module.css
+++ b/src/components/Homepage/IDEPluginSection.module.css
@@ -16,6 +16,12 @@
   font-size: 0.9375rem;
 }
 
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+}
+
 .card {
   border: 1px solid var(--ifm-color-emphasis-200);
   border-top: 4px solid var(--plugin-accent, var(--ifm-color-primary));
@@ -89,7 +95,7 @@
     margin-top: 1.5rem;
   }
 
-  .card {
-    margin-bottom: 1rem;
+  .grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/components/Homepage/IDEPluginSection.tsx
+++ b/src/components/Homepage/IDEPluginSection.tsx
@@ -42,45 +42,41 @@ export default function IDEPluginSection() {
         Go beyond MCP — our official plugins add purpose-built skills and tools
         for Claude Code and Cursor.
       </p>
-      <div className="row">
+      <div className={styles.grid}>
         {plugins.map((plugin) => (
-          <div key={plugin.name} className="col col--6">
-            <div
-              className={styles.card}
-              style={
-                { '--plugin-accent': plugin.accentColor } as React.CSSProperties
-              }
-            >
-              <div className={styles.cardHeader}>
-                <img
-                  src={useBaseUrl(plugin.logo)}
-                  alt={plugin.name}
-                  className={styles.logo}
-                />
-                <span className={styles.pluginName}>{plugin.name}</span>
-              </div>
-              <p className={styles.description}>{plugin.description}</p>
-              <div className={styles.actions}>
-                <Link
-                  to={plugin.repoHref}
-                  className={clsx('button button--secondary', styles.docsBtn)}
-                >
-                  View on GitHub
-                </Link>
-                <Link
-                  to={plugin.pageHref}
-                  className={clsx(
-                    'button button--primary',
-                    styles.configureBtn,
-                  )}
-                  style={{
-                    backgroundColor: plugin.accentColor,
-                    borderColor: plugin.accentColor,
-                  }}
-                >
-                  Get Started
-                </Link>
-              </div>
+          <div
+            key={plugin.name}
+            className={styles.card}
+            style={
+              { '--plugin-accent': plugin.accentColor } as React.CSSProperties
+            }
+          >
+            <div className={styles.cardHeader}>
+              <img
+                src={useBaseUrl(plugin.logo)}
+                alt={plugin.name}
+                className={styles.logo}
+              />
+              <span className={styles.pluginName}>{plugin.name}</span>
+            </div>
+            <p className={styles.description}>{plugin.description}</p>
+            <div className={styles.actions}>
+              <Link
+                to={plugin.repoHref}
+                className={clsx('button button--secondary', styles.docsBtn)}
+              >
+                View on GitHub
+              </Link>
+              <Link
+                to={plugin.pageHref}
+                className={clsx('button button--primary', styles.configureBtn)}
+                style={{
+                  backgroundColor: plugin.accentColor,
+                  borderColor: plugin.accentColor,
+                }}
+              >
+                Get Started
+              </Link>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Problem

The "Official IDE Plugins" cards on the homepage were stacking vertically and touching, instead of sitting side-by-side.

**Root cause:** The cards used Docusaurus's infima `row` / `col col--6` grid, which collapses to full-width (stacked) below the **996px** breakpoint. At typical laptop widths just under 996px the cards stacked, and at intermediate widths they touched because the separating margin only kicked in at 768px.

**BEFORE:**

<img width="2144" height="2324" alt="2026-06-19 at 09 33 34@2x" src="https://github.com/user-attachments/assets/9a53bf0d-de74-4a1e-959d-af52e136e56a" />

**AFTER:**
<img width="4064" height="2324" alt="2026-06-19 at 09 32 55@2x" src="https://github.com/user-attachments/assets/8ba9a44d-9da4-408e-aeea-1bb93c2af83d" />
<img width="2144" height="2324" alt="2026-06-19 at 09 33 29@2x" src="https://github.com/user-attachments/assets/fe356197-f325-456e-ad90-c078a1669c73" />
<img width="1224" height="2324" alt="2026-06-19 at 09 33 51@2x" src="https://github.com/user-attachments/assets/b6c59331-98ca-453d-960e-a6fb6459503a" />


## Fix

In `src/components/Homepage/IDEPluginSection.{tsx,module.css}`:

- Replaced the infima `row` / `col col--6` markup with a dedicated CSS grid (`.grid`) using `grid-template-columns: repeat(2, 1fr)` and `gap: 1.5rem`.
- The grid collapses to a single column at `max-width: 768px` (true mobile), where the same gap handles vertical spacing.

## Verification

Verified via Chrome DevTools across widths:

- **940px** → two columns side-by-side with a clean gap
- **600px** → single column, properly spaced