### PR TITLE
chore(changelog): 2026-07-20

### DIFF
--- a/changelog/entries/2026-07-10-api-client-go-0-13-3.md
+++ b/changelog/entries/2026-07-10-api-client-go-0-13-3.md
@@ -1,0 +1,19 @@
+---
+title: 'api-client-go v0.13.3'
+categories: ['API Clients']
+---
+
+Api-client-go v0.13.3 includes 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Changed `request.ChatRequest.Messages[].Fragments[]` on `client.chat.create()`.
+- Changed `response.Messages[].Fragments[]` on `client.chat.create()`.
+- Changed `response.ChatResult.Chat.Messages[].Fragments[]` on `client.chat.retrieve()`.
+- Changed `request.ChatRequest.Messages[].Fragments[]` on `client.chat.createstream()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.3)

--- a/changelog/entries/2026-07-10-api-client-java-0-14-3.md
+++ b/changelog/entries/2026-07-10-api-client-java-0-14-3.md
@@ -1,0 +1,19 @@
+---
+title: 'api-client-java v0.14.3'
+categories: ['API Clients']
+---
+
+Api-client-java v0.14.3 includes 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Changed `request.chatRequest.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.chatResult.chat.messages[].fragments[]` on `client.chat.retrieve()`.
+- Changed `request.chatRequest.messages[].fragments[]` on `client.chat.createstream()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.3)

--- a/changelog/entries/2026-07-10-api-client-python-0-15-3.md
+++ b/changelog/entries/2026-07-10-api-client-python-0-15-3.md
@@ -1,0 +1,19 @@
+---
+title: 'api-client-python v0.15.3'
+categories: ['API Clients']
+---
+
+Api-client-python v0.15.3 includes 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Changed `request.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.chat_result.chat.messages[].fragments[]` on `client.chat.retrieve()`.
+- Changed `request.messages[].fragments[]` on `client.chat.create_stream()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.3)

--- a/changelog/entries/2026-07-10-api-client-typescript-0-17-3.md
+++ b/changelog/entries/2026-07-10-api-client-typescript-0-17-3.md
@@ -1,0 +1,19 @@
+---
+title: 'api-client-typescript v0.17.3'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.17.3 includes 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Changed `request.chatRequest.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.messages[].fragments[]` on `client.chat.create()`.
+- Changed `response.chatResult.chat.messages[].fragments[]` on `client.chat.retrieve()`.
+- Changed `request.chatRequest.messages[].fragments[]` on `client.chat.createstream()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.3)

