### PR TITLE
Add flag-gated homepage redesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@docusaurus/utils-validation": "^3.10.2",
     "@gleanwork/api-client": "^0.17.3",
     "@gleanwork/docusaurus-theme-glean": "workspace:*",
-    "@gleanwork/mcp-config-schema": "^5.2.0",
+    "@gleanwork/mcp-config-schema": "^5.4.0",
     "@intercom/messenger-js-sdk": "^0.0.19",
     "@mdx-js/react": "^3.0.0",
     "@signalwire/docusaurus-plugin-llms-txt": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: workspace:*
         version: link:packages/docusaurus-theme-glean
       '@gleanwork/mcp-config-schema':
-        specifier: ^5.2.0
-        version: 5.2.0(zod@4.4.3)
+        specifier: ^5.4.0
+        version: 5.4.0(zod@4.4.3)
       '@intercom/messenger-js-sdk':
         specifier: ^0.0.19
         version: 0.0.19
@@ -2107,6 +2107,12 @@ packages:
 
   '@gleanwork/mcp-config-schema@5.2.0':
     resolution: {integrity: sha512-2ldjVVC+ZcgSPXcwahqqZralI0JgMNeHas234psL/KytK74CLXX0OKuLEdI4SUdcHLnnQQSgShvQqy2UYb+lPA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@gleanwork/mcp-config-schema@5.4.0':
+    resolution: {integrity: sha512-1Vt/AR2vXwip2tO6DDV5v1Px4ipdCkxYmPJQz6Dc6a8217XD4AK5Fs1BAahJ9po/m9r0fwPgjCUHQaPC3FK1EA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -9043,6 +9049,10 @@ packages:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  smol-toml@1.7.0:
+    resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
+    engines: {node: '>= 18'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -13866,6 +13876,14 @@ snapshots:
       js-yaml: 4.2.0
       mkdirp: 3.0.1
       smol-toml: 1.6.1
+      zod: 4.4.3
+
+  '@gleanwork/mcp-config-schema@5.4.0(zod@4.4.3)':
+    dependencies:
+      glob: 13.0.6
+      js-yaml: 4.2.0
+      mkdirp: 3.0.1
+      smol-toml: 1.7.0
       zod: 4.4.3
 
   '@gleanwork/web-sdk@2.4.0': {}
@@ -21998,6 +22016,8 @@ snapshots:
   smol-toml@1.5.2: {}
 
   smol-toml@1.6.1: {}
+
+  smol-toml@1.7.0: {}
 
   snake-case@3.0.4:
     dependencies:

--- a/src/components/Homepage/index.tsx
+++ b/src/components/Homepage/index.tsx
@@ -7,6 +7,7 @@ import CarouselSection from './CarouselSection';
 import CookbookSection from './CookbookSection';
 import IDEPluginSection from './IDEPluginSection';
 import FeatureFlag from '../FeatureFlag';
+import HomeRedesign from '../home/HomeRedesign';
 import { GLEAN_BRAND_COLORS } from '@gleanwork/docusaurus-theme-glean/brandColors';
 
 type Feature = {
@@ -18,7 +19,8 @@ type Feature = {
   color?: string;
 };
 
-export default function Home() {
+/** Current production homepage; served while the home-redesign flag is off. */
+function HomeClassic() {
   const features: Feature[] = [
     {
       title: 'Integrate with AI Tools',
@@ -115,5 +117,14 @@ export default function Home() {
         </div>
       </section>
     </>
+  );
+}
+
+/** Flag switch: home-redesign renders the handoff 1a page; off = classic. */
+export default function Home() {
+  return (
+    <FeatureFlag fallback={<HomeClassic />} flag="home-redesign">
+      <HomeRedesign />
+    </FeatureFlag>
   );
 }

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -3,7 +3,15 @@
 
 .page {
   font-family: var(--gdt-font-text);
-  padding-bottom: 24px;
+  /* 56px total gutter each side per handoff 1a (main column padding);
+   * the doc container contributes 14px, we add the rest */
+  padding: 0 42px 24px;
+}
+
+@media (max-width: 996px) {
+  .page {
+    padding: 0 8px 24px;
+  }
 }
 
 .section {

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -608,10 +608,10 @@ html[data-theme='dark'] .heroSecondary:hover {
   font-weight: 600;
 }
 
-.sdkDot {
-  width: 10px;
-  height: 10px;
-  border-radius: 9999px;
+.sdkIcon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--gdt-text-primary);
 }
 
 .sdkInstall {
@@ -662,11 +662,27 @@ html[data-theme='dark'] .heroSecondary:hover {
   width: 40px;
   height: 40px;
   border-radius: 10px;
-  background: var(--gdt-selected-bg);
-  color: var(--gdt-primary);
+  background: var(--gdt-bg-light);
+  border: 1px solid var(--gdt-border-light);
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.mcpIcon svg {
+  width: 22px;
+  height: 22px;
+}
+
+/* Monochrome brand marks (Cursor, Codex) need inverting on dark */
+html[data-theme='dark'] .mcpIconMono svg {
+  filter: invert(1) hue-rotate(180deg);
+}
+
+.mcpHostsNote {
+  margin: 14px 0 0;
+  font-size: 13px;
+  color: var(--gdt-text-secondary);
 }
 
 .mcpTitle {

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -1,0 +1,743 @@
+/* Homepage redesign — design handoff direction 1a, exact values.
+ * Light-first; dark mode maps through the --gdt-* tokens where possible. */
+
+.page {
+  font-family: var(--gdt-font-text);
+  padding-bottom: 24px;
+}
+
+.section {
+  margin-top: 56px;
+}
+
+.sectionTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.6px;
+  margin: 0 0 6px;
+}
+
+.sectionSub {
+  font-size: 14.5px;
+  color: var(--gdt-text-secondary);
+  margin: 0 0 20px;
+}
+
+/* Announcement band */
+.bandWrap {
+  padding-top: 8px;
+}
+
+.band {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  border-radius: 16px;
+  padding: 26px 30px;
+  text-decoration: none;
+  background: linear-gradient(100deg, #343ced 0%, #3b34dd 46%, #4a2fb2 100%);
+  box-shadow: 0 12px 28px -10px rgba(52, 60, 237, 0.55);
+}
+
+.band:hover {
+  text-decoration: none;
+}
+
+.bandAccent {
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 46%;
+  background: linear-gradient(115deg, rgba(217, 241, 129, 0) 30%, #daf181 100%);
+  clip-path: polygon(34% 0, 100% 0, 100% 100%, 0 100%);
+  opacity: 0.85;
+  pointer-events: none;
+}
+
+.bandContent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex: 1;
+  min-width: 0;
+}
+
+.bandTag {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+}
+
+.bandText {
+  min-width: 0;
+}
+
+.bandTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 22px;
+  letter-spacing: -0.5px;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 5px;
+}
+
+.bandBody {
+  font-size: 14.5px;
+  line-height: 1.5;
+  color: rgba(255, 255, 255, 0.9);
+  margin: 0;
+  max-width: 560px;
+}
+
+.bandCta {
+  position: relative;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  background: #fff;
+  color: #1f2024;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .band {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .bandAccent {
+    display: none;
+  }
+}
+
+/* Hero carousel */
+.hero {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 48px;
+  align-items: center;
+  padding: 44px 0 8px;
+}
+
+@media (max-width: 996px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.heroSlides {
+  position: relative;
+  height: 300px;
+  margin-bottom: 4px;
+}
+
+.heroSlide {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+}
+
+.heroSlideActive {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.heroEyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: var(--gdt-selected-bg);
+  color: var(--gdt-info-fg);
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 22px;
+}
+
+.heroEyebrowDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+}
+
+.heroTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 42px;
+  line-height: 1.08;
+  letter-spacing: 0;
+  font-weight: 800;
+  margin: 0 0 18px;
+}
+
+.heroSub {
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--gdt-text-secondary);
+  max-width: 480px;
+  margin: 0;
+}
+
+.heroCtas {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.heroPrimary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 48px;
+  padding: 0 24px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  font-size: 15px;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+
+.heroPrimary:hover {
+  background: var(--gdt-primary-hover);
+  color: #fff;
+  text-decoration: none;
+}
+
+.heroSecondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 48px;
+  padding: 0 24px;
+  border-radius: 9999px;
+  background: var(--gdt-card-bg);
+  color: var(--gdt-text-primary);
+  border: 1px solid var(--gdt-border-dark);
+  font-size: 15px;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+
+.heroSecondary:hover {
+  background: #f4f4fb;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+html[data-theme='dark'] .heroSecondary:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.heroLibs {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--gdt-text-secondary);
+}
+
+.heroLibsList {
+  font-weight: 500;
+  color: var(--gdt-text-primary);
+}
+
+.heroPanels {
+  position: relative;
+  height: 340px;
+}
+
+.heroPanel {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.heroPanelActive {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.heroControls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.heroArrow {
+  width: 32px;
+  height: 32px;
+  border-radius: 9999px;
+  border: 1px solid var(--gdt-border-dark);
+  background: var(--gdt-card-bg);
+  color: var(--gdt-text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.heroArrow:hover {
+  background: var(--gdt-bg-light);
+}
+
+.heroDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: #d9dce2;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.heroDotActive {
+  width: 22px;
+  background: var(--gdt-primary);
+}
+
+/* Terminal panels */
+.terminal {
+  border-radius: 16px;
+  border: 1px solid #1a1b1f;
+  box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.15);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.terminalHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 40px;
+  padding: 0 16px;
+  background: #16171a;
+  border-bottom: 1px solid #26282e;
+  flex-shrink: 0;
+}
+
+.dotRed,
+.dotYellow,
+.dotGreen {
+  width: 11px;
+  height: 11px;
+  border-radius: 9999px;
+}
+
+.dotRed {
+  background: #ff5f57;
+}
+
+.dotYellow {
+  background: #febc2e;
+}
+
+.dotGreen {
+  background: #28c840;
+}
+
+.terminalFile {
+  margin-left: 10px;
+  font-size: 12px;
+  color: #8b8f98;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.terminalLabel {
+  margin-left: auto;
+  font-size: 11px;
+  color: #8f94fd;
+  font-family: var(--ifm-font-family-monospace);
+}
+
+.terminalPre {
+  margin: 0;
+  padding: 22px 20px;
+  background: #1f2024;
+  color: #e6e7ea;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 13.5px;
+  line-height: 1.7;
+  overflow: auto;
+  flex: 1;
+  border-radius: 0;
+}
+
+/* Path cards */
+.pathGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 996px) {
+  .pathGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.pathCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  padding: 22px;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.pathCard:hover {
+  background: var(--gdt-bg-light);
+  border-color: var(--gdt-border-dark);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.pathIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--gdt-selected-bg);
+  color: var(--gdt-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pathTitle {
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.pathBody {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--gdt-text-secondary);
+}
+
+/* Quickstart */
+.quickstart {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 36px;
+  border-radius: 20px;
+  border: 1px solid var(--gdt-border-light);
+  background: var(--gdt-bg-light);
+  padding: 32px;
+  align-items: start;
+}
+
+@media (max-width: 996px) {
+  .quickstart {
+    grid-template-columns: 1fr;
+  }
+}
+
+.quickstartEyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--gdt-primary);
+  margin-bottom: 10px;
+}
+
+.quickstartTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 24px;
+  letter-spacing: -0.5px;
+  font-weight: 700;
+  margin: 0 0 20px;
+}
+
+.quickstartSteps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quickstartSteps li {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  font-size: 14.5px;
+  line-height: 1.55;
+}
+
+.quickstartNum {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  margin-top: 1px;
+}
+
+.quickstartCode {
+  min-width: 0;
+}
+
+.quickstartTabs {
+  display: flex;
+  gap: 4px;
+  background: #16171a;
+  border: 1px solid #1a1b1f;
+  border-bottom: none;
+  border-radius: 16px 16px 0 0;
+  padding: 8px 8px 0;
+}
+
+.quickstartTab {
+  border: none;
+  background: transparent;
+  color: #8b8f98;
+  font-size: 12.5px;
+  padding: 7px 14px;
+  border-radius: 8px 8px 0 0;
+  cursor: pointer;
+}
+
+.quickstartTabActive {
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+}
+
+.quickstartPanel {
+  border-radius: 0 0 16px 16px;
+  border-top: none;
+}
+
+.quickstartPanel > div:first-child {
+  display: none;
+}
+
+/* SDK grid */
+.sdkGrid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 996px) {
+  .sdkGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.sdkCard {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  padding: 18px;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.sdkCard:hover {
+  background: var(--gdt-bg-light);
+  border-color: var(--gdt-border-dark);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.sdkName {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14.5px;
+  font-weight: 600;
+}
+
+.sdkDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 9999px;
+}
+
+.sdkInstall {
+  font-size: 12px;
+  background: var(--gdt-bg-light);
+  border: 1px solid var(--gdt-border-light);
+  border-radius: 8px;
+  padding: 6px 10px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+/* MCP cards */
+.mcpGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+@media (max-width: 996px) {
+  .mcpGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.mcpCard {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  padding: 22px;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.mcpCard:hover {
+  background: var(--gdt-bg-light);
+  border-color: var(--gdt-border-dark);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.mcpIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--gdt-selected-bg);
+  color: var(--gdt-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.mcpTitle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.mcpArrow {
+  color: var(--gdt-text-secondary);
+}
+
+.mcpBody {
+  font-size: 13.5px;
+  line-height: 1.5;
+  color: var(--gdt-text-secondary);
+}
+
+/* Agents band */
+.agentsBand {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 36px;
+  align-items: center;
+  border-radius: 20px;
+  background: #1f2024;
+  color: #fff;
+  padding: 36px;
+}
+
+@media (max-width: 996px) {
+  .agentsBand {
+    grid-template-columns: 1fr;
+  }
+}
+
+.agentsPill {
+  display: inline-flex;
+  align-items: center;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #a9e0ff;
+  font-size: 12px;
+  font-weight: 600;
+  margin-bottom: 16px;
+}
+
+.agentsTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 28px;
+  letter-spacing: -0.6px;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 12px;
+}
+
+.agentsBody {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0 0 20px;
+  max-width: 420px;
+}
+
+.agentsChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.agentsChip {
+  font-size: 12.5px;
+  padding: 6px 12px;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.agentsPanel {
+  box-shadow: none;
+}

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -744,3 +744,75 @@ html[data-theme='dark'] .heroSecondary:hover {
 .agentsPanel {
   box-shadow: none;
 }
+
+/* Cookbook strip (flag-gated) */
+.cookbookStrip {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 8px;
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  padding: 18px 22px;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.cookbookStrip:hover {
+  background: var(--gdt-bg-light);
+  border-color: var(--gdt-border-dark);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.cookbookStripIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: var(--gdt-selected-bg);
+  color: var(--gdt-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.cookbookStripText {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.cookbookStripTitle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.cookbookStripBadge {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+}
+
+.cookbookStripBody {
+  font-size: 13.5px;
+  color: var(--gdt-text-secondary);
+}
+
+.cookbookStripArrow {
+  margin-left: auto;
+  color: var(--gdt-primary);
+  flex-shrink: 0;
+}

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -840,3 +840,40 @@ html[data-theme='dark'] .mcpIconMono svg {
   color: var(--gdt-primary);
   flex-shrink: 0;
 }
+
+/* ---- Dark mode: dark containers must stay distinct from the dark page.
+ * Panels go decisively darker than the page background with hairline
+ * borders; the agents band gets a border and near-black fill. ---- */
+
+html[data-theme='dark'] .terminal {
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: 0 8px 24px -6px rgba(0, 0, 0, 0.5);
+}
+
+html[data-theme='dark'] .terminalHeader {
+  background: #0c0d10;
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme='dark'] .terminalPre {
+  background: #121418;
+}
+
+html[data-theme='dark'] .quickstartTabs {
+  background: #0c0d10;
+  border-color: rgba(255, 255, 255, 0.14);
+}
+
+html[data-theme='dark'] .quickstart {
+  background: #202127;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme='dark'] .agentsBand {
+  background: #131418;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+html[data-theme='dark'] .band {
+  box-shadow: 0 12px 28px -10px rgba(0, 0, 0, 0.6);
+}

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -183,7 +183,10 @@
   background: var(--gdt-primary);
 }
 
-.heroTitle {
+/* Compound selector: out-ranks brand.css `.main-wrapper h1` (0,1,1),
+ * which otherwise forces letter-spacing +0.025em, line-height 1.2, and
+ * weight 700 (same override that hit the cookbook headings) */
+.heroSlide h1.heroTitle {
   font-family: var(--gdt-font-display);
   font-size: 42px;
   line-height: 1.08;

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from '@docusaurus/Link';
 import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import { getClientIcon } from '@gleanwork/mcp-config-schema/browser';
 import FeatureFlag from '../FeatureFlag';
 import TerminalPanel from './TerminalPanel';
 import {
@@ -116,12 +117,6 @@ export function HeroCarousel(): React.ReactElement {
             API reference
           </Link>
         </div>
-        <div className={styles.heroLibs}>
-          <span>Client libraries for</span>
-          <span className={styles.heroLibsList}>
-            Python · TypeScript · Java · Go
-          </span>
-        </div>
       </div>
 
       <div>
@@ -217,7 +212,7 @@ const PATHS = [
   },
   {
     title: 'Bring Glean to your IDE',
-    body: 'Claude Code, Cursor, GitHub Copilot, and any MCP host.',
+    body: 'Claude Code, Cursor, Codex, and any MCP host.',
     icon: 'Terminal',
     href: '/guides/mcp',
   },
@@ -273,7 +268,7 @@ export function QuickstartTabs(): React.ReactElement {
             <li>
               <span className={styles.quickstartNum}>3</span>
               <span>
-                Ask your first question — answers come back grounded and
+                Run your first query — results come back ranked and
                 permission-aware.
               </span>
             </li>
@@ -327,7 +322,13 @@ export function SdkGrid(): React.ReactElement {
             to="/libraries/api-clients"
           >
             <span className={styles.sdkName}>
-              <span className={styles.sdkDot} style={{ background: sdk.dot }} />
+              <span className={styles.sdkIcon}>
+                {getIcon(sdk.icon, 'glean', {
+                  width: 18,
+                  height: 18,
+                  color: 'currentColor',
+                })}
+              </span>
               {sdk.name}
             </span>
             <code className={styles.sdkInstall}>{sdk.install}</code>
@@ -343,22 +344,22 @@ const MCP_CARDS = [
     title: 'Claude Code',
     body: 'Install the Glean plugins and search company knowledge from your terminal.',
     href: '/guides/mcp/claude-code',
-    icon: 'claude',
-    iconSet: 'glean' as const,
+    clientId: 'claude-code',
+    mono: false,
   },
   {
     title: 'Cursor',
     body: 'Connect the Glean MCP server to Cursor for context-aware coding.',
     href: '/guides/mcp/cursor',
-    icon: 'mcp',
-    iconSet: 'glean' as const,
+    clientId: 'cursor',
+    mono: true,
   },
   {
-    title: 'GitHub Copilot & any MCP host',
-    body: 'One remote MCP endpoint works across every supported host.',
-    href: '/guides/mcp/supported-hosts',
-    icon: 'plug',
-    iconSet: 'glean' as const,
+    title: 'Codex',
+    body: 'Install the Glean plugins for Codex from the gleanwork marketplace.',
+    href: 'https://github.com/gleanwork/codex-plugins',
+    clientId: 'codex',
+    mono: true,
   },
 ];
 
@@ -369,13 +370,12 @@ export function McpCards(): React.ReactElement {
       <div className={styles.mcpGrid}>
         {MCP_CARDS.map((card) => (
           <Link className={styles.mcpCard} key={card.title} to={card.href}>
-            <span className={styles.mcpIcon}>
-              {getIcon(card.icon, card.iconSet, {
-                width: 20,
-                height: 20,
-                color: 'currentColor',
-              })}
-            </span>
+            <span
+              className={`${styles.mcpIcon} ${card.mono ? styles.mcpIconMono : ''}`}
+              dangerouslySetInnerHTML={{
+                __html: getClientIcon(card.clientId) ?? '',
+              }}
+            />
             <span className={styles.mcpTitle}>
               {card.title}
               <span className={styles.mcpArrow}>
@@ -386,6 +386,10 @@ export function McpCards(): React.ReactElement {
           </Link>
         ))}
       </div>
+      <p className={styles.mcpHostsNote}>
+        Plus GitHub Copilot, Goose, Windsurf, and{' '}
+        <Link to="/guides/mcp/supported-hosts">any MCP host</Link>.
+      </p>
     </section>
   );
 }

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -1,0 +1,414 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import Link from '@docusaurus/Link';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import TerminalPanel from './TerminalPanel';
+import {
+  AGENTS_BAND_CODE,
+  HERO_SLIDES,
+  QUICKSTART_SNIPPETS,
+  SDK_CARDS,
+} from './snippets';
+import styles from './HomeRedesign.module.css';
+
+function feather(name: string, size = 18): React.ReactNode {
+  return getIcon(name, 'feather', {
+    width: size,
+    height: size,
+    color: 'currentColor',
+  });
+}
+
+/** Experimental Platform APIs announcement band (content-configurable). */
+export function AnnouncementBand({
+  tag = 'Experimental',
+  title = 'Introducing Glean Platform APIs',
+  body = 'Build search experiences and run Glean agents in your applications with our new Platform APIs — now rolling out in experimental preview.',
+  href = '/api/platform-api',
+  cta = 'Explore Platform APIs',
+}: {
+  tag?: string;
+  title?: string;
+  body?: string;
+  href?: string;
+  cta?: string;
+}): React.ReactElement {
+  return (
+    <div className={styles.bandWrap}>
+      <Link className={styles.band} to={href}>
+        <div className={styles.bandAccent} aria-hidden="true" />
+        <div className={styles.bandContent}>
+          <span className={styles.bandTag}>{tag}</span>
+          <div className={styles.bandText}>
+            <h3 className={styles.bandTitle}>{title}</h3>
+            <p className={styles.bandBody}>{body}</p>
+          </div>
+        </div>
+        <span className={styles.bandCta}>
+          {cta}
+          {feather('ArrowRight', 16)}
+        </span>
+      </Link>
+    </div>
+  );
+}
+
+/** Rotating hero: four API surfaces, paired copy + terminal panels. */
+export function HeroCarousel(): React.ReactElement {
+  const [active, setActive] = useState(0);
+  const paused = useRef(false);
+  const reduced = useRef(false);
+
+  useEffect(() => {
+    reduced.current = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches;
+    const timer = setInterval(() => {
+      if (!paused.current && !reduced.current) {
+        setActive((a) => (a + 1) % HERO_SLIDES.length);
+      }
+    }, 4500);
+    return () => clearInterval(timer);
+  }, []);
+
+  const goTo = useCallback((i: number) => {
+    setActive((i + HERO_SLIDES.length) % HERO_SLIDES.length);
+  }, []);
+
+  return (
+    <div
+      className={styles.hero}
+      onMouseEnter={() => {
+        paused.current = true;
+      }}
+      onMouseLeave={() => {
+        paused.current = false;
+      }}
+    >
+      <div>
+        <div className={styles.heroSlides}>
+          {HERO_SLIDES.map((slide, i) => (
+            <div
+              className={`${styles.heroSlide} ${
+                i === active ? styles.heroSlideActive : ''
+              }`}
+              key={slide.surface}
+            >
+              <div className={styles.heroEyebrow}>
+                <span className={styles.heroEyebrowDot} />
+                {slide.surface}
+              </div>
+              <h1 className={styles.heroTitle}>{slide.headline}</h1>
+              <p className={styles.heroSub}>{slide.subcopy}</p>
+            </div>
+          ))}
+        </div>
+        <div className={styles.heroCtas}>
+          <Link
+            className={styles.heroPrimary}
+            to="/api-info/client/getting-started/overview"
+          >
+            Start building
+            {feather('ArrowRight')}
+          </Link>
+          <Link className={styles.heroSecondary} to="/api/platform-api">
+            {feather('BookOpen')}
+            API reference
+          </Link>
+        </div>
+        <div className={styles.heroLibs}>
+          <span>Client libraries for</span>
+          <span className={styles.heroLibsList}>
+            Python · TypeScript · Java · Go
+          </span>
+        </div>
+      </div>
+
+      <div>
+        <div className={styles.heroPanels}>
+          {HERO_SLIDES.map((slide, i) => (
+            <TerminalPanel
+              className={`${styles.heroPanel} ${
+                i === active ? styles.heroPanelActive : ''
+              }`}
+              code={slide.code}
+              filename={slide.filename}
+              key={slide.surface}
+              label={slide.surface}
+            />
+          ))}
+        </div>
+        <div className={styles.heroControls}>
+          <button
+            aria-label="Previous"
+            className={styles.heroArrow}
+            onClick={() => goTo(active - 1)}
+            type="button"
+          >
+            {feather('ChevronLeft', 16)}
+          </button>
+          {HERO_SLIDES.map((slide, i) => (
+            <button
+              aria-label={`Go to ${slide.surface}`}
+              className={`${styles.heroDot} ${
+                i === active ? styles.heroDotActive : ''
+              }`}
+              key={slide.surface}
+              onClick={() => goTo(i)}
+              type="button"
+            />
+          ))}
+          <button
+            aria-label="Next"
+            className={styles.heroArrow}
+            onClick={() => goTo(active + 1)}
+            type="button"
+          >
+            {feather('ChevronRight', 16)}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const PATHS = [
+  {
+    title: 'Quickstart',
+    body: 'Make your first API call in minutes with a token and an SDK.',
+    icon: 'Zap',
+    href: '/api-info/client/getting-started/overview',
+  },
+  {
+    title: 'API reference',
+    body: 'Platform API endpoints for search, chat, and agents.',
+    icon: 'BookOpen',
+    href: '/api/platform-api',
+  },
+  {
+    title: 'SDKs',
+    body: 'Official clients for Python, TypeScript, Java, and Go.',
+    icon: 'Package',
+    href: '/libraries/api-clients',
+  },
+  {
+    title: 'MCP & IDEs',
+    body: 'Bring Glean into Claude Code, Cursor, and any MCP host.',
+    icon: 'Terminal',
+    href: '/guides/mcp',
+  },
+];
+
+export function PathCards(): React.ReactElement {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>Choose your path</h2>
+      <p className={styles.sectionSub}>Four ways to get started.</p>
+      <div className={styles.pathGrid}>
+        {PATHS.map((path) => (
+          <Link className={styles.pathCard} key={path.title} to={path.href}>
+            <span className={styles.pathIcon}>{feather(path.icon, 20)}</span>
+            <span className={styles.pathTitle}>{path.title}</span>
+            <span className={styles.pathBody}>{path.body}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function QuickstartTabs(): React.ReactElement {
+  const [lang, setLang] = useState<'python' | 'typescript' | 'curl'>('python');
+  const snippet = QUICKSTART_SNIPPETS[lang];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.quickstart}>
+        <div>
+          <div className={styles.quickstartEyebrow}>Quickstart</div>
+          <h3 className={styles.quickstartTitle}>
+            One call to your knowledge graph
+          </h3>
+          <ol className={styles.quickstartSteps}>
+            <li>
+              <span className={styles.quickstartNum}>1</span>
+              <span>
+                Create an API token in{' '}
+                <Link to="/get-started/authentication">Authentication</Link> —
+                OAuth or a Glean-issued token.
+              </span>
+            </li>
+            <li>
+              <span className={styles.quickstartNum}>2</span>
+              <span>
+                Install a{' '}
+                <Link to="/libraries/api-clients">client library</Link> for your
+                language.
+              </span>
+            </li>
+            <li>
+              <span className={styles.quickstartNum}>3</span>
+              <span>
+                Ask your first question — answers come back grounded and
+                permission-aware.
+              </span>
+            </li>
+          </ol>
+        </div>
+        <div className={styles.quickstartCode}>
+          <div className={styles.quickstartTabs}>
+            {(
+              Object.entries(QUICKSTART_SNIPPETS) as Array<
+                [typeof lang, { label: string; code: string }]
+              >
+            ).map(([key, value]) => (
+              <button
+                className={`${styles.quickstartTab} ${
+                  key === lang ? styles.quickstartTabActive : ''
+                }`}
+                key={key}
+                onClick={() => setLang(key)}
+                type="button"
+              >
+                {value.label}
+              </button>
+            ))}
+          </div>
+          <TerminalPanel
+            className={styles.quickstartPanel}
+            code={snippet.code}
+            filename={
+              lang === 'curl'
+                ? 'terminal'
+                : lang === 'python'
+                  ? 'main.py'
+                  : 'main.ts'
+            }
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function SdkGrid(): React.ReactElement {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>Official SDKs</h2>
+      <div className={styles.sdkGrid}>
+        {SDK_CARDS.map((sdk) => (
+          <Link
+            className={styles.sdkCard}
+            key={sdk.name}
+            to="/libraries/api-clients"
+          >
+            <span className={styles.sdkName}>
+              <span className={styles.sdkDot} style={{ background: sdk.dot }} />
+              {sdk.name}
+            </span>
+            <code className={styles.sdkInstall}>{sdk.install}</code>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+const MCP_CARDS = [
+  {
+    title: 'Claude Code',
+    body: 'Install the Glean plugins and search company knowledge from your terminal.',
+    href: '/guides/mcp/claude-code',
+    icon: 'claude',
+    iconSet: 'glean' as const,
+  },
+  {
+    title: 'Cursor',
+    body: 'Connect the Glean MCP server to Cursor for context-aware coding.',
+    href: '/guides/mcp/cursor',
+    icon: 'mcp',
+    iconSet: 'glean' as const,
+  },
+  {
+    title: 'GitHub Copilot & any MCP host',
+    body: 'One remote MCP endpoint works across every supported host.',
+    href: '/guides/mcp/supported-hosts',
+    icon: 'plug',
+    iconSet: 'glean' as const,
+  },
+];
+
+export function McpCards(): React.ReactElement {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.sectionTitle}>Bring Glean into your IDE</h2>
+      <div className={styles.mcpGrid}>
+        {MCP_CARDS.map((card) => (
+          <Link className={styles.mcpCard} key={card.title} to={card.href}>
+            <span className={styles.mcpIcon}>
+              {getIcon(card.icon, card.iconSet, {
+                width: 20,
+                height: 20,
+                color: 'currentColor',
+              })}
+            </span>
+            <span className={styles.mcpTitle}>
+              {card.title}
+              <span className={styles.mcpArrow}>
+                {feather('ArrowUpRight', 15)}
+              </span>
+            </span>
+            <span className={styles.mcpBody}>{card.body}</span>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function AgentsBand(): React.ReactElement {
+  return (
+    <section className={styles.section}>
+      <div className={styles.agentsBand}>
+        <div>
+          <span className={styles.agentsPill}>Agents</span>
+          <h2 className={styles.agentsTitle}>Framework-agnostic by design</h2>
+          <p className={styles.agentsBody}>
+            The agent toolkit exposes Glean retrieval as tools for whatever you
+            build with — the knowledge graph comes along regardless of
+            framework.
+          </p>
+          <div className={styles.agentsChips}>
+            {['LangChain', 'OpenAI Agents SDK', 'Google ADK', 'MCP'].map(
+              (chip) => (
+                <span className={styles.agentsChip} key={chip}>
+                  {chip}
+                </span>
+              ),
+            )}
+          </div>
+        </div>
+        <TerminalPanel
+          className={styles.agentsPanel}
+          code={AGENTS_BAND_CODE}
+          filename="tools.py"
+          label="Agent toolkit"
+        />
+      </div>
+    </section>
+  );
+}
+
+/** The full redesigned homepage (handoff direction 1a), flag-gated. */
+export default function HomeRedesign(): React.ReactElement {
+  return (
+    <div className={`${styles.page} home-redesign-root`}>
+      <AnnouncementBand />
+      <HeroCarousel />
+      <PathCards />
+      <QuickstartTabs />
+      <SdkGrid />
+      <McpCards />
+      <AgentsBand />
+    </div>
+  );
+}

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -167,10 +167,10 @@ export function HeroCarousel(): React.ReactElement {
   );
 }
 
-/** Flag-gated cookbook teaser — hidden until the cookbooks flag flips. */
+/** Flag-gated cookbook teaser — hidden until the cookbook flag flips. */
 export function CookbookStrip(): React.ReactElement {
   return (
-    <Link className={styles.cookbookStrip} to="/cookbooks">
+    <Link className={styles.cookbookStrip} to="/cookbook">
       <span className={styles.cookbookStripIcon}>
         {feather('BookOpen', 20)}
       </span>
@@ -433,7 +433,7 @@ export default function HomeRedesign(): React.ReactElement {
     <div className={`${styles.page} home-redesign-root`}>
       <AnnouncementBand />
       <HeroCarousel />
-      <FeatureFlag flag="cookbooks">
+      <FeatureFlag flag="cookbook">
         <CookbookStrip />
       </FeatureFlag>
       <PathCards />

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Link from '@docusaurus/Link';
 import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import FeatureFlag from '../FeatureFlag';
 import TerminalPanel from './TerminalPanel';
 import {
   AGENTS_BAND_CODE,
@@ -171,28 +172,52 @@ export function HeroCarousel(): React.ReactElement {
   );
 }
 
+/** Flag-gated cookbook teaser — hidden until the cookbooks flag flips. */
+export function CookbookStrip(): React.ReactElement {
+  return (
+    <Link className={styles.cookbookStrip} to="/cookbooks">
+      <span className={styles.cookbookStripIcon}>
+        {feather('BookOpen', 20)}
+      </span>
+      <span className={styles.cookbookStripText}>
+        <span className={styles.cookbookStripTitle}>
+          New: Cookbooks
+          <span className={styles.cookbookStripBadge}>Recipes</span>
+        </span>
+        <span className={styles.cookbookStripBody}>
+          Runnable patterns that go from problem to working demo to scaffolded
+          starter code — auth and permissions laid out for each.
+        </span>
+      </span>
+      <span className={styles.cookbookStripArrow}>
+        {feather('ArrowRight', 18)}
+      </span>
+    </Link>
+  );
+}
+
 const PATHS = [
   {
-    title: 'Quickstart',
-    body: 'Make your first API call in minutes with a token and an SDK.',
-    icon: 'Zap',
+    title: 'Build with the APIs',
+    body: 'Search, chat, and agents from your code — with client libraries for four languages.',
+    icon: 'Code',
     href: '/api-info/client/getting-started/overview',
   },
   {
-    title: 'API reference',
-    body: 'Platform API endpoints for search, chat, and agents.',
-    icon: 'BookOpen',
-    href: '/api/platform-api',
+    title: 'Embed with the Web SDK',
+    body: 'Permission-aware search and chat inside the apps your team already uses.',
+    icon: 'Layout',
+    href: '/libraries/web-sdk/overview',
   },
   {
-    title: 'SDKs',
-    body: 'Official clients for Python, TypeScript, Java, and Go.',
-    icon: 'Package',
-    href: '/libraries/api-clients',
+    title: 'Connect your data',
+    body: 'Bring any source into Glean with the Indexing API and connector framework.',
+    icon: 'Database',
+    href: '/api-info/indexing/getting-started/overview',
   },
   {
-    title: 'MCP & IDEs',
-    body: 'Bring Glean into Claude Code, Cursor, and any MCP host.',
+    title: 'Bring Glean to your IDE',
+    body: 'Claude Code, Cursor, GitHub Copilot, and any MCP host.',
     icon: 'Terminal',
     href: '/guides/mcp',
   },
@@ -293,7 +318,7 @@ export function QuickstartTabs(): React.ReactElement {
 export function SdkGrid(): React.ReactElement {
   return (
     <section className={styles.section}>
-      <h2 className={styles.sectionTitle}>Official SDKs</h2>
+      <h2 className={styles.sectionTitle}>API client libraries</h2>
       <div className={styles.sdkGrid}>
         {SDK_CARDS.map((sdk) => (
           <Link
@@ -404,6 +429,9 @@ export default function HomeRedesign(): React.ReactElement {
     <div className={`${styles.page} home-redesign-root`}>
       <AnnouncementBand />
       <HeroCarousel />
+      <FeatureFlag flag="cookbooks">
+        <CookbookStrip />
+      </FeatureFlag>
       <PathCards />
       <QuickstartTabs />
       <SdkGrid />

--- a/src/components/home/TerminalPanel.tsx
+++ b/src/components/home/TerminalPanel.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import styles from './HomeRedesign.module.css';
+
+/** Minimal syntax tinting per the handoff token colors. */
+export function tint(code: string): React.ReactNode[] {
+  const pattern =
+    /("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*')|\b(from|import|with|as|print|const|await|new|return|async)\b|\b(\d+)\b/g;
+  const out: React.ReactNode[] = [];
+  let last = 0;
+  let i = 0;
+  for (const m of code.matchAll(pattern)) {
+    const idx = m.index ?? 0;
+    if (idx > last) out.push(code.slice(last, idx));
+    if (m[1] !== undefined) {
+      out.push(
+        <span key={i++} style={{ color: '#d0e26f' }}>
+          {m[0]}
+        </span>,
+      );
+    } else if (m[2] !== undefined) {
+      out.push(
+        <span key={i++} style={{ color: '#8f94fd' }}>
+          {m[0]}
+        </span>,
+      );
+    } else {
+      out.push(
+        <span key={i++} style={{ color: '#ffd4bf' }}>
+          {m[0]}
+        </span>,
+      );
+    }
+    last = idx + m[0].length;
+  }
+  if (last < code.length) out.push(code.slice(last));
+  return out;
+}
+
+interface TerminalPanelProps {
+  filename: string;
+  label?: string;
+  code: string;
+  className?: string;
+}
+
+/** Dark editor/terminal card per the handoff: mac dots, filename, label. */
+export default function TerminalPanel({
+  filename,
+  label,
+  code,
+  className,
+}: TerminalPanelProps): React.ReactElement {
+  return (
+    <div className={`${styles.terminal} ${className ?? ''}`}>
+      <div className={styles.terminalHeader}>
+        <span className={styles.dotRed} />
+        <span className={styles.dotYellow} />
+        <span className={styles.dotGreen} />
+        <span className={styles.terminalFile}>{filename}</span>
+        {label ? <span className={styles.terminalLabel}>{label}</span> : null}
+      </div>
+      <pre className={styles.terminalPre}>{tint(code)}</pre>
+    </div>
+  );
+}

--- a/src/components/home/snippets.ts
+++ b/src/components/home/snippets.ts
@@ -121,12 +121,13 @@ export const QUICKSTART_SNIPPETS: Record<
 with Glean(
     api_token=os.environ["GLEAN_API_TOKEN"],
     server_url=os.environ["GLEAN_SERVER_URL"],
-) as client:
-    response = client.client.chat.create(
-        messages=[{"fragments":
-            [{"text": "What is our vacation policy?"}]}]
+) as glean:
+    results = glean.client.search.query(
+        query="quarterly planning",
+        page_size=10,
     )
-    print(response.text)`,
+    for r in results.results:
+        print(r.title, r.url)`,
   },
   typescript: {
     label: 'TypeScript',
@@ -137,26 +138,21 @@ const client = new Glean({
   serverURL: process.env.GLEAN_SERVER_URL,
 });
 
-const result = await client.client.chat.create({
-  messages: [{
-    fragments: [{ text: "What are our company values?" }]
-  }]
-});`,
+const results = await client.client.search.query({
+  query: "quarterly planning",
+  pageSize: 10,
+});
+
+results.results?.forEach((r) => console.log(r.title));`,
   },
   curl: {
     label: 'cURL',
-    code: `curl -X POST https://your-instance-be.glean.com/rest/api/v1/chat \\
+    code: `curl -X POST https://your-instance-be.glean.com/rest/api/v1/search \\
   -H 'Authorization: Bearer <your_token>' \\
   -H 'Content-Type: application/json' \\
   -d '{
-    "messages": [
-      {
-        "author": "USER",
-        "fragments": [
-          { "text": "What is our vacation policy?" }
-        ]
-      }
-    ]
+    "query": "quarterly planning",
+    "pageSize": 10
   }'`,
   },
 };
@@ -173,16 +169,16 @@ lc_tool = glean_search.as_langchain_tool()
 crew_tool = glean_search.as_crewai_tool()`;
 
 export const SDK_CARDS = [
-  { name: 'Python', dot: '#3572A5', install: 'pip install glean-api-client' },
+  { name: 'Python', icon: 'python', install: 'pip install glean-api-client' },
   {
     name: 'TypeScript',
-    dot: '#3178C6',
+    icon: 'typescript',
     install: 'npm install @gleanwork/api-client',
   },
-  { name: 'Java', dot: '#B07219', install: 'com.glean.api-client' },
+  { name: 'Java', icon: 'java', install: 'com.glean.api-client' },
   {
     name: 'Go',
-    dot: '#00ADD8',
+    icon: 'go',
     install: 'go get github.com/gleanwork/api-client-go',
   },
 ];

--- a/src/components/home/snippets.ts
+++ b/src/components/home/snippets.ts
@@ -1,0 +1,169 @@
+/**
+ * Code snippets for the homepage redesign — every snippet is sourced from
+ * published docs (never invented):
+ * - chat/search: docs/libraries/api-clients/python.mdx
+ * - indexing:    docs/api-info/indexing/getting-started/index-documents.mdx
+ * - agents:      docs/guides/agents/toolkit.mdx
+ * - typescript:  docs/libraries/api-clients/typescript.mdx
+ * - curl:        docs/api-info/client/getting-started/basic-usage.mdx
+ */
+
+export type HeroSlide = {
+  surface: string;
+  headline: string;
+  subcopy: string;
+  filename: string;
+  code: string;
+};
+
+export const HERO_SLIDES: HeroSlide[] = [
+  {
+    surface: 'Chat API',
+    headline: 'Chat grounded in company knowledge',
+    subcopy:
+      'Ask across every connected app and get permission-aware answers, with citations, in a single API call.',
+    filename: 'chat.py',
+    code: `from glean.api_client import Glean
+
+with Glean(
+    api_token=os.environ["GLEAN_API_TOKEN"],
+    server_url=os.environ["GLEAN_SERVER_URL"],
+) as client:
+    response = client.client.chat.create(
+        messages=[{"fragments":
+            [{"text": "Summarize the Q3 roadmap"}]}]
+    )
+    print(response.text)`,
+  },
+  {
+    surface: 'Search API',
+    headline: 'Search your entire knowledge graph',
+    subcopy:
+      'Enterprise search over 100+ connected sources — ranked, permission-aware, and fast, from one query.',
+    filename: 'search.py',
+    code: `from glean.api_client import Glean
+
+with Glean(
+    api_token=os.environ["GLEAN_API_TOKEN"],
+    server_url=os.environ["GLEAN_SERVER_URL"],
+) as glean:
+    results = glean.client.search.query(
+        query="quarterly reports",
+        page_size=10,
+    )
+    titles = [r.title for r in results.results]`,
+  },
+  {
+    surface: 'Agents',
+    headline: "Build agents on your company's knowledge",
+    subcopy:
+      'Plan, retrieve, and act across your tools — agents reason over the knowledge graph, not just a prompt window.',
+    filename: 'agent.py',
+    code: `from glean.agent_toolkit.tools import (
+    glean_search,
+    employee_search,
+)
+
+# Use with LangChain
+search_tool = glean_search.as_langchain_tool()
+people_tool = employee_search.as_langchain_tool()
+
+# Use with CrewAI
+crew_tool = glean_search.as_crewai_tool()`,
+  },
+  {
+    surface: 'Indexing API',
+    headline: 'Bring any data into Glean',
+    subcopy:
+      'Push documents from any source through the indexing API and make them searchable everywhere.',
+    filename: 'index.py',
+    code: `client.indexing.documents.index(request={
+    "document": {
+        "datasource": "gleantest",
+        "objectType": "EngineeringDoc",
+        "id": "blueskytest-1",
+        "title": "Getting started with Blue Sky",
+        "viewURL": "https://bluesky.test/1",
+        "body": {"mimeType": "text/plain",
+            "textContent": "..."},
+    },
+})`,
+  },
+];
+
+export const QUICKSTART_SNIPPETS: Record<
+  string,
+  { label: string; code: string }
+> = {
+  python: {
+    label: 'Python',
+    code: `from glean.api_client import Glean
+
+with Glean(
+    api_token=os.environ["GLEAN_API_TOKEN"],
+    server_url=os.environ["GLEAN_SERVER_URL"],
+) as client:
+    response = client.client.chat.create(
+        messages=[{"fragments":
+            [{"text": "What is our vacation policy?"}]}]
+    )
+    print(response.text)`,
+  },
+  typescript: {
+    label: 'TypeScript',
+    code: `import { Glean } from "@gleanwork/api-client";
+
+const client = new Glean({
+  apiToken: process.env.GLEAN_API_TOKEN,
+  serverURL: process.env.GLEAN_SERVER_URL,
+});
+
+const result = await client.client.chat.create({
+  messages: [{
+    fragments: [{ text: "What are our company values?" }]
+  }]
+});`,
+  },
+  curl: {
+    label: 'cURL',
+    code: `curl -X POST https://your-instance-be.glean.com/rest/api/v1/chat \\
+  -H 'Authorization: Bearer <your_token>' \\
+  -H 'Content-Type: application/json' \\
+  -d '{
+    "messages": [
+      {
+        "author": "USER",
+        "fragments": [
+          { "text": "What is our vacation policy?" }
+        ]
+      }
+    ]
+  }'`,
+  },
+};
+
+export const AGENTS_BAND_CODE = `from glean.agent_toolkit.tools import (
+    glean_search,
+    employee_search,
+)
+
+# LangChain
+lc_tool = glean_search.as_langchain_tool()
+
+# CrewAI
+crew_tool = glean_search.as_crewai_tool()`;
+
+export const SDK_CARDS = [
+  { name: 'Python', dot: '#3572A5', install: 'pip install glean-api-client' },
+  {
+    name: 'TypeScript',
+    dot: '#3178C6',
+    install: 'npm install @gleanwork/api-client',
+  },
+  { name: 'Java', dot: '#B07219', install: 'com.glean.api-client' },
+  {
+    name: 'Go',
+    dot: '#00ADD8',
+    install: 'go get github.com/gleanwork/api-client-go',
+  },
+];

--- a/src/components/home/snippets.ts
+++ b/src/components/home/snippets.ts
@@ -6,6 +6,7 @@
  * - agents:      docs/guides/agents/toolkit.mdx
  * - typescript:  docs/libraries/api-clients/typescript.mdx
  * - curl:        docs/api-info/client/getting-started/basic-usage.mdx
+ * - web sdk:     docs/libraries/web-sdk/components/{chat,autocomplete}.mdx
  */
 
 export type HeroSlide = {
@@ -70,6 +71,25 @@ people_tool = employee_search.as_langchain_tool()
 
 # Use with CrewAI
 crew_tool = glean_search.as_crewai_tool()`,
+  },
+  {
+    surface: 'Web SDK',
+    headline: 'Embed Glean in your apps',
+    subcopy:
+      'Drop permission-aware search and chat into the tools your team already uses — a script tag and two components.',
+    filename: 'embed.html',
+    code: `<script defer
+  src="https://{GLEAN_APP_DOMAIN}/embedded-search-latest.min.js">
+</script>
+
+<script>
+  window.GleanWebSDK.renderSearchBox(searchEl, {
+    onSearch: (query) =>
+      window.GleanWebSDK.renderSearchResults(
+        resultsEl, { query }),
+  });
+  window.EmbeddedSearch.renderChat(chatEl);
+</script>`,
   },
   {
     surface: 'Indexing API',

--- a/src/components/home/snippets.ts
+++ b/src/components/home/snippets.ts
@@ -2,7 +2,7 @@
  * Code snippets for the homepage redesign — every snippet is sourced from
  * published docs (never invented):
  * - chat/search: docs/libraries/api-clients/python.mdx
- * - indexing:    docs/api-info/indexing/getting-started/index-documents.mdx
+ * - indexing:    scripts/indexing/ (this repo's own glean-indexing-sdk connector)
  * - agents:      docs/guides/agents/toolkit.mdx
  * - typescript:  docs/libraries/api-clients/typescript.mdx
  * - curl:        docs/api-info/client/getting-started/basic-usage.mdx
@@ -92,22 +92,21 @@ crew_tool = glean_search.as_crewai_tool()`,
 </script>`,
   },
   {
-    surface: 'Indexing API',
+    surface: 'Indexing SDK',
     headline: 'Bring any data into Glean',
     subcopy:
-      'Push documents from any source through the indexing API and make them searchable everywhere.',
-    filename: 'index.py',
-    code: `client.indexing.documents.index(request={
-    "document": {
-        "datasource": "gleantest",
-        "objectType": "EngineeringDoc",
-        "id": "blueskytest-1",
-        "title": "Getting started with Blue Sky",
-        "viewURL": "https://bluesky.test/1",
-        "body": {"mimeType": "text/plain",
-            "textContent": "..."},
-    },
-})`,
+      'Build a connector on the open-source indexing SDK — push documents from any source and make them searchable everywhere.',
+    filename: 'connector.py',
+    code: `from glean.indexing.connectors import (
+    BaseDatasourceConnector,
+)
+
+class CatalogConnector(BaseDatasourceConnector):
+    def get_data(self):
+        return load_catalog_pages()
+
+connector = CatalogConnector(name="catalog")
+connector.index_data(mode=IndexingMode.FULL)`,
   },
 ];
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -740,3 +740,16 @@ article:has(.home-redesign-root) > .theme-doc-markdown > header,
 article:has(.home-redesign-root) > header {
   display: none;
 }
+
+/* Home redesign fills the main column: the doc container's max-width is
+ * sized for text + TOC layouts, which the redesigned homepage doesn't use.
+ * Scoped via :has so it only applies while the redesign is rendering. */
+.container:has(.home-redesign-root) {
+  max-width: 100%;
+}
+
+.container:has(.home-redesign-root) [class*='docItemCol'] {
+  /* the theme pins the doc column to 75% with !important to reserve TOC
+   * space; the redesigned homepage has no TOC affordance */
+  max-width: 100% !important;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -733,3 +733,10 @@ html[class*='docs-doc-id-cookbook'] .theme-doc-footer {
 html[class*='docs-doc-id-cookbook'] main[class*='docMainContainer'] {
   container-type: inline-size;
 }
+
+/* Home redesign: the 1a design opens on the announcement band — hide the
+ * doc-title header only when the redesigned homepage is rendering */
+article:has(.home-redesign-root) > .theme-doc-markdown > header,
+article:has(.home-redesign-root) > header {
+  display: none;
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -748,6 +748,13 @@ article:has(.home-redesign-root) > header {
   max-width: 100%;
 }
 
+/* Breadcrumbs render outside the redesign root — align them with the
+ * page's 56px gutter (42px + the container's 14px) */
+.container:has(.home-redesign-root) .theme-doc-breadcrumbs {
+  margin-left: 42px;
+  margin-right: 42px;
+}
+
 .container:has(.home-redesign-root) [class*='docItemCol'] {
   /* the theme pins the doc column to 75% with !important to reserve TOC
    * space; the redesigned homepage has no TOC affordance */


### PR DESCRIPTION
## Summary
The redesigned homepage (approved design handoff, direction 1a), entirely behind the `home-redesign` feature flag — flag off serves the current homepage unchanged, including the #620 Platform APIs banner.

Sections: **AnnouncementBand** (content-configurable) · **HeroCarousel** — five slides covering the full platform: Chat API, Search API, Agents (agent toolkit), **Indexing SDK** (connector built on glean-indexing-sdk), and **Web SDK** — with paired terminal panels, autoplay 4.5s, pause-on-hover, `prefers-reduced-motion` honored · flag-gated **Cookbook strip** · **PathCards** aligned to the four platform pillars · **QuickstartTabs** leading with the **Search API** (chat waits for the new platform chat API) · **API client libraries** (correct product name; language glyphs from the Glean icon set) · **McpCards** — Claude Code / Cursor / Codex with real brand marks from `@gleanwork/mcp-config-schema` 5.4.0 · **AgentsBand**.

**Layout:** full main-column width (lifts the doc container cap and the theme's `docItemCol` 75% TOC affordance, scoped via `:has`), 56px gutters per the handoff, breadcrumbs aligned. **Dark mode:** dark containers stay distinct (darker-than-page panels, hairline borders).

**Content accuracy:** every snippet and install command is sourced from published docs or this repo's own indexing connector — sources annotated in `snippets.ts`.

## Verification
- `FF_HOME_REDESIGN=true pnpm build` and plain `pnpm build` both green; classic homepage intact with the flag off
- `pnpm vitest run` — 143 passing
- Margins/typography verified by computed style via DevTools protocol
- Preview with `FF_HOME_REDESIGN=true FF_COOKBOOKS=true`

## Screenshots
_Light:_
![Homepage redesign](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/home-redesign-final.png)

_Dark:_
![Homepage redesign dark](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/home-redesign-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)