### PR TITLE
fix(openapi): suppress Beta banner when endpoint is experimental

### DIFF
--- a/scripts/generator/customMdGenerators.ts
+++ b/scripts/generator/customMdGenerators.ts
@@ -199,7 +199,12 @@ export function customApiMdGenerator({
           deprecated,
           description: deprecatedDescription,
         }),
-    createPreviewNotice({ xVisibility, xBeta }),
+    // When an endpoint is experimental, the experimental notice is the
+    // stronger/more specific signal, so we suppress the (redundant) Beta/Preview
+    // notice to avoid stacking two stability banners.
+    xGleanExperimental
+      ? undefined
+      : createPreviewNotice({ xVisibility, xBeta }),
     createExperimentalNotice({ xGleanExperimental }),
     createDescription(description),
     requestBody || parameters ? createRequestHeader('Request') : undefined,


### PR DESCRIPTION
## Summary

API pages generated for endpoints marked as **both** `x-beta`/`Preview` **and** `x-glean-experimental` rendered two stacked stability admonitions — an outer Beta banner wrapping the Experimental one.

Since the Experimental notice is the stronger, more specific signal, the generator now **skips the redundant Beta/Preview admonition when `x-glean-experimental` is set**.

## Change

- `scripts/generator/customMdGenerators.ts`: gate `createPreviewNotice` on the absence of `xGleanExperimental`.

## Original Issue

<img width="1570" height="408" alt="2026-07-07 at 11 17 23@2x" src="https://github.com/user-attachments/assets/5c9bacc0-6d75-4703-a22e-1a4b9581f171" />

We will need to clean up the original specs so they dont use the old `visibility:preview` property and instead use `x-glean-experimental`