### PR TITLE
chore(changelog): 2026-06-30

### DIFF
--- a/changelog/entries/2026-06-29-api-client-go-0-12-1.md
+++ b/changelog/entries/2026-06-29-api-client-go-0-12-1.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-go v0.12.1'
+categories: ['API Clients']
+---
+
+Api-client-go v0.12.1 includes 57 additions, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.CreateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.announcements.create()`.
+- Added `response.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.announcements.create()`.
+- Added `request.UpdateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.announcements.update()`.
+- Added `response.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.announcements.update()`.
+- Added `request.CreateAnswerRequest.Data.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.create()`.
+- Added `response.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.create()`.
+- Added `request.EditAnswerRequest.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.AnswerResult.Answer.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.retrieve()`.
+- Added `response.AnswerResults[].Answer.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.answers.list()`.
+- Added `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.ChatResult.Chat.CreatedBy.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.chat.retrieve()`.
+- Added `response.ChatResults[].Chat.CreatedBy.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.chat.list()`.
+- Added `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.chat.createstream()`.
+- Added `response.Collection.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.additems()`.
+- Added `request.CreateCollectionRequest.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.union(class (0)).Collection.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.Collection.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.deleteitem()`.
+- Added `request.EditCollectionRequest.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.Collection.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.updateitem()`.
+- Added `response.Collection.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.retrieve()`.
+- Added `response.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.collections.list()`.
+- Added `response.Documents.Map<DocumentOrError>.union(Document).Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.documents.retrieve()`.
+- Added `response.Documents[].Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.documents.retrievebyfacets()`.
+- Added `response.GleanAssist.ActivityInsights[].User.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.insights.retrieve()`.
+- Added `response.SearchResponse.Results[].StructuredResults[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.messages.retrieve()`.
+- Added `response.Attribution.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.pins.update()`.
+- Added `response.Pin.Attribution.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.pins.retrieve()`.
+- Added `response.Pins[].Attribution.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.pins.list()`.
+- Added `response.Attribution.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.pins.create()`.
+- Added `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.Results[].StructuredResults[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.Results[].Document.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.search.autocomplete()`.
+- Added `request.FeedRequest.Categories[].Enum(cardStackPromo)` to `client.search.retrievefeed()`.
+- Added `request.RecommendationsRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `response.Results[].StructuredResults[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[].StructuredResults[].CustomEntity.Roles[].Group.Type.Enum(collectionAudience)` to `client.search.query()`.
+- Added `response.Results[].StructuredResults[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.search.query()`.
+- Added `response.Results[].RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.entities.list()`.
+- Added `response.Results[].RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.entities.readpeople()`.
+- Added `request.CreateShortcutRequest.Data.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.Shortcut.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.Shortcut.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.retrieve()`.
+- Added `response.Shortcuts[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.list()`.
+- Added `request.UpdateShortcutRequest.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.Shortcut.AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.verification.addreminder()`.
+- Added `response.Documents[].Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.verification.list()`.
+- Added `response.Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata.Collections[].AddedRoles[].Group.Type.Enum(collectionAudience)` to `client.verification.verify()`.
+- Added `response.Report.Config.AllowlistOptions.Regexes` to `client.governance.data.policies.retrieve()`.
+- Added `request.UpdateDlpReportRequest.Config.AllowlistOptions.Regexes` to `client.governance.data.policies.update()`.
+- Added `response.Reports[].Config.AllowlistOptions.Regexes` to `client.governance.data.policies.list()`.
+- Added `request.Request.Config.AllowlistOptions.Regexes` to `client.governance.data.policies.create()`.
+- Added `response.Report.Config.AllowlistOptions.Regexes` to `client.governance.data.policies.create()`.
+- Added `request.Request.Config.AllowlistOptions.Regexes` to `client.governance.data.reports.create()`.
+- Changed `response.Results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.12.1)

--- a/changelog/entries/2026-06-29-api-client-java-0-13-2.md
+++ b/changelog/entries/2026-06-29-api-client-java-0-13-2.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-java v0.13.2'
+categories: ['API Clients']
+---
+
+Api-client-java v0.13.2 includes 57 additions, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.create()`.
+- Added `response.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.create()`.
+- Added `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.update()`.
+- Added `response.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.update()`.
+- Added `request.createAnswerRequest.data.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.create()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.create()`.
+- Added `request.editAnswerRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.answerResult.answer.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.retrieve()`.
+- Added `response.answerResults[].answer.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.list()`.
+- Added `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.chatResult.chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.chat.retrieve()`.
+- Added `response.chatResults[].chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.chat.list()`.
+- Added `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.createstream()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.additems()`.
+- Added `request.createCollectionRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.union(class (0)).collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.deleteitem()`.
+- Added `request.editCollectionRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.updateitem()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.retrieve()`.
+- Added `response.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.collections.list()`.
+- Added `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.documents.retrieve()`.
+- Added `response.documents[].metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.documents.retrievebyfacets()`.
+- Added `response.gleanAssist.activityInsights[].user.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.insights.retrieve()`.
+- Added `response.searchResponse.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.messages.retrieve()`.
+- Added `response.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.update()`.
+- Added `response.pin.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.retrieve()`.
+- Added `response.pins[].attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.list()`.
+- Added `response.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.create()`.
+- Added `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.results[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.autocomplete()`.
+- Added `request.feedRequest.categories[].enum(cardStackPromo)` to `client.search.retrievefeed()`.
+- Added `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.query()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.query()`.
+- Added `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.entities.list()`.
+- Added `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.entities.readpeople()`.
+- Added `request.createShortcutRequest.data.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.retrieve()`.
+- Added `response.shortcuts[].addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.list()`.
+- Added `request.updateShortcutRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.addreminder()`.
+- Added `response.documents[].metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.list()`.
+- Added `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.verify()`.
+- Added `response.report.config.allowlistOptions.regexes` to `client.governance.data.policies.retrieve()`.
+- Added `request.updateDlpReportRequest.config.allowlistOptions.regexes` to `client.governance.data.policies.update()`.
+- Added `response.reports[].config.allowlistOptions.regexes` to `client.governance.data.policies.list()`.
+- Added `request.config.allowlistOptions.regexes` to `client.governance.data.policies.create()`.
+- Added `response.report.config.allowlistOptions.regexes` to `client.governance.data.policies.create()`.
+- Added `request.config.allowlistOptions.regexes` to `client.governance.data.reports.create()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.2)

--- a/changelog/entries/2026-06-29-api-client-python-0-14-0.md
+++ b/changelog/entries/2026-06-29-api-client-python-0-14-0.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-python v0.14.0'
+categories: ['API Clients']
+---
+
+Api-client-python v0.14.0 includes 56 additions, 2 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.messages[].citations[].source_document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.chat.create()`.
+- Added `response.attribution.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.pins.update()`.
+- Added `request.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.announcements.update()`.
+- Added `response.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.announcements.update()`.
+- Added `request.data.added_roles[].group.type.enum(collection_audience)` to `client.answers.create()`.
+- Added `response.added_roles[].group.type.enum(collection_audience)` to `client.answers.create()`.
+- Added `request.added_roles[].group.type.enum(collection_audience)` to `client.answers.update()`.
+- Added `response.added_roles[].group.type.enum(collection_audience)` to `client.answers.update()`.
+- Added `response.answer_result.answer.added_roles[].group.type.enum(collection_audience)` to `client.answers.retrieve()`.
+- Added `response.answer_results[].answer.added_roles[].group.type.enum(collection_audience)` to `client.answers.list()`.
+- Added `request.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.announcements.create()`.
+- Added `response.body.structured_list[].document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.announcements.create()`.
+- Added `response.chat_result.chat.created_by.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.chat.retrieve()`.
+- Added `response.chat_results[].chat.created_by.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.chat.list()`.
+- Added `request.messages[].citations[].source_document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.chat.create_stream()`.
+- Added `response.collection.added_roles[].group.type.enum(collection_audience)` to `client.collections.add_items()`.
+- Added `request.added_roles[].group.type.enum(collection_audience)` to `client.collections.create()`.
+- Added `response.union(class (0)).collection.added_roles[].group.type.enum(collection_audience)` to `client.collections.create()`.
+- Added `response.collection.added_roles[].group.type.enum(collection_audience)` to `client.collections.delete_item()`.
+- Added `request.added_roles[].group.type.enum(collection_audience)` to `client.collections.update()`.
+- Added `response.added_roles[].group.type.enum(collection_audience)` to `client.collections.update()`.
+- Added `response.collection.added_roles[].group.type.enum(collection_audience)` to `client.collections.update_item()`.
+- Added `response.collection.added_roles[].group.type.enum(collection_audience)` to `client.collections.retrieve()`.
+- Added `response.collections[].added_roles[].group.type.enum(collection_audience)` to `client.collections.list()`.
+- Added `response.documents.Map<DocumentOrError>.union(Document).metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.documents.retrieve()`.
+- Added `response.documents[].metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.documents.retrieve_by_facets()`.
+- Added `response.glean_assist.activity_insights[].user.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.insights.retrieve()`.
+- Added `response.pin.attribution.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.pins.retrieve()`.
+- Added `response.search_response.results[].structured_results[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.messages.retrieve()`.
+- Added `response.pins[].attribution.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.pins.list()`.
+- Added `response.attribution.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.pins.create()`.
+- Added `request.source_document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.search.query_as_admin()`.
+- Added `response.results[].structured_results[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.search.query_as_admin()`.
+- Added `response.results[].document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.search.autocomplete()`.
+- Added `request.categories[].enum(card_stack_promo)` to `client.search.retrieve_feed()`.
+- Added `request.source_document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.search.recommendations()`.
+- Added `response.results[].structured_results[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.search.recommendations()`.
+- Added `request.source_document.metadata.author.related_documents[].results[].structured_results[].custom_entity.roles[].group.type.enum(collection_audience)` to `client.search.query()`.
+- Added `response.results[].structured_results[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.search.query()`.
+- Added `response.results[].related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.entities.list()`.
+- Added `response.results[].related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.entities.read_people()`.
+- Added `request.data.added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.retrieve()`.
+- Added `response.shortcuts[].added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.list()`.
+- Added `request.added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.update()`.
+- Added `response.shortcut.added_roles[].group.type.enum(collection_audience)` to `client.shortcuts.update()`.
+- Added `response.metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.verification.add_reminder()`.
+- Added `response.documents[].metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.verification.list()`.
+- Added `response.metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata.collections[].added_roles[].group.type.enum(collection_audience)` to `client.verification.verify()`.
+- Added `response.report.config.allowlist_options.regexes` to `client.governance.data.policies.retrieve()`.
+- Added `request.config.allowlist_options.regexes` to `client.governance.data.policies.update()`.
+- Added `response.reports[].config.allowlist_options.regexes` to `client.governance.data.policies.list()`.
+- Added `request.config.allowlist_options.regexes` to `client.governance.data.policies.create()`.
+- Added `response.report.config.allowlist_options.regexes` to `client.governance.data.policies.create()`.
+- Added `request.config.allowlist_options.regexes` to `client.governance.data.reports.create()`.
+- Changed `response` on `client.chat.create()`.
+- Changed `response.results[]` on `client.search.retrieve_feed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.14.0)

--- a/changelog/entries/2026-06-29-api-client-typescript-0-16-0.md
+++ b/changelog/entries/2026-06-29-api-client-typescript-0-16-0.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-typescript v0.16.0'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.16.0 includes 57 additions, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.create()`.
+- Added `response.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.create()`.
+- Added `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.update()`.
+- Added `response.body.structuredList[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.announcements.update()`.
+- Added `request.createAnswerRequest.data.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.create()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.create()`.
+- Added `request.editAnswerRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.update()`.
+- Added `response.answerResult.answer.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.retrieve()`.
+- Added `response.answerResults[].answer.addedRoles[].group.type.enum(collectionAudience)` to `client.answers.list()`.
+- Added `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.create()`.
+- Added `response.chatResult.chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.chat.retrieve()`.
+- Added `response.chatResults[].chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.chat.list()`.
+- Added `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.chat.createstream()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.additems()`.
+- Added `request.createCollectionRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.union(class (0)).collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.create()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.deleteitem()`.
+- Added `request.editCollectionRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.update()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.updateitem()`.
+- Added `response.collection.addedRoles[].group.type.enum(collectionAudience)` to `client.collections.retrieve()`.
+- Added `response.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.collections.list()`.
+- Added `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.documents.retrieve()`.
+- Added `response.documents[].metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.documents.retrievebyfacets()`.
+- Added `response.gleanAssist.activityInsights[].user.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.insights.retrieve()`.
+- Added `response.searchResponse.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.messages.retrieve()`.
+- Added `response.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.update()`.
+- Added `response.pin.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.retrieve()`.
+- Added `response.pins[].attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.list()`.
+- Added `response.attribution.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.pins.create()`.
+- Added `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.queryasadmin()`.
+- Added `response.results[].document.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.autocomplete()`.
+- Added `request.feedRequest.categories[].enum(cardStackPromo)` to `client.search.retrievefeed()`.
+- Added `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.recommendations()`.
+- Added `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[].structuredResults[].customEntity.roles[].group.type.enum(collectionAudience)` to `client.search.query()`.
+- Added `response.results[].structuredResults[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.search.query()`.
+- Added `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.entities.list()`.
+- Added `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.entities.readpeople()`.
+- Added `request.createShortcutRequest.data.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.create()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.retrieve()`.
+- Added `response.shortcuts[].addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.list()`.
+- Added `request.updateShortcutRequest.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.shortcut.addedRoles[].group.type.enum(collectionAudience)` to `client.shortcuts.update()`.
+- Added `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.addreminder()`.
+- Added `response.documents[].metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.list()`.
+- Added `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata.collections[].addedRoles[].group.type.enum(collectionAudience)` to `client.verification.verify()`.
+- Added `response.report.config.allowlistOptions.regexes` to `client.governance.data.policies.retrieve()`.
+- Added `request.updateDlpReportRequest.config.allowlistOptions.regexes` to `client.governance.data.policies.update()`.
+- Added `response.reports[].config.allowlistOptions.regexes` to `client.governance.data.policies.list()`.
+- Added `request.config.allowlistOptions.regexes` to `client.governance.data.policies.create()`.
+- Added `response.report.config.allowlistOptions.regexes` to `client.governance.data.policies.create()`.
+- Added `request.config.allowlistOptions.regexes` to `client.governance.data.reports.create()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.16.0)


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-06-30.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.13.2 | speakeasy | `changelog/entries/2026-06-29-api-client-java-0-13-2.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.13.2) |
| api-client-python | v0.14.0 | speakeasy | `changelog/entries/2026-06-29-api-client-python-0-14-0.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.14.0) |
| api-client-typescript | v0.16.0 | speakeasy | `changelog/entries/2026-06-29-api-client-typescript-0-16-0.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.16.0) |
| api-client-go | v0.12.1 | speakeasy | `changelog/entries/2026-06-29-api-client-go-0-12-1.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.12.1) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| mcp-config | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |
| open-api | no new open-api commits | skip |