### PR TITLE
Add cookbook recipe schema, types, and validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "generate:experimental": "tsx scripts/generate-experimental.ts",
     "generate:deprecations:rss": "node scripts/generate-deprecations-rss.mjs",
     "generate:platform-errors": "tsx scripts/generate-platform-errors.ts",
+    "recipes:schema": "tsx scripts/generate-recipe-schema.ts",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "test": "vitest run",

--- a/schemas/recipe.schema.json
+++ b/schemas/recipe.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://developers.glean.com/schemas/recipe.schema.json",
+  "title": "Glean Cookbook Recipe",
+  "description": "The `recipe` frontmatter block of a cookbook recipe MDX file. Generated from src/types/recipe.ts — do not edit by hand.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$"
+    },
+    "surfaces": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "mcp",
+          "platform-api",
+          "web-sdk",
+          "connector-sdk",
+          "indexing-api",
+          "sdk-client",
+          "actions",
+          "agents"
+        ]
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["showcase", "production-pattern"]
+    },
+    "category": {
+      "type": "string",
+      "enum": ["search", "index", "mcp", "workflow", "agent", "portal"]
+    },
+    "level": {
+      "type": "string",
+      "enum": ["Beginner", "Intermediate", "Advanced"]
+    },
+    "levels": {
+      "type": "object",
+      "properties": {
+        "minimal": {
+          "type": "boolean"
+        },
+        "wow": {
+          "type": "boolean"
+        }
+      },
+      "required": ["minimal", "wow"],
+      "additionalProperties": false
+    },
+    "time_estimate": {
+      "type": "string",
+      "minLength": 1
+    },
+    "required_scopes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "prerequisites": {
+      "minItems": 1,
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "demo_queries": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "code_assets": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "repo_path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "language": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": ["repo_path", "language", "description"],
+        "additionalProperties": false
+      }
+    },
+    "scaffold_actions": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "scaffold-connector",
+          "scaffold-web-sdk-embed",
+          "scaffold-mcp-config",
+          "scaffold-n8n-workflow"
+        ]
+      }
+    },
+    "combines": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "surface": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "enum": ["search", "index", "mcp", "workflow", "agent", "portal"]
+          }
+        },
+        "required": ["title", "surface", "category"],
+        "additionalProperties": false
+      }
+    },
+    "architecture": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 1
+          },
+          "caption": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "enum": ["search", "index", "mcp", "workflow", "agent", "portal"]
+          },
+          "icon": {
+            "type": "string",
+            "minLength": 1
+          },
+          "emphasized": {
+            "default": false,
+            "type": "boolean"
+          }
+        },
+        "required": ["label", "caption"],
+        "additionalProperties": false
+      }
+    },
+    "ai_prompt": {
+      "type": "string",
+      "minLength": 1
+    },
+    "llm_context": {
+      "type": "string",
+      "minLength": 1
+    },
+    "last_verified": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))$"
+    },
+    "go_dependency": {
+      "default": false,
+      "type": "boolean"
+    },
+    "featured": {
+      "default": false,
+      "type": "boolean"
+    },
+    "tags": {
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": [
+    "id",
+    "surfaces",
+    "status",
+    "category",
+    "level",
+    "levels",
+    "time_estimate",
+    "required_scopes",
+    "prerequisites",
+    "ai_prompt"
+  ],
+  "additionalProperties": false
+}

--- a/scripts/generate-recipe-schema.ts
+++ b/scripts/generate-recipe-schema.ts
@@ -1,0 +1,31 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { z } from 'zod';
+import { recipeMetaSchema } from '../src/types/recipe';
+
+/**
+ * Generates schemas/recipe.schema.json from the zod schema in
+ * src/types/recipe.ts. The zod schema is the source of truth; the JSON
+ * Schema artifact exists for external consumers (the glean-cookbook
+ * plugin, the cookbook repo CI, editors).
+ *
+ * Run via `pnpm recipes:schema`.
+ */
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const outFile = path.join(repoRoot, 'schemas', 'recipe.schema.json');
+
+const jsonSchema = z.toJSONSchema(recipeMetaSchema, { io: 'input' });
+
+const artifact = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $id: 'https://developers.glean.com/schemas/recipe.schema.json',
+  title: 'Glean Cookbook Recipe',
+  description:
+    'The `recipe` frontmatter block of a cookbook recipe MDX file. Generated from src/types/recipe.ts — do not edit by hand.',
+  ...jsonSchema,
+};
+
+fs.mkdirSync(path.dirname(outFile), { recursive: true });
+fs.writeFileSync(outFile, `${JSON.stringify(artifact, null, 2)}\n`);
+console.log(`Wrote ${path.relative(repoRoot, outFile)}`);

