### PR TITLE
Add flag-gated Cookbook section: pages, recipes, IA

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -36,3 +36,4 @@ openapi
 changelog
 src/data/changelog.json
 src/data/deprecations.json
+src/data/recipes.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,33 @@ AVOID RUNNING `pnpm start` - this causes very slow build times, and will interup
 Project-local Claude Code skills live under `.claude/skills/`. Load the relevant skill when its scenario triggers:
 
 - **`.claude/skills/fix-broken-links/SKILL.md`** — Use when investigating a `Broken Links Detected` issue or a failing `Link Checker` workflow run. The nightly link checker emits a `link-check-fixme.md` artifact designed to be handed directly to an agent; the skill describes the project conventions for triaging the failures, where exclusions belong, and how to verify a fix.
+
+## Cookbook recipes
+
+Recipes live in `docs/cookbook/*.mdx` — one file per recipe. The frontmatter
+`recipe:` block is the machine-readable schema record (validated by
+`src/types/recipe.ts`; JSON Schema artifact at `schemas/recipe.schema.json`);
+the MDX body is the prose. `pnpm recipes:compile` validates every recipe and
+emits `src/data/recipes.json`, which drives the `/cookbook` index, the recipe
+right rail, and the homepage band. Validation failures fail the build.
+
+To add a recipe:
+
+1. Create `docs/cookbook/<id>.mdx`. The filename must equal `recipe.id`
+   (kebab-case). Copy the frontmatter shape from
+   `docs/cookbook/embed-search-chat.mdx`.
+2. Set page `title`/`description` — they double as the recipe's title and
+   summary. Put everything else in the `recipe:` block (personas, surfaces,
+   status, levels, time_estimate, required_scopes, prerequisites,
+   demo_queries, code_assets, scaffold_actions, ai_prompt, llm_context, tags).
+3. Wrap the body in `<RecipePage recipeId="<id>">` and use the standard
+   sections: Problem, Architecture (mermaid), Prerequisites, Steps
+   (`<Steps>`/`<Step>`), Extensions (wow).
+4. Only document verified APIs — source code samples from the published
+   guides (e.g. `docs/libraries/web-sdk/`), never from memory. Scope names,
+   endpoints, and function names must exist in the docs.
+5. `featured: true` surfaces the recipe on the homepage band (max 3 shown);
+   a `flagship` tag renders the flagship card treatment.
+6. Verify with `pnpm recipes:compile`, `pnpm test`, and `pnpm build`
+   (the Cookbooks nav/band are gated behind the `cookbook` feature flag —
+   build with `FF_COOKBOOKS=true` to see them).

