### PR TITLE
chore(api): regenerate client docs to drop redundant Beta banner

### DIFF
--- a/docs/api/client-api/tools/authorize-tool-server.api.mdx
+++ b/docs/api/client-api/tools/authorize-tool-server.api.mdx
@@ -35,11 +35,7 @@ import Translate from "@docusaurus/Translate";
   
 </MethodEndpoint>
 
-:::info beta
-
-This endpoint is in Beta. Expect changes and instability.
-
-::::::experimental
+:::experimental
 
 This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
 

--- a/docs/api/client-api/tools/get-tool-server-auth-status.api.mdx
+++ b/docs/api/client-api/tools/get-tool-server-auth-status.api.mdx
@@ -35,11 +35,7 @@ import Translate from "@docusaurus/Translate";
   
 </MethodEndpoint>
 
-:::info beta
-
-This endpoint is in Beta. Expect changes and instability.
-
-::::::experimental
+:::experimental
 
 This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
 


### PR DESCRIPTION
## Summary

Follow-up to #611. That PR fixed the generator, but the already-committed `.api.mdx` files were produced *before* the fix, so pages like [`authorize-tool-server`](https://developers.glean.com/api/client-api/tools/authorize-tool-server) still rendered **both** the Beta and Experimental banners.

This regenerates the client API docs so the fix actually reaches the site.

## Affected pages

- `tools/authorize-tool-server`
- `tools/get-tool-server-auth-status`

Both were endpoints marked as *both* Beta and `x-glean-experimental`. The old output also merged the admonition fences (`::::::experimental`), which is what caused the nested banner look. Now each shows only the single **Experimental** banner.

## Notes

Data-file timestamp churn (`deprecations.json`, `experimental.json`, `deprecations.xml`) from the regeneration was reverted to keep the diff focused.