--- a/src/types/recipe.test.ts
+++ b/src/types/recipe.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseRecipeFrontmatter,
+  recipeMetaSchema,
+  RECIPE_SCAFFOLD_ACTIONS,
+} from './recipe';
+
+function validFrontmatter() {
+  return {
+    title: 'Embed search & chat',
+    description:
+      'Put permission-aware Glean search and chat inside an internal app with the Web SDK.',
+    recipe: {
+      id: 'embed-search-chat',
+      surfaces: ['web-sdk', 'platform-api'],
+      status: 'production-pattern',
+      category: 'search',
+      level: 'Beginner',
+      levels: { minimal: true, wow: true },
+      time_estimate: '~15 min (minimal)',
+      required_scopes: ['search:read', 'chat:write'],
+      prerequisites: ['A Glean instance with content indexed'],
+      ai_prompt:
+        'Build the embed-search-chat recipe from developers.glean.com.',
+    },
+  };
+}
+
+describe('parseRecipeFrontmatter', () => {
+  it('accepts a valid frontmatter and composes the flat record', () => {
+    const result = parseRecipeFrontmatter(
+      validFrontmatter(),
+      'embed-search-chat',
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.record.id).toBe('embed-search-chat');
+    expect(result.record.title).toBe('Embed search & chat');
+    expect(result.record.summary).toMatch(/permission-aware/);
+    expect(result.record.permalink).toBe('/cookbook/embed-search-chat');
+    // defaults applied
+    expect(result.record.tags).toEqual([]);
+    expect(result.record.featured).toBe(false);
+    expect(result.record.go_dependency).toBe(false);
+  });
+
+  it('allows extra Docusaurus keys at the top level only', () => {
+    const fm = { ...validFrontmatter(), sidebar_label: 'Embed', slug: '/x' };
+    expect(parseRecipeFrontmatter(fm, 'embed-search-chat').success).toBe(true);
+  });
+
+  it('rejects unknown keys inside the recipe block', () => {
+    const fm = validFrontmatter();
+    (fm.recipe as Record<string, unknown>).surprise = true;
+    const result = parseRecipeFrontmatter(fm, 'embed-search-chat');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errors.join('\n')).toMatch(/recipe/);
+  });
+
+  it('rejects unknown enum values (surfaces, scaffold_actions)', () => {
+    const fm = validFrontmatter();
+    (fm.recipe as Record<string, unknown>).surfaces = ['web-sdkk'];
+    const result = parseRecipeFrontmatter(fm, 'embed-search-chat');
+    expect(result.success).toBe(false);
+
+    const fm2 = validFrontmatter();
+    (fm2.recipe as Record<string, unknown>).scaffold_actions = [
+      'scaffold-everything',
+    ];
+    expect(parseRecipeFrontmatter(fm2, 'embed-search-chat').success).toBe(
+      false,
+    );
+  });
+
+  it('rejects missing required fields with a path in the error', () => {
+    const fm = validFrontmatter();
+    delete (fm.recipe as Record<string, unknown>).ai_prompt;
+    const result = parseRecipeFrontmatter(fm, 'embed-search-chat');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errors.some((e) => e.includes('recipe.ai_prompt'))).toBe(
+      true,
+    );
+  });
+
+  it('rejects a non-kebab-case id', () => {
+    const fm = validFrontmatter();
+    fm.recipe.id = 'Embed_Search';
+    expect(parseRecipeFrontmatter(fm).success).toBe(false);
+  });
+
+  it('rejects an id that does not match the file name', () => {
+    const result = parseRecipeFrontmatter(validFrontmatter(), 'other-file');
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.errors[0]).toMatch(/must match the file name/);
+  });
+
+  it('rejects a malformed last_verified date', () => {
+    const fm = validFrontmatter();
+    (fm.recipe as Record<string, unknown>).last_verified = 'yesterday';
+    expect(parseRecipeFrontmatter(fm, 'embed-search-chat').success).toBe(false);
+  });
+});
+
+describe('recipeMetaSchema', () => {
+  it('exposes the four launch scaffold actions', () => {
+    expect(RECIPE_SCAFFOLD_ACTIONS).toHaveLength(4);
+    const fm = validFrontmatter();
+    (fm.recipe as Record<string, unknown>).scaffold_actions = [
+      ...RECIPE_SCAFFOLD_ACTIONS,
+    ];
+    expect(parseRecipeFrontmatter(fm, 'embed-search-chat').success).toBe(true);
+  });
+
+  it('requires at least one surface and prerequisite', () => {
+    for (const key of ['surfaces', 'prerequisites'] as const) {
+      const fm = validFrontmatter();
+      (fm.recipe as Record<string, unknown>)[key] = [];
+      expect(parseRecipeFrontmatter(fm, 'embed-search-chat').success).toBe(
+        false,
+      );
+    }
+  });
+});

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,0 +1,199 @@
+import { z } from 'zod';
+
+/**
+ * Recipe schema — the single source of truth for the Cookbooks section.
+ *
+ * A recipe is authored as one MDX file in `docs/cookbook/`. The page-level
+ * Docusaurus fields (`title`, `description`) double as the recipe's title and
+ * summary; everything else lives in a nested `recipe:` frontmatter block so
+ * recipe fields never collide with Docusaurus frontmatter.
+ *
+ * Consumed by:
+ * - `scripts/compile-recipes.ts` → `src/data/recipes.json` (build-failing validation)
+ * - the Cookbook components (index cards, filters, detail right rail)
+ * - the glean-cookbook plugin (scaffold actions, ai_prompt)
+ *
+ * `schemas/recipe.schema.json` is generated from this file via
+ * `pnpm recipes:schema` — do not edit that artifact by hand.
+ */
+
+export const RECIPE_SURFACES = [
+  'mcp',
+  'platform-api',
+  'web-sdk',
+  'connector-sdk',
+  'indexing-api',
+  'sdk-client',
+  'actions',
+  'agents',
+] as const;
+
+export const RECIPE_STATUSES = ['showcase', 'production-pattern'] as const;
+
+export const RECIPE_SURFACE_LABELS: Record<
+  (typeof RECIPE_SURFACES)[number],
+  string
+> = {
+  mcp: 'MCP',
+  'platform-api': 'Platform API',
+  'web-sdk': 'Web SDK',
+  'connector-sdk': 'Connector SDK',
+  'indexing-api': 'Indexing API',
+  'sdk-client': 'API clients',
+  actions: 'Actions',
+  agents: 'Agents',
+};
+
+export const RECIPE_STATUS_LABELS: Record<
+  (typeof RECIPE_STATUSES)[number],
+  string
+> = {
+  showcase: 'Showcase',
+  'production-pattern': 'Production pattern',
+};
+
+export const RECIPE_SCAFFOLD_ACTIONS = [
+  'scaffold-connector',
+  'scaffold-web-sdk-embed',
+  'scaffold-mcp-config',
+  'scaffold-n8n-workflow',
+] as const;
+
+/** Visual category — drives the pastel tile color and icon (design handoff). */
+export const RECIPE_CATEGORIES = [
+  'search',
+  'index',
+  'mcp',
+  'workflow',
+  'agent',
+  'portal',
+] as const;
+
+export const RECIPE_LEVELS = ['Beginner', 'Intermediate', 'Advanced'] as const;
+
+export const recipeCodeAssetSchema = z.strictObject({
+  repo_path: z.string().min(1),
+  language: z.string().min(1),
+  description: z.string().min(1),
+});
+
+/** One row in the flagship "Combines N recipes" list. */
+export const recipeCombinesSchema = z.strictObject({
+  title: z.string().min(1),
+  surface: z.string().min(1),
+  category: z.enum(RECIPE_CATEGORIES),
+});
+
+/** One node in the architecture flow diagram. */
+export const recipeArchitectureNodeSchema = z.strictObject({
+  label: z.string().min(1),
+  caption: z.string().min(1),
+  category: z.enum(RECIPE_CATEGORIES).optional(),
+  /** Explicit Glean icon name; overrides the category's default glyph. */
+  icon: z.string().min(1).optional(),
+  emphasized: z.boolean().default(false),
+});
+
+export const recipeMetaSchema = z.strictObject({
+  id: z
+    .string()
+    .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'id must be a kebab-case slug'),
+  surfaces: z.array(z.enum(RECIPE_SURFACES)).min(1),
+  status: z.enum(RECIPE_STATUSES),
+  category: z.enum(RECIPE_CATEGORIES),
+  level: z.enum(RECIPE_LEVELS),
+  levels: z.strictObject({
+    minimal: z.boolean(),
+    wow: z.boolean(),
+  }),
+  time_estimate: z.string().min(1),
+  required_scopes: z.array(z.string().min(1)),
+  prerequisites: z.array(z.string().min(1)).min(1),
+  demo_queries: z.array(z.string().min(1)).default([]),
+  code_assets: z.array(recipeCodeAssetSchema).default([]),
+  scaffold_actions: z.array(z.enum(RECIPE_SCAFFOLD_ACTIONS)).default([]),
+  combines: z.array(recipeCombinesSchema).optional(),
+  architecture: z.array(recipeArchitectureNodeSchema).optional(),
+  ai_prompt: z.string().min(1),
+  llm_context: z.string().min(1).optional(),
+  last_verified: z.iso.date().optional(),
+  go_dependency: z.boolean().default(false),
+  featured: z.boolean().default(false),
+  tags: z.array(z.string().min(1)).default([]),
+});
+
+/**
+ * Frontmatter of a recipe MDX file: Docusaurus page fields we rely on plus
+ * the nested recipe block. Other Docusaurus frontmatter keys are allowed.
+ */
+export const recipeFrontmatterSchema = z.looseObject({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  recipe: recipeMetaSchema,
+});
+
+export type RecipeCodeAsset = z.infer<typeof recipeCodeAssetSchema>;
+export type RecipeMeta = z.infer<typeof recipeMetaSchema>;
+export type RecipeFrontmatter = z.infer<typeof recipeFrontmatterSchema>;
+
+/** The flat, compiled record consumed by components and the plugin. */
+export type RecipeRecord = RecipeMeta & {
+  title: string;
+  summary: string;
+  /** Site-relative permalink to the recipe page, e.g. `/cookbook/embed-search-chat`. */
+  permalink: string;
+};
+
+/** Shape of the generated `src/data/recipes.json`. */
+export type RecipesData = {
+  recipes: RecipeRecord[];
+  surfaces: string[];
+  generatedAt: string;
+  totalRecipes: number;
+};
+
+export type RecipeValidationResult =
+  | { success: true; record: RecipeRecord }
+  | { success: false; errors: string[] };
+
+function formatIssues(error: z.ZodError): string[] {
+  return error.issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '(root)';
+    return `${path}: ${issue.message}`;
+  });
+}
+
+/**
+ * Validates a recipe MDX file's frontmatter and composes the flat record.
+ * `expectedId` is the file's basename; it must match `recipe.id` so slugs,
+ * filenames, and permalinks never drift.
+ */
+export function parseRecipeFrontmatter(
+  frontmatter: unknown,
+  expectedId?: string,
+): RecipeValidationResult {
+  const parsed = recipeFrontmatterSchema.safeParse(frontmatter);
+  if (!parsed.success) {
+    return { success: false, errors: formatIssues(parsed.error) };
+  }
+
+  const { title, description, recipe } = parsed.data;
+  if (expectedId !== undefined && recipe.id !== expectedId) {
+    return {
+      success: false,
+      errors: [
+        `recipe.id: "${recipe.id}" must match the file name "${expectedId}"`,
+      ],
+    };
+  }
+
+  return {
+    success: true,
+    record: {
+      ...recipe,
+      title,
+      summary: description,
+      permalink: `/cookbook/${recipe.id}`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Foundation for the flag-gated Cookbook section: a zod schema as the single source of truth for recipe MDX frontmatter (nested `recipe:` block — page title/description double as recipe title/summary), build-failing validation helpers, and a generated JSON Schema artifact (`pnpm recipes:schema`) for external consumers (planned glean-cookbook plugin, cookbook repo CI).

Part 1 of a 4-PR stack; nothing user-visible until #628, and the whole section stays behind the `cookbook` feature flag (off by default).

## Verification
- `pnpm vitest run src/types/recipe.test.ts` — 10 tests (enum/id/date validation, defaults, id↔filename match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
