### PR TITLE
fix(homepage): remove fixed card min-height on mobile

### DIFF
--- a/src/components/Homepage/index.module.css
+++ b/src/components/Homepage/index.module.css
@@ -149,6 +149,12 @@ h3.bannerTitle {
 
 /* RESPONSIVE TWEAKS */
 @media (max-width: 996px) {
+  /* Cards stack below this breakpoint, so the equal-height min-height
+     just creates excess vertical space around the content. */
+  .featureCard {
+    min-height: auto;
+  }
+
   .bannerTitle {
     font-size: 1.75rem;
   }


### PR DESCRIPTION
## Summary

On mobile, the homepage feature cards ("Integrate with AI Tools", "Build with Our APIs", "Connect Your Data") had excessive empty space around their content.

**BEFORE:**
<img width="2144" height="2324" alt="2026-06-19 at 09 54 49@2x" src="https://github.com/user-attachments/assets/afc346fe-0687-46cd-a73c-363bb0cd7ff0" />

**AFTER:**

<img width="2144" height="2324" alt="2026-06-19 at 09 54 35@2x" src="https://github.com/user-attachments/assets/521425c3-6ef8-4ea8-b326-0381dae92cb3" />

## Cause

`.featureCard` sets `min-height: 200px` to keep the three side-by-side cards equal-height on desktop. Below the `996px` breakpoint the columns stack, so that fixed min-height just padded out each short card with empty space.

## Fix

Reset `.featureCard` `min-height` to `auto` at the `<=996px` stacking breakpoint. Desktop cards keep their uniform height; mobile cards size to their content.

## Test plan
- [ ] Verify desktop cards remain equal-height
- [ ] Verify mobile cards size to content (no excess vertical space)