### PR TITLE
chore(changelog): 2026-07-08

### DIFF
--- a/changelog/entries/2026-07-06-api-client-go-0-13-1.md
+++ b/changelog/entries/2026-07-06-api-client-go-0-13-1.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-go v0.13.1'
+categories: ['API Clients']
+---
+
+Api-client-go v0.13.1 includes 3 additions, 55 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error.Code.Enum(requestTooLarge)` to `agents.get()`.
+- Added `error.Code.Enum(requestTooLarge)` to `agents.getschemas()`.
+- Added `request.FeedRequest.Categories[].Enum(podcast)` to `client.search.retrievefeed()`.
+- Changed `error` on `agents.search()`.
+- Changed `error` on `agents.createrun()`.
+- Changed `error` on `search.query()`.
+- Changed `request.CreateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[]` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.UpdateAnnouncementRequest.Body.StructuredList[].Document.Metadata.Author.RelatedDocuments[].Results[]` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.CreateAnswerRequest.Data.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.answers.create()`.
+- Changed `response.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.answers.create()`.
+- Changed `request.EditAnswerRequest.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.answers.update()`.
+- Changed `response.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.answers.update()`.
+- Changed `response.AnswerResult` on `client.answers.retrieve()`.
+- Changed `response.AnswerResults[]` on `client.answers.list()`.
+- Changed `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.chat.create()`.
+- Changed `response.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.chat.create()`.
+- Changed `response.ChatResult.Chat.CreatedBy.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.chat.retrieve()`.
+- Changed `response.ChatResults[].Chat.CreatedBy.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.chat.list()`.
+- Changed `request.ChatRequest.Messages[].Citations[].SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.chat.createstream()`.
+- Changed `response.Workflow.Author.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.agents.create()`.
+- Changed `response.Collection` on `client.collections.additems()`.
+- Changed `request.CreateCollectionRequest.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.collections.create()`.
+- Changed `response.union(class (0)).Collection` on `client.collections.create()`.
+- Changed `response.Collection` on `client.collections.deleteitem()`.
+- Changed `request.EditCollectionRequest.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.Collection` on `client.collections.updateitem()`.
+- Changed `response.Collection` on `client.collections.retrieve()`.
+- Changed `response.Collections[]` on `client.collections.list()`.
+- Changed `response.Documents.Map<DocumentOrError>.union(Document).Metadata.Author.RelatedDocuments[].Results[]` on `client.documents.retrieve()`.
+- Changed `response.Documents[].Metadata.Author.RelatedDocuments[].Results[]` on `client.documents.retrievebyfacets()`.
+- Changed `response.GleanAssist.ActivityInsights[].User.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.insights.retrieve()`.
+- Changed `response.SearchResponse.Results[].StructuredResults[].Document.Metadata` on `client.messages.retrieve()`.
+- Changed `response` on `client.pins.update()`.
+- Changed `response.Pin` on `client.pins.retrieve()`.
+- Changed `response.Pins[]` on `client.pins.list()`.
+- Changed `response` on `client.pins.create()`.
+- Changed `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.search.queryasadmin()`.
+- Changed `response.Results[].StructuredResults[].Document.Metadata` on `client.search.queryasadmin()`.
+- Changed `response.Results[].Document.Metadata.Author.RelatedDocuments[].Results[]` on `client.search.autocomplete()`.
+- Changed `response.Results[]` on `client.search.retrievefeed()`.
+- Changed `request.RecommendationsRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.search.recommendations()`.
+- Changed `response.Results[].StructuredResults[].Document.Metadata` on `client.search.recommendations()`.
+- Changed `request.SearchRequest.SourceDocument.Metadata.Author.RelatedDocuments[].Results[]` on `client.search.query()`.
+- Changed `response.Results[].StructuredResults[].Document.Metadata` on `client.search.query()`.
+- Changed `response.Results[].RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.entities.list()`.
+- Changed `response.Results[].RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.entities.readpeople()`.
+- Changed `request.CreateShortcutRequest.Data.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.shortcuts.create()`.
+- Changed `response.Shortcut` on `client.shortcuts.create()`.
+- Changed `response.Shortcut` on `client.shortcuts.retrieve()`.
+- Changed `response.Shortcuts[]` on `client.shortcuts.list()`.
+- Changed `request.UpdateShortcutRequest.AddedRoles[].Person.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.shortcuts.update()`.
+- Changed `response.Shortcut` on `client.shortcuts.update()`.
+- Changed `response.Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.verification.addreminder()`.
+- Changed `response.Documents[].Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.verification.list()`.
+- Changed `response.Metadata.LastVerifier.RelatedDocuments[].QuerySuggestion.Ranges[].Document.Metadata` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.1)

--- a/changelog/entries/2026-07-06-api-client-java-0-14-1.md
+++ b/changelog/entries/2026-07-06-api-client-java-0-14-1.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-java v0.14.1'
+categories: ['API Clients']
+---
+
+Api-client-java v0.14.1 includes 3 additions, 55 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error.code.enum(requestTooLarge)` to `agents.get()`.
+- Added `error.code.enum(requestTooLarge)` to `agents.getschemas()`.
+- Added `request.feedRequest.categories[].enum(podcast)` to `client.search.retrievefeed()`.
+- Changed `error` on `agents.search()`.
+- Changed `error` on `agents.createrun()`.
+- Changed `error` on `search.query()`.
+- Changed `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[]` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[]` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.createAnswerRequest.data.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `response.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `request.editAnswerRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.answerResult` on `client.answers.retrieve()`.
+- Changed `response.answerResults[]` on `client.answers.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.create()`.
+- Changed `response.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.create()`.
+- Changed `response.chatResult.chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.chat.retrieve()`.
+- Changed `response.chatResults[].chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.chat.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.createstream()`.
+- Changed `response.workflow.author.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.agents.create()`.
+- Changed `response.collection` on `client.collections.additems()`.
+- Changed `request.createCollectionRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.collections.create()`.
+- Changed `response.union(class (0)).collection` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.deleteitem()`.
+- Changed `request.editCollectionRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.updateitem()`.
+- Changed `response.collection` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[]` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.relatedDocuments[].results[]` on `client.documents.retrievebyfacets()`.
+- Changed `response.gleanAssist.activityInsights[].user.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.insights.retrieve()`.
+- Changed `response.searchResponse.results[].structuredResults[].document.metadata` on `client.messages.retrieve()`.
+- Changed `response` on `client.pins.update()`.
+- Changed `response.pin` on `client.pins.retrieve()`.
+- Changed `response.pins[]` on `client.pins.list()`.
+- Changed `response` on `client.pins.create()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.queryasadmin()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.queryasadmin()`.
+- Changed `response.results[].document.metadata.author.relatedDocuments[].results[]` on `client.search.autocomplete()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+- Changed `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.recommendations()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.recommendations()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.query()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.query()`.
+- Changed `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.entities.list()`.
+- Changed `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.entities.readpeople()`.
+- Changed `request.createShortcutRequest.data.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[]` on `client.shortcuts.list()`.
+- Changed `request.updateShortcutRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.shortcuts.update()`.
+- Changed `response.shortcut` on `client.shortcuts.update()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.addreminder()`.
+- Changed `response.documents[].metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.list()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.1)

--- a/changelog/entries/2026-07-06-api-client-python-0-15-1.md
+++ b/changelog/entries/2026-07-06-api-client-python-0-15-1.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-python v0.15.1'
+categories: ['API Clients']
+---
+
+Api-client-python v0.15.1 includes 3 additions, 55 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error.code.enum(request_too_large)` to `agents.get()`.
+- Added `error.code.enum(request_too_large)` to `agents.get_schemas()`.
+- Added `request.categories[].enum(podcast)` to `client.search.retrieve_feed()`.
+- Changed `error` on `agents.search()`.
+- Changed `error` on `agents.create_run()`.
+- Changed `error` on `search.query()`.
+- Changed `request.body.structured_list[].document.metadata.author.related_documents[].results[]` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.body.structured_list[].document.metadata.author.related_documents[].results[]` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.data.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `response.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `request.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.answer_result` on `client.answers.retrieve()`.
+- Changed `response.answer_results[]` on `client.answers.list()`.
+- Changed `request.messages[].citations[].source_document.metadata.author.related_documents[].results[]` on `client.chat.create()`.
+- Changed `response.messages[].citations[].source_document.metadata.author.related_documents[].results[]` on `client.chat.create()`.
+- Changed `response.chat_result.chat.created_by.related_documents[].query_suggestion.ranges[].document.metadata` on `client.chat.retrieve()`.
+- Changed `response.chat_results[].chat.created_by.related_documents[].query_suggestion.ranges[].document.metadata` on `client.chat.list()`.
+- Changed `request.messages[].citations[].source_document.metadata.author.related_documents[].results[]` on `client.chat.create_stream()`.
+- Changed `response.workflow.author.related_documents[].query_suggestion.ranges[].document.metadata` on `client.agents.create()`.
+- Changed `response.collection` on `client.collections.add_items()`.
+- Changed `request.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.collections.create()`.
+- Changed `response.union(class (0)).collection` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.delete_item()`.
+- Changed `request.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.update_item()`.
+- Changed `response.collection` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.related_documents[].results[]` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.related_documents[].results[]` on `client.documents.retrieve_by_facets()`.
+- Changed `response.glean_assist.activity_insights[].user.related_documents[].query_suggestion.ranges[].document.metadata` on `client.insights.retrieve()`.
+- Changed `response.search_response.results[].structured_results[].document.metadata` on `client.messages.retrieve()`.
+- Changed `response` on `client.pins.update()`.
+- Changed `response.pin` on `client.pins.retrieve()`.
+- Changed `response.pins[]` on `client.pins.list()`.
+- Changed `response` on `client.pins.create()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[]` on `client.search.query_as_admin()`.
+- Changed `response.results[].structured_results[].document.metadata` on `client.search.query_as_admin()`.
+- Changed `response.results[].document.metadata.author.related_documents[].results[]` on `client.search.autocomplete()`.
+- Changed `response.results[]` on `client.search.retrieve_feed()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[]` on `client.search.recommendations()`.
+- Changed `response.results[].structured_results[].document.metadata` on `client.search.recommendations()`.
+- Changed `request.source_document.metadata.author.related_documents[].results[]` on `client.search.query()`.
+- Changed `response.results[].structured_results[].document.metadata` on `client.search.query()`.
+- Changed `response.results[].related_documents[].query_suggestion.ranges[].document.metadata` on `client.entities.list()`.
+- Changed `response.results[].related_documents[].query_suggestion.ranges[].document.metadata` on `client.entities.read_people()`.
+- Changed `request.data.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[]` on `client.shortcuts.list()`.
+- Changed `request.added_roles[].person.related_documents[].query_suggestion.ranges[].document.metadata` on `client.shortcuts.update()`.
+- Changed `response.shortcut` on `client.shortcuts.update()`.
+- Changed `response.metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata` on `client.verification.add_reminder()`.
+- Changed `response.documents[].metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata` on `client.verification.list()`.
+- Changed `response.metadata.last_verifier.related_documents[].query_suggestion.ranges[].document.metadata` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.1)

--- a/changelog/entries/2026-07-06-api-client-typescript-0-17-1.md
+++ b/changelog/entries/2026-07-06-api-client-typescript-0-17-1.md
@@ -1,0 +1,73 @@
+---
+title: 'api-client-typescript v0.17.1'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.17.1 includes 3 additions, 55 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `error.code.enum(requestTooLarge)` to `agents.get()`.
+- Added `error.code.enum(requestTooLarge)` to `agents.getschemas()`.
+- Added `request.feedRequest.categories[].enum(podcast)` to `client.search.retrievefeed()`.
+- Changed `error` on `agents.search()`.
+- Changed `error` on `agents.createrun()`.
+- Changed `error` on `search.query()`.
+- Changed `request.createAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[]` on `client.announcements.create()`.
+- Changed `response` on `client.announcements.create()`.
+- Changed `request.updateAnnouncementRequest.body.structuredList[].document.metadata.author.relatedDocuments[].results[]` on `client.announcements.update()`.
+- Changed `response` on `client.announcements.update()`.
+- Changed `request.createAnswerRequest.data.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `response.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.create()`.
+- Changed `request.editAnswerRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.answers.update()`.
+- Changed `response.answerResult` on `client.answers.retrieve()`.
+- Changed `response.answerResults[]` on `client.answers.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.create()`.
+- Changed `response.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.create()`.
+- Changed `response.chatResult.chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.chat.retrieve()`.
+- Changed `response.chatResults[].chat.createdBy.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.chat.list()`.
+- Changed `request.chatRequest.messages[].citations[].sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.chat.createstream()`.
+- Changed `response.workflow.author.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.agents.create()`.
+- Changed `response.collection` on `client.collections.additems()`.
+- Changed `request.createCollectionRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.collections.create()`.
+- Changed `response.union(class (0)).collection` on `client.collections.create()`.
+- Changed `response.collection` on `client.collections.deleteitem()`.
+- Changed `request.editCollectionRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.collections.update()`.
+- Changed `response` on `client.collections.update()`.
+- Changed `response.collection` on `client.collections.updateitem()`.
+- Changed `response.collection` on `client.collections.retrieve()`.
+- Changed `response.collections[]` on `client.collections.list()`.
+- Changed `response.documents.Map<DocumentOrError>.union(Document).metadata.author.relatedDocuments[].results[]` on `client.documents.retrieve()`.
+- Changed `response.documents[].metadata.author.relatedDocuments[].results[]` on `client.documents.retrievebyfacets()`.
+- Changed `response.gleanAssist.activityInsights[].user.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.insights.retrieve()`.
+- Changed `response.searchResponse.results[].structuredResults[].document.metadata` on `client.messages.retrieve()`.
+- Changed `response` on `client.pins.update()`.
+- Changed `response.pin` on `client.pins.retrieve()`.
+- Changed `response.pins[]` on `client.pins.list()`.
+- Changed `response` on `client.pins.create()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.queryasadmin()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.queryasadmin()`.
+- Changed `response.results[].document.metadata.author.relatedDocuments[].results[]` on `client.search.autocomplete()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+- Changed `request.recommendationsRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.recommendations()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.recommendations()`.
+- Changed `request.searchRequest.sourceDocument.metadata.author.relatedDocuments[].results[]` on `client.search.query()`.
+- Changed `response.results[].structuredResults[].document.metadata` on `client.search.query()`.
+- Changed `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.entities.list()`.
+- Changed `response.results[].relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.entities.readpeople()`.
+- Changed `request.createShortcutRequest.data.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.create()`.
+- Changed `response.shortcut` on `client.shortcuts.retrieve()`.
+- Changed `response.shortcuts[]` on `client.shortcuts.list()`.
+- Changed `request.updateShortcutRequest.addedRoles[].person.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.shortcuts.update()`.
+- Changed `response.shortcut` on `client.shortcuts.update()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.addreminder()`.
+- Changed `response.documents[].metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.list()`.
+- Changed `response.metadata.lastVerifier.relatedDocuments[].querySuggestion.ranges[].document.metadata` on `client.verification.verify()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.1)

