### PR TITLE
feat(api): show introduced date in experimental banner

### DIFF
--- a/docs/api/client-api/tools/authorize-tool-server.api.mdx
+++ b/docs/api/client-api/tools/authorize-tool-server.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on July 2, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/client-api/tools/get-tool-server-auth-status.api.mdx
+++ b/docs/api/client-api/tools/get-tool-server-auth-status.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on July 2, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/platform-api/platform-agents-create-run.api.mdx
+++ b/docs/api/platform-api/platform-agents-create-run.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on May 12, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/platform-api/platform-agents-get-schemas.api.mdx
+++ b/docs/api/platform-api/platform-agents-get-schemas.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on May 12, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/platform-api/platform-agents-get.api.mdx
+++ b/docs/api/platform-api/platform-agents-get.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on May 12, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/platform-api/platform-agents-search.api.mdx
+++ b/docs/api/platform-api/platform-agents-search.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on May 12, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/docs/api/platform-api/platform-search.api.mdx
+++ b/docs/api/platform-api/platform-search.api.mdx
@@ -37,7 +37,7 @@ import Translate from "@docusaurus/Translate";
 
 :::experimental
 
-This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).
+Expect changes and instability. Introduced on April 8, 2026. [Learn how experimental APIs work](/experimental/overview).
 
 :::
 

--- a/scripts/generator/customMdGenerators.ts
+++ b/scripts/generator/customMdGenerators.ts
@@ -116,16 +116,44 @@ function createExperimentalAdmonition({ children }: Props) {
 }
 
 interface ExperimentalNoticeProps {
-  xGleanExperimental?: unknown;
+  xGleanExperimental?: { id?: string; introduced?: string } | unknown;
+}
+
+/**
+ * Format an ISO date (`YYYY-MM-DD`) as a human-readable string, e.g.
+ * "May 12, 2026". Parsed in UTC so the day doesn't drift across time zones.
+ * Returns `undefined` for missing or unparseable input.
+ */
+function formatIntroducedDate(introduced?: string): string | undefined {
+  if (!introduced) return undefined;
+  const date = new Date(introduced);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
 }
 
 function createExperimentalNotice({
   xGleanExperimental,
 }: ExperimentalNoticeProps) {
+  const introduced =
+    xGleanExperimental && typeof xGleanExperimental === 'object'
+      ? (xGleanExperimental as { introduced?: string }).introduced
+      : undefined;
+  const introducedDate = formatIntroducedDate(introduced);
+  const introducedSentence = introducedDate
+    ? ` Introduced on ${introducedDate}.`
+    : '';
+
   return guard(Boolean(xGleanExperimental), () =>
     createExperimentalAdmonition({
       children:
-        'This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).',
+        'Expect changes and instability.' +
+        introducedSentence +
+        ' [Learn how experimental APIs work](/experimental/overview).',
     }),
   );
 }


### PR DESCRIPTION
## What

Adds the **introduced date** to the experimental banner shown on API endpoint pages, and rewords the notice to lead with the stability warning.

Before:
> This endpoint is experimental. Expect changes and instability. [Learn how experimental APIs work](/experimental/overview).

After:
> Expect changes and instability. Introduced on May 12, 2026. [Learn how experimental APIs work](/experimental/overview).

## How

- `createExperimentalNotice` in `scripts/generator/customMdGenerators.ts` now reads `introduced` from the `x-glean-experimental` extension and appends `Introduced on <date>.` to the banner.
- Dates are parsed in UTC and formatted (e.g. `May 12, 2026`); when no `introduced` date is present, the sentence is omitted.
- Regenerated the 7 experimental endpoint pages (Platform search/agents + client-api tools) with the new copy.

## Screenshot

![Experimental banner with introduced date](https://raw.githubusercontent.com/gleanwork/glean-developer-site/aa9a0e3968a46d3f271dbbdfaeb14c666003fb7a/assets/experimental-banner.png)

## Testing

- `pnpm test` ✅ (123 passed)