--- a/docs/cookbook/build-engineering-portal.mdx
+++ b/docs/cookbook/build-engineering-portal.mdx
@@ -1,0 +1,162 @@
+---
+title: Build an engineering portal
+description: >-
+  The end-to-end showcase — index a developer catalog into Glean, then embed
+  permission-aware search and chat back into the portal your team already
+  uses.
+slug: /cookbook/build-engineering-portal
+hide_table_of_contents: true
+hide_title: true
+pagination_prev: null
+pagination_next: null
+recipe:
+  id: build-engineering-portal
+  surfaces:
+    - connector-sdk
+    - indexing-api
+    - web-sdk
+    - platform-api
+  status: showcase
+  category: portal
+  level: Intermediate
+  levels:
+    minimal: true
+    wow: true
+  time_estimate: '~30 min'
+  required_scopes:
+    - SEARCH
+    - CHAT
+  prerequisites:
+    - A Glean instance where you can add a custom datasource
+    - A Glean-issued Indexing API token
+    - Node.js 18+ to run the portal app locally
+  demo_queries:
+    - Who owns the payments service?
+    - What is the on-call runbook for checkout?
+    - Show me the docs for the identity service
+  scaffold_actions:
+    - scaffold-connector
+    - scaffold-web-sdk-embed
+  combines:
+    - title: Index a developer catalog
+      surface: Connector SDK
+      category: index
+    - title: Embed search into the portal
+      surface: Web SDK
+      category: search
+    - title: Ground chat in the catalog
+      surface: Platform API
+      category: mcp
+  architecture:
+    - label: Service catalog
+      caption: YAML + runbooks
+      category: index
+    - label: Custom connector
+      caption: Indexing API
+      category: workflow
+      icon: plug
+    - label: Glean
+      caption: permission-aware index
+      emphasized: true
+    - label: Portal UI
+      caption: Web SDK embed
+      category: portal
+      icon: layout-outlined
+  ai_prompt: |-
+    Build the "Engineering portal with Glean" flagship recipe from
+    https://developers.glean.com/cookbook/build-engineering-portal
+
+    It composes two published recipes:
+    1. Index the portal's service catalog into Glean with the open-source
+       indexing SDK (see the Index a custom data source recipe and
+       https://developers.glean.com/api-info/indexing/getting-started/overview).
+    2. Embed Glean search and chat into the portal UI with the Web SDK (see
+       https://developers.glean.com/cookbook/embed-search-chat).
+
+    Ask me for: my Glean instance/backend domain, an Indexing API token, and
+    my Glean web app domain. Verify at the end that a search for a service
+    name returns the indexed catalog entry, respecting my permissions.
+  llm_context: >-
+    Flagship showcase composing the custom-connector and Web SDK embed
+    recipes: a service-catalog portal whose catalog is indexed into Glean via
+    the indexing SDK, with Glean search and chat embedded back into the
+    portal UI. Requires a Glean-issued Indexing API token for the connector
+    and SEARCH/CHAT scopes for the embed.
+  go_dependency: false
+  featured: false
+  tags:
+    - flagship
+    - portal
+---
+
+import RecipePage from '@site/src/components/Cookbook/RecipePage';
+import {
+  RecipeSection,
+  RecipeArchitecture,
+  RecipePrereqs,
+  RecipeSteps,
+  RecipeNote,
+  TakeItFurther,
+} from '@site/src/components/Cookbook/RecipeLayout';
+
+<RecipePage recipeId="build-engineering-portal">
+
+<RecipeSection label="Problem">
+
+Service ownership, on-call, and docs live in a portal nobody can search,
+and the knowledge about those services lives everywhere else. This recipe
+turns a lightweight service-catalog portal into the one-stop shop: its
+catalog becomes searchable in Glean, and Glean's permission-aware search
+and chat come back into the portal itself.
+
+</RecipeSection>
+
+<RecipeArchitecture />
+
+<RecipePrereqs />
+
+<RecipeSteps>
+
+<>
+Index the catalog: follow the connector recipe to push the portal's
+service catalog (services, owners, runbooks) into Glean with the
+[Indexing API](/api-info/indexing/getting-started/overview) and the
+open-source indexing SDK. Verify a service shows up in Glean search.
+
+</>
+
+<>
+Embed search and chat: follow the
+[Embed search & chat recipe](/cookbook/embed-search-chat) inside the
+portal — the Web SDK script tag, a search route, and a chat container.
+
+</>
+
+<>
+Ground answers in the catalog: with the catalog indexed, chat answers
+questions like "who owns the payments service?" from the portal's own
+data — permission-aware, with citations back to the catalog entries.
+
+</>
+
+</RecipeSteps>
+
+<RecipeNote>
+
+The clonable portal starter repo is in progress — until it lands, this
+recipe composes the two linked recipes against your own portal or a plain
+Next.js app.
+
+</RecipeNote>
+
+<TakeItFurther>
+
+<>Add an on-call answer card to the portal backed by a Platform API search call.</>
+
+<>Extend the connector with incremental sync and identity mapping so catalog permissions mirror your org.</>
+
+<>Wire the portal's "ask" box to open Glean Chat with the current service as context.</>
+
+</TakeItFurther>
+
+</RecipePage>

--- a/docs/cookbook/embed-search-chat.mdx
+++ b/docs/cookbook/embed-search-chat.mdx
@@ -1,0 +1,177 @@
+---
+title: Embed search & chat in an internal app
+description: >-
+  Put permission-aware Glean search and chat directly inside an internal app
+  with the Web SDK, so your team gets answers where they already work.
+slug: /cookbook/embed-search-chat
+hide_table_of_contents: true
+hide_title: true
+pagination_prev: null
+pagination_next: null
+recipe:
+  id: embed-search-chat
+  surfaces:
+    - web-sdk
+  status: production-pattern
+  category: search
+  level: Beginner
+  levels:
+    minimal: true
+    wow: true
+  time_estimate: '~15 min (minimal)'
+  required_scopes:
+    - SEARCH
+    - CHAT
+  prerequisites:
+    - A Glean instance with content indexed
+    - Your Glean web app domain (typically app.glean.com — see admin/about-glean)
+    - A frontend app or page where you can add a script tag and a container element
+    - 'For token auth only: an admin API key from the Token Management page'
+  demo_queries:
+    - What is our PTO policy?
+    - Who owns the payments service?
+    - Summarize the latest incident review
+  scaffold_actions:
+    - scaffold-web-sdk-embed
+  architecture:
+    - label: Internal app
+      caption: Your existing frontend
+      icon: layout-outlined
+    - label: Glean Web SDK
+      caption: search + chat UI
+      category: search
+      icon: message-with-sparkles
+    - label: Auth
+      caption: SSO or scoped token
+      category: agent
+      icon: verification
+    - label: Glean
+      caption: permission-aware index
+      emphasized: true
+  ai_prompt: |-
+    Embed Glean search and chat in my internal web app using the Glean Web
+    SDK, following the recipe at
+    https://developers.glean.com/cookbook/embed-search-chat
+
+    Steps:
+    1. Ask me for my Glean web app domain (typically app.glean.com).
+    2. Add the Web SDK script tag to the page <head>:
+       <script defer src="https://{GLEAN_APP_DOMAIN}/embedded-search-latest.min.js"></script>
+    3. Add a search box and results container, and render them with
+       window.GleanWebSDK.renderSearchBox(...) and
+       window.GleanWebSDK.renderSearchResults(...).
+    4. Add a chat container (position: relative, display: block, explicit
+       width/height) and render it with
+       window.EmbeddedSearch.renderChat(containerElement).
+    5. Default SSO auth needs no extra configuration. If I ask for
+       server-to-server auth instead, follow
+       https://developers.glean.com/libraries/web-sdk/authentication/server-to-server
+       and keep the API key strictly server-side.
+
+    Verify by running the app and issuing a search; results must respect my
+    Glean permissions.
+  llm_context: >-
+    Embeds Glean search and chat into an existing web app via the Glean Web
+    SDK (script tag, window.GleanWebSDK.renderSearchBox/renderSearchResults,
+    window.EmbeddedSearch.renderChat). Auth is Glean SSO by default or
+    server-to-server tokens minted by a backend holding an admin API key with
+    SEARCH and CHAT scopes. All results are permission-aware per user.
+  go_dependency: false
+  featured: true
+  tags:
+    - embed
+    - web-sdk
+---
+
+import RecipePage from '@site/src/components/Cookbook/RecipePage';
+import {
+  RecipeSection,
+  RecipeArchitecture,
+  RecipePrereqs,
+  RecipeSteps,
+  TakeItFurther,
+} from '@site/src/components/Cookbook/RecipeLayout';
+
+<RecipePage recipeId="embed-search-chat">
+
+<RecipeSection label="Problem">
+
+Your team lives in an internal tool and context-switches to find answers.
+Instead of sending them elsewhere, bring Glean's answers into the app they
+already use — with permissions enforced per user, automatically.
+
+</RecipeSection>
+
+<RecipeArchitecture />
+
+<RecipePrereqs />
+
+<RecipeSteps>
+
+<>
+Include the Web SDK: add the JavaScript client to the `<head>` of your
+page, replacing `GLEAN_APP_DOMAIN` with your Glean web app domain.
+
+```html
+<script
+  defer
+  src="https://{GLEAN_APP_DOMAIN}/embedded-search-latest.min.js"
+></script>
+```
+
+</>
+
+<>
+Render search: add a search box and a results container, then render both
+components. See the [Autocomplete + Search Page guide](/libraries/web-sdk/components/autocomplete)
+for the full options.
+
+```javascript
+window.GleanWebSDK.renderSearchBox(searchBoxElement, {
+  onSearch: (query) => {
+    window.GleanWebSDK.renderSearchResults(resultsElement, { query });
+  },
+});
+```
+
+</>
+
+<>
+Render chat: create a container element with `position: relative`,
+`display: block`, and an explicit width and height, then render Glean Chat
+into it.
+
+```javascript
+window.EmbeddedSearch.renderChat(containerElement);
+```
+
+</>
+
+<>
+Authenticate users: with the default setup, users authenticate through your
+company's SSO — no extra configuration. To skip the SSO prompt (or support
+users without Glean accounts), use
+[server-to-server authentication](/libraries/web-sdk/authentication/server-to-server):
+your backend mints short-lived user tokens with an admin API key
+(`SEARCH` and `CHAT` scopes). Keep that key strictly server-side.
+
+</>
+
+</RecipeSteps>
+
+Try it with a query like **"What is our PTO policy?"** — results reflect
+exactly what the signed-in user is permitted to see.
+
+<TakeItFurther>
+
+<>Hand off context between search and chat so a search result opens a grounded conversation ([separate pages for chat and search](/libraries/web-sdk/components/chat)).</>
+
+<>Scope chat to your app's context by passing an AI App `applicationId` to the chat component.</>
+
+<>Go tokenless for guests with the Web SDK's guest auth provider for public-facing deployments.</>
+
+<>Add the [Modal Search](/libraries/web-sdk/components/modal-search) or [Sidebar](/libraries/web-sdk/components/sidebar) variants for search anywhere in the app.</>
+
+</TakeItFurther>
+
+</RecipePage>

--- a/docs/cookbook/index.mdx
+++ b/docs/cookbook/index.mdx
@@ -1,0 +1,20 @@
+---
+title: Cookbook
+description: >-
+  Recipes for building on Glean — every recipe includes the problem,
+  architecture, prerequisites, runnable code, auth and permissions, and how
+  to push it further.
+slug: /cookbook
+hide_table_of_contents: true
+pagination_prev: null
+pagination_next: null
+hide_title: true
+---
+
+import RecipeIndex from '@site/src/components/Cookbook/RecipeIndex';
+import recipesData from '@site/src/data/recipes.json';
+
+<RecipeIndex
+  recipes={recipesData.recipes}
+  surfaces={recipesData.surfaces}
+/>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -94,6 +94,31 @@ const baseSidebars: SidebarsConfig = {
       items: [
         {
           type: 'category',
+          label: 'Cookbook',
+          customProps: {
+            icon: 'BookOpen',
+            iconSet: 'feather',
+            flag: 'cookbook',
+          },
+          link: {
+            type: 'doc',
+            id: 'cookbook/index',
+          },
+          items: [
+            {
+              type: 'doc',
+              id: 'cookbook/embed-search-chat',
+              label: 'Embed search & chat',
+            },
+            {
+              type: 'doc',
+              id: 'cookbook/build-engineering-portal',
+              label: 'Build an engineering portal',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Chat',
           customProps: {
             icon: 'chat',

--- a/src/components/Homepage/CookbookSection.module.css
+++ b/src/components/Homepage/CookbookSection.module.css
@@ -1,0 +1,48 @@
+.band {
+  border: 1px solid var(--ifm-color-emphasis-200);
+  border-radius: var(--glean-border-radius-2xl);
+  /* Glean ivory, per the glean.com marketing palette */
+  background: var(--glean-brand-ivory);
+  padding: 2.25rem 2rem 1.5rem;
+}
+
+html[data-theme='dark'] .band {
+  background: linear-gradient(
+    160deg,
+    var(--ifm-color-primary-contrast-background) 0%,
+    var(--ifm-background-surface-color) 70%
+  );
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.kicker {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ifm-color-primary);
+  margin-bottom: 0.4rem;
+}
+
+.heading {
+  margin-bottom: 0.5rem;
+}
+
+.subheading {
+  color: var(--ifm-color-emphasis-700);
+  max-width: 42rem;
+  margin-bottom: 0.5rem;
+}
+
+.cta {
+  flex-shrink: 0;
+  margin-top: 1.4rem;
+}

--- a/src/components/Homepage/CookbookSection.tsx
+++ b/src/components/Homepage/CookbookSection.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import Card from '@theme/Card';
+import { GLEAN_BRAND_COLORS } from '@gleanwork/docusaurus-theme-glean/brandColors';
+import recipesData from '@site/src/data/recipes.json';
+import type { RecipesData } from '../../types/recipe';
+import { SURFACE_ICONS } from '../Cookbook/RecipeCard';
+import styles from './CookbookSection.module.css';
+import homeStyles from './index.module.css';
+
+/**
+ * "Build something with Glean" band on the landing page. Renders the
+ * `featured` recipes from the compiled schema; renders nothing when no
+ * recipe is featured, so the band cannot ship half-empty.
+ */
+export default function CookbookSection(): React.ReactElement | null {
+  const featured = (recipesData as RecipesData).recipes
+    .filter((recipe) => recipe.featured)
+    .slice(0, 3);
+
+  if (featured.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      className={clsx('container', homeStyles.wideContainer, 'margin-vert--l')}
+    >
+      <div className={styles.band}>
+        <div className={styles.header}>
+          <div>
+            <span className={styles.kicker}>Cookbooks</span>
+            <h2 className={styles.heading}>Build something with Glean</h2>
+            <p className={styles.subheading}>
+              Copy-paste recipes that take you from a pattern to a running demo
+              to scaffolded starter code — each with exact scopes, runnable
+              code, and a prompt your AI assistant can build from.
+            </p>
+          </div>
+          <Link
+            className={clsx('button', 'button--primary', styles.cta)}
+            to="/cookbook"
+          >
+            Browse all recipes →
+          </Link>
+        </div>
+        <div className="row">
+          {featured.map((recipe) => (
+            <div className="col col--4 margin-vert--sm" key={recipe.id}>
+              <div className={homeStyles.featureCard}>
+                <Card
+                  title={recipe.title}
+                  icon={SURFACE_ICONS[recipe.surfaces[0]] ?? 'Code'}
+                  iconSet="feather"
+                  href={recipe.permalink}
+                  color={GLEAN_BRAND_COLORS.PRIMARY_BLUE}
+                >
+                  {recipe.summary}
+                </Card>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -4,7 +4,9 @@ import Link from '@docusaurus/Link';
 import styles from './index.module.css';
 import Card from '@theme/Card';
 import CarouselSection from './CarouselSection';
+import CookbookSection from './CookbookSection';
 import IDEPluginSection from './IDEPluginSection';
+import FeatureFlag from '../FeatureFlag';
 import { GLEAN_BRAND_COLORS } from '@gleanwork/docusaurus-theme-glean/brandColors';
 
 type Feature = {
@@ -77,6 +79,11 @@ export default function Home() {
 
       {/* Dynamic Carousel Section */}
       <CarouselSection />
+
+      {/* Cookbook band — renders featured recipes from the compiled schema */}
+      <FeatureFlag flag="cookbook">
+        <CookbookSection />
+      </FeatureFlag>
 
       <hr />
 

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -1,6 +1,174 @@
 {
-  "recipes": [],
-  "surfaces": [],
+  "recipes": [
+    {
+      "id": "build-engineering-portal",
+      "surfaces": [
+        "connector-sdk",
+        "indexing-api",
+        "web-sdk",
+        "platform-api"
+      ],
+      "status": "showcase",
+      "category": "portal",
+      "level": "Intermediate",
+      "levels": {
+        "minimal": true,
+        "wow": true
+      },
+      "time_estimate": "~30 min",
+      "required_scopes": [
+        "SEARCH",
+        "CHAT"
+      ],
+      "prerequisites": [
+        "A Glean instance where you can add a custom datasource",
+        "A Glean-issued Indexing API token",
+        "Node.js 18+ to run the portal app locally"
+      ],
+      "demo_queries": [
+        "Who owns the payments service?",
+        "What is the on-call runbook for checkout?",
+        "Show me the docs for the identity service"
+      ],
+      "code_assets": [],
+      "scaffold_actions": [
+        "scaffold-connector",
+        "scaffold-web-sdk-embed"
+      ],
+      "combines": [
+        {
+          "title": "Index a developer catalog",
+          "surface": "Connector SDK",
+          "category": "index"
+        },
+        {
+          "title": "Embed search into the portal",
+          "surface": "Web SDK",
+          "category": "search"
+        },
+        {
+          "title": "Ground chat in the catalog",
+          "surface": "Platform API",
+          "category": "mcp"
+        }
+      ],
+      "architecture": [
+        {
+          "label": "Service catalog",
+          "caption": "YAML + runbooks",
+          "category": "index",
+          "emphasized": false
+        },
+        {
+          "label": "Custom connector",
+          "caption": "Indexing API",
+          "category": "workflow",
+          "icon": "plug",
+          "emphasized": false
+        },
+        {
+          "label": "Glean",
+          "caption": "permission-aware index",
+          "emphasized": true
+        },
+        {
+          "label": "Portal UI",
+          "caption": "Web SDK embed",
+          "category": "portal",
+          "icon": "layout-outlined",
+          "emphasized": false
+        }
+      ],
+      "ai_prompt": "Build the \"Engineering portal with Glean\" flagship recipe from\nhttps://developers.glean.com/cookbook/build-engineering-portal\n\nIt composes two published recipes:\n1. Index the portal's service catalog into Glean with the open-source\n   indexing SDK (see the Index a custom data source recipe and\n   https://developers.glean.com/api-info/indexing/getting-started/overview).\n2. Embed Glean search and chat into the portal UI with the Web SDK (see\n   https://developers.glean.com/cookbook/embed-search-chat).\n\nAsk me for: my Glean instance/backend domain, an Indexing API token, and\nmy Glean web app domain. Verify at the end that a search for a service\nname returns the indexed catalog entry, respecting my permissions.",
+      "llm_context": "Flagship showcase composing the custom-connector and Web SDK embed recipes: a service-catalog portal whose catalog is indexed into Glean via the indexing SDK, with Glean search and chat embedded back into the portal UI. Requires a Glean-issued Indexing API token for the connector and SEARCH/CHAT scopes for the embed.",
+      "go_dependency": false,
+      "featured": false,
+      "tags": [
+        "flagship",
+        "portal"
+      ],
+      "title": "Build an engineering portal",
+      "summary": "The end-to-end showcase — index a developer catalog into Glean, then embed permission-aware search and chat back into the portal your team already uses.",
+      "permalink": "/cookbook/build-engineering-portal"
+    },
+    {
+      "id": "embed-search-chat",
+      "surfaces": [
+        "web-sdk"
+      ],
+      "status": "production-pattern",
+      "category": "search",
+      "level": "Beginner",
+      "levels": {
+        "minimal": true,
+        "wow": true
+      },
+      "time_estimate": "~15 min (minimal)",
+      "required_scopes": [
+        "SEARCH",
+        "CHAT"
+      ],
+      "prerequisites": [
+        "A Glean instance with content indexed",
+        "Your Glean web app domain (typically app.glean.com — see admin/about-glean)",
+        "A frontend app or page where you can add a script tag and a container element",
+        "For token auth only: an admin API key from the Token Management page"
+      ],
+      "demo_queries": [
+        "What is our PTO policy?",
+        "Who owns the payments service?",
+        "Summarize the latest incident review"
+      ],
+      "code_assets": [],
+      "scaffold_actions": [
+        "scaffold-web-sdk-embed"
+      ],
+      "architecture": [
+        {
+          "label": "Internal app",
+          "caption": "Your existing frontend",
+          "icon": "layout-outlined",
+          "emphasized": false
+        },
+        {
+          "label": "Glean Web SDK",
+          "caption": "search + chat UI",
+          "category": "search",
+          "icon": "message-with-sparkles",
+          "emphasized": false
+        },
+        {
+          "label": "Auth",
+          "caption": "SSO or scoped token",
+          "category": "agent",
+          "icon": "verification",
+          "emphasized": false
+        },
+        {
+          "label": "Glean",
+          "caption": "permission-aware index",
+          "emphasized": true
+        }
+      ],
+      "ai_prompt": "Embed Glean search and chat in my internal web app using the Glean Web\nSDK, following the recipe at\nhttps://developers.glean.com/cookbook/embed-search-chat\n\nSteps:\n1. Ask me for my Glean web app domain (typically app.glean.com).\n2. Add the Web SDK script tag to the page <head>:\n   <script defer src=\"https://{GLEAN_APP_DOMAIN}/embedded-search-latest.min.js\"></script>\n3. Add a search box and results container, and render them with\n   window.GleanWebSDK.renderSearchBox(...) and\n   window.GleanWebSDK.renderSearchResults(...).\n4. Add a chat container (position: relative, display: block, explicit\n   width/height) and render it with\n   window.EmbeddedSearch.renderChat(containerElement).\n5. Default SSO auth needs no extra configuration. If I ask for\n   server-to-server auth instead, follow\n   https://developers.glean.com/libraries/web-sdk/authentication/server-to-server\n   and keep the API key strictly server-side.\n\nVerify by running the app and issuing a search; results must respect my\nGlean permissions.",
+      "llm_context": "Embeds Glean search and chat into an existing web app via the Glean Web SDK (script tag, window.GleanWebSDK.renderSearchBox/renderSearchResults, window.EmbeddedSearch.renderChat). Auth is Glean SSO by default or server-to-server tokens minted by a backend holding an admin API key with SEARCH and CHAT scopes. All results are permission-aware per user.",
+      "go_dependency": false,
+      "featured": true,
+      "tags": [
+        "embed",
+        "web-sdk"
+      ],
+      "title": "Embed search & chat in an internal app",
+      "summary": "Put permission-aware Glean search and chat directly inside an internal app with the Web SDK, so your team gets answers where they already work.",
+      "permalink": "/cookbook/embed-search-chat"
+    }
+  ],
+  "surfaces": [
+    "platform-api",
+    "web-sdk",
+    "connector-sdk",
+    "indexing-api"
+  ],
   "generatedAt": "1970-01-01T00:00:00.000Z",
-  "totalRecipes": 0
+  "totalRecipes": 2
 }


### PR DESCRIPTION
## Summary
The user-facing Cookbook section, entirely behind the `cookbook` feature flag (off by default — nothing changes in production until the flag flips):
- `/cookbook` index + two recipes: `embed-search-chat` (seed, verified Web SDK APIs and real `SEARCH`/`CHAT` scopes) and `build-engineering-portal` (end-to-end build composing the other recipes)
- Cookbooks sidebar category at the top of Guides; homepage band rendering `featured` recipes from the compiled schema (hides itself when none)
- Recipe authoring playbook in AGENTS.md — after this lands, a new recipe = one MDX file + one sidebar entry, schema-validated at build

Grafted onto #620's homepage banner and sidebar changes (both preserved — verified in build output).

## Verification
- `FF_COOKBOOKS=true pnpm build` and `pnpm build` both green; flag-off hides sidebar entry + homepage band while pages remain unlinked-but-buildable
- `pnpm vitest run` — 143 passing
- Preview with `FF_COOKBOOKS=true` to see the section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
_Flagship end-to-end recipe page:_
![Engineering portal recipe](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/recipe-portal.png)

_Homepage with the flag-gated cookbook band (below the #620 Platform APIs banner, which is preserved):_
![Homepage band](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/homepage-band.png)