--- a/changelog/entries/2026-07-06-rest-api-changes-open-api.md
+++ b/changelog/entries/2026-07-06-rest-api-changes-open-api.md
@@ -1,0 +1,23 @@
+---
+title: 'REST API: changes (endpoints) 2026-07-06'
+categories: ['API']
+---
+
+1 endpoint added.
+
+{/* truncate */}
+
+## Changes
+
+- Added endpoint: /tool-servers/{serverId}/auth
+
+## Source
+
+- [open-api 4a21fa5](https://github.com/gleanwork/open-api/commit/4a21fa5af798541d971684d6553cac6518076572)
+- [open-api 4fe01f0](https://github.com/gleanwork/open-api/commit/4fe01f099b6b30460fd3c6cd2ed47cb4a77797e1)
+- [open-api 566e3d3](https://github.com/gleanwork/open-api/commit/566e3d392ace2cb8f2cd9a6fd99c9f47b1fee05a)
+- [open-api 6154b37](https://github.com/gleanwork/open-api/commit/6154b37644c41cc06ec7707d153e0babaa182692)
+- [open-api 66b0eaf](https://github.com/gleanwork/open-api/commit/66b0eaff65a1685a2aac683388743350dc8b82cc)
+- [open-api 7163488](https://github.com/gleanwork/open-api/commit/71634881068d89d4bf7db5d0464d083bad3570c7)
+- [open-api 78aad8c](https://github.com/gleanwork/open-api/commit/78aad8ce6c1ac5d1bb48377182f00e85bb723591)
+- [open-api 872c2b5](https://github.com/gleanwork/open-api/commit/872c2b51976682d881d04d05a90d7df93c20883a)


### PR DESCRIPTION
Adds 5 changelog entries generated on 2026-07-08.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.14.1 | speakeasy | `changelog/entries/2026-07-06-api-client-java-0-14-1.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.1) |
| api-client-python | v0.15.1 | speakeasy | `changelog/entries/2026-07-06-api-client-python-0-15-1.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.1) |
| api-client-typescript | v0.17.1 | speakeasy | `changelog/entries/2026-07-06-api-client-typescript-0-17-1.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.1) |
| api-client-go | v0.13.1 | speakeasy | `changelog/entries/2026-07-06-api-client-go-0-13-1.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.1) |
| open-api | 2026-07-06 | openapi | `changelog/entries/2026-07-06-rest-api-changes-open-api.md` | [open-api 4a21fa5](https://github.com/gleanwork/open-api/commit/4a21fa5af798541d971684d6553cac6518076572)<br />[open-api 4fe01f0](https://github.com/gleanwork/open-api/commit/4fe01f099b6b30460fd3c6cd2ed47cb4a77797e1)<br />[open-api 566e3d3](https://github.com/gleanwork/open-api/commit/566e3d392ace2cb8f2cd9a6fd99c9f47b1fee05a)<br />[open-api 6154b37](https://github.com/gleanwork/open-api/commit/6154b37644c41cc06ec7707d153e0babaa182692)<br />[open-api 66b0eaf](https://github.com/gleanwork/open-api/commit/66b0eaff65a1685a2aac683388743350dc8b82cc)<br />[open-api 7163488](https://github.com/gleanwork/open-api/commit/71634881068d89d4bf7db5d0464d083bad3570c7)<br />[open-api 78aad8c](https://github.com/gleanwork/open-api/commit/78aad8ce6c1ac5d1bb48377182f00e85bb723591)<br />[open-api 872c2b5](https://github.com/gleanwork/open-api/commit/872c2b51976682d881d04d05a90d7df93c20883a) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| mcp-config | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |
| api-client-java v0.14.0 | v0.14.0 has no meaningful changelog changes | empty/no-op |
| api-client-python v0.15.0 | v0.15.0 has no meaningful changelog changes | empty/no-op |
| api-client-typescript v0.17.0 | v0.17.0 has no meaningful changelog changes | empty/no-op |
| api-client-go v0.13.0 | v0.13.0 has no meaningful changelog changes | empty/no-op |