### PR TITLE
chore(changelog): 2026-07-09

### DIFF
--- a/changelog/entries/2026-07-08-api-client-go-0-13-2.md
+++ b/changelog/entries/2026-07-08-api-client-go-0-13-2.md
@@ -1,0 +1,17 @@
+---
+title: 'api-client-go v0.13.2'
+categories: ['API Clients']
+---
+
+Api-client-go v0.13.2 includes 1 addition, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.FeedRequest.Categories[].Enum(adminHealthCenter)` to `client.search.retrievefeed()`.
+- Changed `response.Results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.2)

--- a/changelog/entries/2026-07-08-api-client-java-0-14-2.md
+++ b/changelog/entries/2026-07-08-api-client-java-0-14-2.md
@@ -1,0 +1,17 @@
+---
+title: 'api-client-java v0.14.2'
+categories: ['API Clients']
+---
+
+Api-client-java v0.14.2 includes 1 addition, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.feedRequest.categories[].enum(adminHealthCenter)` to `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.2)

--- a/changelog/entries/2026-07-08-api-client-python-0-15-2.md
+++ b/changelog/entries/2026-07-08-api-client-python-0-15-2.md
@@ -1,0 +1,17 @@
+---
+title: 'api-client-python v0.15.2'
+categories: ['API Clients']
+---
+
+Api-client-python v0.15.2 includes 1 addition, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.categories[].enum(admin_health_center)` to `client.search.retrieve_feed()`.
+- Changed `response.results[]` on `client.search.retrieve_feed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.2)

--- a/changelog/entries/2026-07-08-api-client-typescript-0-17-2.md
+++ b/changelog/entries/2026-07-08-api-client-typescript-0-17-2.md
@@ -1,0 +1,17 @@
+---
+title: 'api-client-typescript v0.17.2'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.17.2 includes 1 addition, 1 change.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.feedRequest.categories[].enum(adminHealthCenter)` to `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.2)


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-07-09.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.14.2 | speakeasy | `changelog/entries/2026-07-08-api-client-java-0-14-2.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.2) |
| api-client-python | v0.15.2 | speakeasy | `changelog/entries/2026-07-08-api-client-python-0-15-2.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.2) |
| api-client-typescript | v0.17.2 | speakeasy | `changelog/entries/2026-07-08-api-client-typescript-0-17-2.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.2) |
| api-client-go | v0.13.2 | speakeasy | `changelog/entries/2026-07-08-api-client-go-0-13-2.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.2) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| mcp-config | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |
| open-api | no new open-api commits | skip |