--- a/changelog/entries/2026-07-14-mcp-config-5-3-0.md
+++ b/changelog/entries/2026-07-14-mcp-config-5-3-0.md
@@ -1,0 +1,17 @@
+---
+title: 'mcp-config v5.3.0'
+categories: ['MCP']
+---
+
+Mcp-config v5.3.0: `mcp-config-schema`: add Copilot Studio, Gemini Enterprise, and LibreChat clients.
+
+{/* truncate */}
+
+## Changes
+
+- `mcp-config-schema`: add Copilot Studio, Gemini Enterprise, and LibreChat clients.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.3.0)
+- [PR #124](https://github.com/gleanwork/mcp-config/pull/124)

--- a/changelog/entries/2026-07-15-mcp-config-5-4-0.md
+++ b/changelog/entries/2026-07-15-mcp-config-5-4-0.md
@@ -1,0 +1,19 @@
+---
+title: 'mcp-config v5.4.0'
+categories: ['MCP']
+---
+
+Mcp-config v5.4.0: `mcp-config-glean`, `mcp-config-schema`: add managed setup URLs.
+
+{/* truncate */}
+
+## Changes
+
+- `mcp-config-glean`, `mcp-config-schema`: add managed setup URLs.
+- `mcp-config-schema`: add Cursor Team MCP Servers client.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.4.0)
+- [PR #126](https://github.com/gleanwork/mcp-config/pull/126)
+- [PR #125](https://github.com/gleanwork/mcp-config/pull/125)

--- a/changelog/entries/2026-07-15-rest-api-changes-open-api.md
+++ b/changelog/entries/2026-07-15-rest-api-changes-open-api.md
@@ -1,0 +1,24 @@
+---
+title: 'REST API: changes (endpoints) 2026-07-15'
+categories: ['API']
+---
+
+2 endpoints added.
+
+{/* truncate */}
+
+## Changes
+
+- Added endpoint: /rest/api/index/submissions/{datasourceInstance}/{type}
+- Added endpoint: /submissions/{datasourceInstance}/{type}
+
+## Source
+
+- [open-api 0014369](https://github.com/gleanwork/open-api/commit/0014369d53ab6aeab9d28a4d3a24dea2361c43cd)
+- [open-api 0dce218](https://github.com/gleanwork/open-api/commit/0dce2185d014565fa994ea8b485b2c354632bc35)
+- [open-api 0dfbcff](https://github.com/gleanwork/open-api/commit/0dfbcffd5e93be2858b792645a4ad878be2c6c80)
+- [open-api 2d5869e](https://github.com/gleanwork/open-api/commit/2d5869e5349aa2221f85aa1b4e8138acc76e02f2)
+- [open-api 2da199e](https://github.com/gleanwork/open-api/commit/2da199e3d09b50fb6e535ce8d682e8faea0d5c4f)
+- [open-api 2e06973](https://github.com/gleanwork/open-api/commit/2e069735ae7931e10a7fc35947465d1995fcdb48)
+- [open-api 32e7a51](https://github.com/gleanwork/open-api/commit/32e7a5113a574eea522faa51c2d948e14af0c650)
+- [open-api 438762b](https://github.com/gleanwork/open-api/commit/438762b2397cac4b50c63dba42784619bca9279c)

--- a/changelog/entries/2026-07-19-glean-agent-toolkit-0-6-0.md
+++ b/changelog/entries/2026-07-19-glean-agent-toolkit-0-6-0.md
@@ -1,0 +1,63 @@
+---
+title: 'glean-agent-toolkit 0.6.0'
+categories: ['Glean Agent Toolkit']
+---
+
+Glean-agent-toolkit 0.6.0: **crewai**: pass args_schema to BaseTool so the LLM sees real parameters.
+
+{/* truncate */}
+
+## Action Required
+
+- Plan migration away from deprecated behavior.
+
+## Changes
+
+- Add installable skills for SDK usage and tool building.
+- Search API alignment, chat tool, deprecation path, get_tools, async support, import docs.
+- Injectable GleanContext replaces hidden api_client() global (#62).
+- **deps**: add [all] extra combining all framework adapters (CHK-001).
+- **crewai**: pass args_schema to BaseTool so the LLM sees real parameters.
+- **adk**: expose real typed signatures so declarations and invocation work.
+- **openai**: sanitize strict schemas and isolate per-tool conversion failures.
+- **adapters**: map anyOf/union and array item types correctly in get_field_type.
+- **langchain**: use StructuredTool so converted tools are invocable.
+- **tools**: stop closing shared Glean client on every tool call.
+- Correct web search tool name from 'Web Browser' to 'Gemini Web Search'.
+- Resolve remaining P2 eval items (CHK-111, CHK-115, CHK-118, CHK-119).
+- Resolve eval checklist items — dedup, dead code, error handling, imports.
+- Namespace tool names and optimize descriptions for LLM consumption.
+- Structured error results and consistent adapter return types.
+- Depend on langchain-core instead of langchain to support LangGraph 1.x.
+- Regenerate lockfile.
+- Align publish workflow tag trigger with commitizen tag format.
+- Use is not None checks in read_document validation.
+- Export Registry from top-level package.
+- Remove pydantic BaseModel from adapters public API.
+- Preserve float values in retry backoff config (CHK-002).
+- **release**: correct broken version_files path in .cz.toml (CHK-006).
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.0)
+- [PR #73](https://github.com/gleanwork/glean-agent-toolkit/pull/73)
+- [PR #77](https://github.com/gleanwork/glean-agent-toolkit/pull/77)
+- [PR #76](https://github.com/gleanwork/glean-agent-toolkit/pull/76)
+- [PR #75](https://github.com/gleanwork/glean-agent-toolkit/pull/75)
+- [PR #74](https://github.com/gleanwork/glean-agent-toolkit/pull/74)
+- [PR #72](https://github.com/gleanwork/glean-agent-toolkit/pull/72)
+- [PR #70](https://github.com/gleanwork/glean-agent-toolkit/pull/70)
+- [PR #66](https://github.com/gleanwork/glean-agent-toolkit/pull/66)
+- [PR #65](https://github.com/gleanwork/glean-agent-toolkit/pull/65)
+- [PR #27](https://github.com/gleanwork/glean-agent-toolkit/pull/27)
+- [PR #71](https://github.com/gleanwork/glean-agent-toolkit/pull/71)
+- [PR #68](https://github.com/gleanwork/glean-agent-toolkit/pull/68)
+- [PR #67](https://github.com/gleanwork/glean-agent-toolkit/pull/67)
+- [PR #58](https://github.com/gleanwork/glean-agent-toolkit/pull/58)
+- [PR #55](https://github.com/gleanwork/glean-agent-toolkit/pull/55)
+- [PR #54](https://github.com/gleanwork/glean-agent-toolkit/pull/54)
+- [PR #39](https://github.com/gleanwork/glean-agent-toolkit/pull/39)
+- [PR #37](https://github.com/gleanwork/glean-agent-toolkit/pull/37)
+- [PR #36](https://github.com/gleanwork/glean-agent-toolkit/pull/36)
+- [PR #35](https://github.com/gleanwork/glean-agent-toolkit/pull/35)
+- [PR #31](https://github.com/gleanwork/glean-agent-toolkit/pull/31)

--- a/changelog/entries/2026-07-19-glean-agent-toolkit-0-6-1.md
+++ b/changelog/entries/2026-07-19-glean-agent-toolkit-0-6-1.md
@@ -1,0 +1,29 @@
+---
+title: 'glean-agent-toolkit 0.6.1'
+categories: ['Glean Agent Toolkit']
+---
+
+Glean-agent-toolkit 0.6.1: **read_document**: support renamed retrieve kwarg across glean-api-client versions.
+
+{/* truncate */}
+
+## Changes
+
+- **read_document**: support renamed retrieve kwarg across glean-api-client versions.
+- **crewai**: pass args_schema to BaseTool so the LLM sees real parameters.
+- **adk**: expose real typed signatures so declarations and invocation work.
+- **openai**: sanitize strict schemas and isolate per-tool conversion failures.
+- **adapters**: map anyOf/union and array item types correctly in get_field_type.
+- **langchain**: use StructuredTool so converted tools are invocable.
+- **tools**: stop closing shared Glean client on every tool call.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.1)
+- [PR #81](https://github.com/gleanwork/glean-agent-toolkit/pull/81)
+- [PR #73](https://github.com/gleanwork/glean-agent-toolkit/pull/73)
+- [PR #77](https://github.com/gleanwork/glean-agent-toolkit/pull/77)
+- [PR #76](https://github.com/gleanwork/glean-agent-toolkit/pull/76)
+- [PR #75](https://github.com/gleanwork/glean-agent-toolkit/pull/75)
+- [PR #74](https://github.com/gleanwork/glean-agent-toolkit/pull/74)
+- [PR #72](https://github.com/gleanwork/glean-agent-toolkit/pull/72)

--- a/changelog/entries/2026-07-20-glean-agent-toolkit-0-7-0.md
+++ b/changelog/entries/2026-07-20-glean-agent-toolkit-0-7-0.md
@@ -1,0 +1,23 @@
+---
+title: 'glean-agent-toolkit 0.7.0'
+categories: ['Glean Agent Toolkit']
+---
+
+Glean-agent-toolkit 0.7.0: **tools**: add transport seam, typed search backend, result truncation, status-code errors.
+
+{/* truncate */}
+
+## Changes
+
+- **tools**: add transport seam, typed search backend, result truncation, status-code errors.
+- **chat**: read citations from fragments with legacy fallback.
+- **core**: ctx-aware as\_\*\_tool, registry collision warnings, retry unit fix.
+- **read_document**: support renamed retrieve kwarg across glean-api-client versions.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.7.0)
+- [PR #87](https://github.com/gleanwork/glean-agent-toolkit/pull/87)
+- [PR #83](https://github.com/gleanwork/glean-agent-toolkit/pull/83)
+- [PR #84](https://github.com/gleanwork/glean-agent-toolkit/pull/84)
+- [PR #81](https://github.com/gleanwork/glean-agent-toolkit/pull/81)


### PR DESCRIPTION
Adds 10 changelog entries generated on 2026-07-20.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.14.3 | speakeasy | `changelog/entries/2026-07-10-api-client-java-0-14-3.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.14.3) |
| api-client-python | v0.15.3 | speakeasy | `changelog/entries/2026-07-10-api-client-python-0-15-3.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.15.3) |
| api-client-typescript | v0.17.3 | speakeasy | `changelog/entries/2026-07-10-api-client-typescript-0-17-3.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.3) |
| api-client-go | v0.13.3 | speakeasy | `changelog/entries/2026-07-10-api-client-go-0-13-3.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.13.3) |
| glean-agent-toolkit | 0.7.0 | commitizen | `changelog/entries/2026-07-20-glean-agent-toolkit-0-7-0.md` | [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.7.0)<br />[PR #87](https://github.com/gleanwork/glean-agent-toolkit/pull/87)<br />[PR #83](https://github.com/gleanwork/glean-agent-toolkit/pull/83)<br />[PR #84](https://github.com/gleanwork/glean-agent-toolkit/pull/84)<br />[PR #81](https://github.com/gleanwork/glean-agent-toolkit/pull/81) |
| glean-agent-toolkit | 0.6.1 | commitizen | `changelog/entries/2026-07-19-glean-agent-toolkit-0-6-1.md` | [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.1)<br />[PR #81](https://github.com/gleanwork/glean-agent-toolkit/pull/81)<br />[PR #73](https://github.com/gleanwork/glean-agent-toolkit/pull/73)<br />[PR #77](https://github.com/gleanwork/glean-agent-toolkit/pull/77)<br />[PR #76](https://github.com/gleanwork/glean-agent-toolkit/pull/76)<br />[PR #75](https://github.com/gleanwork/glean-agent-toolkit/pull/75)<br />[PR #74](https://github.com/gleanwork/glean-agent-toolkit/pull/74)<br />[PR #72](https://github.com/gleanwork/glean-agent-toolkit/pull/72) |
| glean-agent-toolkit | 0.6.0 | commitizen | `changelog/entries/2026-07-19-glean-agent-toolkit-0-6-0.md` | [Release notes](https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.0)<br />[PR #73](https://github.com/gleanwork/glean-agent-toolkit/pull/73)<br />[PR #77](https://github.com/gleanwork/glean-agent-toolkit/pull/77)<br />[PR #76](https://github.com/gleanwork/glean-agent-toolkit/pull/76)<br />[PR #75](https://github.com/gleanwork/glean-agent-toolkit/pull/75)<br />[PR #74](https://github.com/gleanwork/glean-agent-toolkit/pull/74)<br />[PR #72](https://github.com/gleanwork/glean-agent-toolkit/pull/72)<br />[PR #70](https://github.com/gleanwork/glean-agent-toolkit/pull/70)<br />[PR #66](https://github.com/gleanwork/glean-agent-toolkit/pull/66)<br />[PR #65](https://github.com/gleanwork/glean-agent-toolkit/pull/65)<br />[PR #27](https://github.com/gleanwork/glean-agent-toolkit/pull/27)<br />[PR #71](https://github.com/gleanwork/glean-agent-toolkit/pull/71)<br />[PR #68](https://github.com/gleanwork/glean-agent-toolkit/pull/68)<br />[PR #67](https://github.com/gleanwork/glean-agent-toolkit/pull/67)<br />[PR #58](https://github.com/gleanwork/glean-agent-toolkit/pull/58)<br />[PR #55](https://github.com/gleanwork/glean-agent-toolkit/pull/55)<br />[PR #54](https://github.com/gleanwork/glean-agent-toolkit/pull/54)<br />[PR #39](https://github.com/gleanwork/glean-agent-toolkit/pull/39)<br />[PR #37](https://github.com/gleanwork/glean-agent-toolkit/pull/37)<br />[PR #36](https://github.com/gleanwork/glean-agent-toolkit/pull/36)<br />[PR #35](https://github.com/gleanwork/glean-agent-toolkit/pull/35)<br />[PR #31](https://github.com/gleanwork/glean-agent-toolkit/pull/31) |
| mcp-config | v5.4.0 | lerna-changelog | `changelog/entries/2026-07-15-mcp-config-5-4-0.md` | [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.4.0)<br />[PR #126](https://github.com/gleanwork/mcp-config/pull/126)<br />[PR #125](https://github.com/gleanwork/mcp-config/pull/125) |
| mcp-config | v5.3.0 | lerna-changelog | `changelog/entries/2026-07-14-mcp-config-5-3-0.md` | [Release notes](https://github.com/gleanwork/mcp-config/releases/tag/v5.3.0)<br />[PR #124](https://github.com/gleanwork/mcp-config/pull/124) |
| open-api | 2026-07-15 | openapi | `changelog/entries/2026-07-15-rest-api-changes-open-api.md` | [open-api 0014369](https://github.com/gleanwork/open-api/commit/0014369d53ab6aeab9d28a4d3a24dea2361c43cd)<br />[open-api 0dce218](https://github.com/gleanwork/open-api/commit/0dce2185d014565fa994ea8b485b2c354632bc35)<br />[open-api 0dfbcff](https://github.com/gleanwork/open-api/commit/0dfbcffd5e93be2858b792645a4ad878be2c6c80)<br />[open-api 2d5869e](https://github.com/gleanwork/open-api/commit/2d5869e5349aa2221f85aa1b4e8138acc76e02f2)<br />[open-api 2da199e](https://github.com/gleanwork/open-api/commit/2da199e3d09b50fb6e535ce8d682e8faea0d5c4f)<br />[open-api 2e06973](https://github.com/gleanwork/open-api/commit/2e069735ae7931e10a7fc35947465d1995fcdb48)<br />[open-api 32e7a51](https://github.com/gleanwork/open-api/commit/32e7a5113a574eea522faa51c2d948e14af0c650)<br />[open-api 438762b](https://github.com/gleanwork/open-api/commit/438762b2397cac4b50c63dba42784619bca9279c) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| mcp-server | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |