### PR TITLE
Add recipe compile pipeline wired into Turbo

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "generate:deprecations:rss": "node scripts/generate-deprecations-rss.mjs",
     "generate:platform-errors": "tsx scripts/generate-platform-errors.ts",
     "recipes:schema": "tsx scripts/generate-recipe-schema.ts",
+    "recipes:compile": "tsx scripts/compile-recipes.ts",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "test": "vitest run",

--- a/scripts/compile-recipes.ts
+++ b/scripts/compile-recipes.ts
@@ -1,0 +1,116 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import yaml from 'js-yaml';
+import { parseRecipeFrontmatter } from '../src/types/recipe';
+import { RECIPE_SURFACES } from '../src/types/recipe';
+import type { RecipeRecord, RecipesData } from '../src/types/recipe';
+
+/**
+ * Compiles cookbook recipes into src/data/recipes.json.
+ *
+ * Reads every .mdx file in docs/cookbook/ (except index.mdx), validates the
+ * frontmatter `recipe:` block against the schema in src/types/recipe.ts, and
+ * emits the flat records consumed by the Cookbook components and the
+ * glean-cookbook plugin.
+ *
+ * Validation failures FAIL THE BUILD (exit 1) — lax registries rot.
+ *
+ * Wired into Turbo as //#recipes:compile (a dependsOn of //#docusaurus:build),
+ * mirroring //#changelog:aggregate. Run directly via `pnpm recipes:compile`.
+ */
+
+const repoRoot = path.resolve(import.meta.dirname, '..');
+const recipesDir = path.join(repoRoot, 'docs', 'cookbook');
+const outputFile = path.join(repoRoot, 'src', 'data', 'recipes.json');
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+function extractFrontmatter(source: string, fileName: string): unknown {
+  const match = source.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`${fileName}: no frontmatter block found`);
+  }
+  return yaml.load(match[1]);
+}
+
+function main(): void {
+  const records: RecipeRecord[] = [];
+  const errors: string[] = [];
+
+  const files = fs.existsSync(recipesDir)
+    ? fs
+        .readdirSync(recipesDir)
+        .filter((file) => file.endsWith('.mdx') && file !== 'index.mdx')
+        .sort()
+    : [];
+
+  for (const fileName of files) {
+    const filePath = path.join(recipesDir, fileName);
+    const expectedId = path.basename(fileName, '.mdx');
+
+    let frontmatter: unknown;
+    try {
+      frontmatter = extractFrontmatter(
+        fs.readFileSync(filePath, 'utf-8'),
+        fileName,
+      );
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : String(error));
+      continue;
+    }
+
+    const result = parseRecipeFrontmatter(frontmatter, expectedId);
+    if (!result.success) {
+      errors.push(...result.errors.map((e) => `${fileName}: ${e}`));
+      continue;
+    }
+    records.push(result.record);
+  }
+
+  const duplicates = records
+    .map((r) => r.id)
+    .filter((id, i, ids) => ids.indexOf(id) !== i);
+  if (duplicates.length > 0) {
+    errors.push(`duplicate recipe ids: ${[...new Set(duplicates)].join(', ')}`);
+  }
+
+  if (errors.length > 0) {
+    console.error(`Recipe validation failed (${errors.length} error(s)):`);
+    for (const error of errors) {
+      console.error(`  - ${error}`);
+    }
+    process.exit(1);
+  }
+
+  // generatedAt mirrors the changelog convention (derived from content, not
+  // wall-clock) so the committed artifact stays deterministic for Turbo.
+  const latestVerified = records
+    .map((r) => r.last_verified)
+    .filter((d): d is string => Boolean(d))
+    .sort()
+    .at(-1);
+
+  // Facet chips follow the design's deliberate order (the schema enum
+  // order), not alphabetical.
+  const enumOrder = (order: readonly string[]) => (a: string, b: string) =>
+    order.indexOf(a) - order.indexOf(b);
+
+  const data: RecipesData = {
+    recipes: records,
+    surfaces: [...new Set(records.flatMap((r) => r.surfaces))].sort(
+      enumOrder(RECIPE_SURFACES),
+    ),
+    generatedAt: latestVerified
+      ? new Date(`${latestVerified}T00:00:00.000Z`).toISOString()
+      : new Date(0).toISOString(),
+    totalRecipes: records.length,
+  };
+
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, `${JSON.stringify(data, null, 2)}\n`);
+  console.log(
+    `Generated recipes data with ${records.length} recipe(s) from ${files.length} file(s)`,
+  );
+}
+
+main();

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -1,0 +1,6 @@
+{
+  "recipes": [],
+  "surfaces": [],
+  "generatedAt": "1970-01-01T00:00:00.000Z",
+  "totalRecipes": 0
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "globalEnv": ["FF_*", "FEATURE_FLAGS_JSON"],
   "tasks": {
     "//#changelog:aggregate": {
       "inputs": [
@@ -7,6 +8,15 @@
         "packages/changelog-generator/src/**/*.ts"
       ],
       "outputs": ["src/data/changelog.json"],
+      "cache": true
+    },
+    "//#recipes:compile": {
+      "inputs": [
+        "docs/cookbook/**/*.mdx",
+        "src/types/recipe.ts",
+        "scripts/compile-recipes.ts"
+      ],
+      "outputs": ["src/data/recipes.json"],
       "cache": true
     },
     "//#generate:rss": {
@@ -19,7 +29,11 @@
       "cache": true
     },
     "//#docusaurus:build": {
-      "dependsOn": ["//#changelog:aggregate", "//#generate:rss"],
+      "dependsOn": [
+        "//#changelog:aggregate",
+        "//#generate:rss",
+        "//#recipes:compile"
+      ],
       "inputs": [
         "docs/**",
         "src/**",
@@ -36,8 +50,16 @@
       "cache": true
     },
     "//#prepare-dev": {
-      "dependsOn": ["//#changelog:aggregate", "//#generate:rss"],
-      "outputs": ["src/data/changelog.json", "static/changelog.xml"],
+      "dependsOn": [
+        "//#changelog:aggregate",
+        "//#generate:rss",
+        "//#recipes:compile"
+      ],
+      "outputs": [
+        "src/data/changelog.json",
+        "static/changelog.xml",
+        "src/data/recipes.json"
+      ],
       "cache": true
     },
     "//#dev": {


### PR DESCRIPTION
## Summary
`scripts/compile-recipes.ts` validates every `docs/cookbook/*.mdx` frontmatter block against the recipe schema — build-failing on any violation (unknown enums, id/filename mismatch, duplicate ids) — and emits `src/data/recipes.json`, mirroring the changelog aggregate pipeline (`//#recipes:compile` Turbo task).

Also declares `FF_*` and `FEATURE_FLAGS_JSON` in Turbo `globalEnv`: strict env mode was silently stripping feature-flag env vars from the docusaurus build subprocess **and** omitting them from cache keys (a flag-on build could replay a cached flag-off build). This fix benefits all build-time flags, not just the cookbook.

Part 2 of 4; recipes.json is empty until #628 adds content.

## Verification
- `pnpm recipes:compile` and `pnpm turbo run //#recipes:compile` both green (0 recipes at this point in the stack)
- Validation failure path exits 1 with path-qualified errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
