### PR TITLE
docs: show sidebar on experimental overview page

### DIFF
--- a/docs/experimental/overview.mdx
+++ b/docs/experimental/overview.mdx
@@ -1,6 +1,7 @@
 ---
 title: Experimental APIs
 description: How Glean ships experimental REST API features and how to opt in to preview them
+displayed_sidebar: docSidebar
 ---
 
 # Experimental APIs


### PR DESCRIPTION
## Summary

The `/experimental/overview` page was rendering as a standalone page with no sidebar because `docs/experimental/overview.mdx` was not attached to any sidebar.

This adds `displayed_sidebar: docSidebar` to the page frontmatter so the main `docSidebar` is shown for navigation.

## Testing

- `pnpm build` succeeds.

<img width="4064" height="2324" alt="2026-07-07 at 14 36 36@2x" src="https://github.com/user-attachments/assets/00aeb5be-3c8d-4b18-b5b8-97006a0c45c5" />
