### PR TITLE
chore(changelog): 2026-07-01

### DIFF
--- a/changelog/entries/2026-06-30-configure-mcp-server-3-2-1.md
+++ b/changelog/entries/2026-06-30-configure-mcp-server-3-2-1.md
@@ -1,0 +1,17 @@
+---
+title: 'configure-mcp-server v3.2.1'
+categories: ['MCP']
+---
+
+Configure-mcp-server v3.2.1: Inline mcp-server-utils utilities; drop the dependency.
+
+{/* truncate */}
+
+## Changes
+
+- Inline mcp-server-utils utilities; drop the dependency.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.2.1)
+- [PR #84](https://github.com/gleanwork/configure-mcp-server/pull/84)


### PR DESCRIPTION
Adds 1 changelog entries generated on 2026-07-01.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| configure-mcp-server | v3.2.1 | lerna-changelog | `changelog/entries/2026-06-30-configure-mcp-server-3-2-1.md` | [Release notes](https://github.com/gleanwork/configure-mcp-server/releases/tag/v3.2.1)<br />[PR #84](https://github.com/gleanwork/configure-mcp-server/pull/84) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| api-client-java | no newer release than latest entry | older than latest entry |
| api-client-python | no newer release than latest entry | older than latest entry |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| mcp-config | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |
| api-client-typescript v0.16.1 | v0.16.1 has no meaningful changelog changes | empty/no-op |
| api-client-go v0.12.2 | v0.12.2 has no meaningful changelog changes | empty/no-op |
| open-api | no new open-api commits | skip |