### PR TITLE
Add Cookbook UI components

### DIFF
--- a/src/components/Cookbook/Cookbook.test.tsx
+++ b/src/components/Cookbook/Cookbook.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RecipeIndex from './RecipeIndex';
+import RecipeLayout from './RecipeLayout';
+import FlagshipCard from './FlagshipCard';
+import type { RecipeRecord } from '../../types/recipe';
+
+function makeRecipe(overrides: Partial<RecipeRecord>): RecipeRecord {
+  return {
+    id: 'embed-search-chat',
+    title: 'Embed search & chat',
+    summary: 'Put Glean search and chat inside an internal app.',
+    permalink: '/cookbook/embed-search-chat',
+    surfaces: ['web-sdk'],
+    status: 'production-pattern',
+    category: 'search',
+    level: 'Beginner',
+    levels: { minimal: true, wow: true },
+    time_estimate: '~15 min (minimal)',
+    required_scopes: ['SEARCH'],
+    prerequisites: ['A Glean instance'],
+    demo_queries: [],
+    code_assets: [],
+    scaffold_actions: [],
+    ai_prompt: 'Build the recipe.',
+    go_dependency: false,
+    featured: false,
+    tags: [],
+    ...overrides,
+  };
+}
+
+const flagship = makeRecipe({
+  id: 'build-engineering-portal',
+  title: 'Build an engineering portal',
+  permalink: '/cookbook/build-engineering-portal',
+  surfaces: ['connector-sdk', 'web-sdk'],
+  category: 'portal',
+  level: 'Intermediate',
+  tags: ['flagship'],
+  combines: [
+    {
+      title: 'Index a developer catalog',
+      surface: 'Connector SDK',
+      category: 'index',
+    },
+    {
+      title: 'Embed search into the portal',
+      surface: 'Web SDK',
+      category: 'search',
+    },
+    {
+      title: 'Ground chat in the catalog',
+      surface: 'Platform API',
+      category: 'mcp',
+    },
+  ],
+});
+
+const recipes = [
+  makeRecipe({}),
+  makeRecipe({
+    id: 'index-custom-source',
+    title: 'Index a custom data source',
+    permalink: '/cookbook/index-custom-source',
+    surfaces: ['connector-sdk', 'indexing-api'],
+    category: 'index',
+    level: 'Intermediate',
+  }),
+  flagship,
+];
+
+describe('RecipeIndex', () => {
+  const props = {
+    recipes,
+    surfaces: ['web-sdk', 'connector-sdk', 'indexing-api'],
+  };
+
+  it('renders the header, flagship hero, and grid cards', () => {
+    render(<RecipeIndex {...props} />);
+    expect(
+      screen.getByText('Recipes for building on Glean'),
+    ).toBeInTheDocument();
+    // flagship renders as the hero, not a grid card
+    expect(screen.getByText('End-to-end build')).toBeInTheDocument();
+    expect(screen.getByText('Open the build guide')).toBeInTheDocument();
+    expect(screen.getByText('Embed search & chat')).toBeInTheDocument();
+    expect(screen.getByText('Index a custom data source')).toBeInTheDocument();
+    expect(screen.getByText('3 recipes')).toBeInTheDocument();
+  });
+
+  it('filters via a single-select chip and hides the flagship when unmatched', async () => {
+    const user = userEvent.setup();
+    render(<RecipeIndex {...props} />);
+
+    await user.click(screen.getByRole('button', { name: 'Indexing API' }));
+    expect(screen.queryByText('Embed search & chat')).not.toBeInTheDocument();
+    expect(screen.queryByText('End-to-end build')).not.toBeInTheDocument();
+    expect(screen.getByText('1 recipe')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'All' }));
+    expect(screen.getByText('End-to-end build')).toBeInTheDocument();
+    expect(screen.getByText('3 recipes')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no recipes exist', () => {
+    render(<RecipeIndex recipes={[]} surfaces={[]} />);
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+});
+
+describe('FlagshipCard', () => {
+  it('renders the combines mini-list', () => {
+    render(<FlagshipCard recipe={flagship} />);
+    expect(screen.getByText('Combines three recipes')).toBeInTheDocument();
+    expect(screen.getByText('Index a developer catalog')).toBeInTheDocument();
+    expect(screen.getByText('Ground chat in the catalog')).toBeInTheDocument();
+  });
+});
+
+describe('RecipeLayout', () => {
+  it('renders the banner, meta pills, and rail from the record', () => {
+    render(
+      <RecipeLayout
+        recipe={makeRecipe({
+          required_scopes: ['SEARCH', 'CHAT'],
+          code_assets: [
+            {
+              repo_path: 'recipes/embed-search-chat/minimal',
+              language: 'TypeScript',
+              description: 'Starter repo',
+            },
+          ],
+        })}
+      >
+        <p>Body content</p>
+      </RecipeLayout>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /Run minimal demo/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Scaffold starter code')).toBeInTheDocument();
+    expect(screen.getByText('SEARCH')).toBeInTheDocument();
+    expect(screen.getByText('CHAT')).toBeInTheDocument();
+    expect(screen.getByText('Starter repo')).toBeInTheDocument();
+    expect(screen.getByText('At a glance')).toBeInTheDocument();
+    expect(screen.getByText('Beginner')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+});

--- a/src/components/Cookbook/FlagshipCard.module.css
+++ b/src/components/Cookbook/FlagshipCard.module.css
@@ -1,0 +1,135 @@
+/* Flagship hero card — design handoff 4a, exact values */
+
+.card {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 40px;
+  align-items: center;
+  padding: 36px;
+  border-radius: 22px;
+  border: 1.5px solid var(--gdt-primary);
+  background: linear-gradient(150deg, #eef0ff 0%, #f7f8ff 45%, #ffffff 100%);
+  text-decoration: none;
+  color: var(--gdt-text-primary);
+  margin-bottom: 40px;
+  overflow: hidden;
+  transition: box-shadow 0.15s ease;
+}
+
+html[data-theme='dark'] .card {
+  background: linear-gradient(
+    150deg,
+    rgba(52, 60, 237, 0.18) 0%,
+    var(--ifm-background-surface-color) 60%
+  );
+}
+
+.card:hover {
+  box-shadow: 0 20px 40px -14px rgba(52, 60, 237, 0.35);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 26px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-family: var(--gdt-font-display);
+  font-size: 30px;
+  letter-spacing: 0;
+  font-weight: 700;
+  margin: 0 0 12px;
+  line-height: 1.1;
+}
+
+.body {
+  font-size: 15.5px;
+  line-height: 1.6;
+  color: var(--gdt-text-secondary);
+  margin: 0 0 24px;
+  max-width: 440px;
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 46px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  transition: background 0.15s ease;
+}
+
+.card:hover .cta {
+  background: var(--gdt-primary-hover);
+}
+
+.combines {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.combinesLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--gdt-text-secondary);
+  text-transform: uppercase;
+  margin-bottom: 2px;
+}
+
+.combineRow {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: var(--gdt-card-bg);
+  border: 1px solid var(--gdt-border-light);
+}
+
+.combineNum {
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.combineTitle {
+  font-size: 13.5px;
+  font-weight: 500;
+}
+
+.combineSurface {
+  font-size: 12px;
+  color: var(--gdt-text-secondary);
+}
+
+@media (max-width: 900px) {
+  .card {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/Cookbook/FlagshipCard.tsx
+++ b/src/components/Cookbook/FlagshipCard.tsx
@@ -1,0 +1,59 @@
+import type React from 'react';
+import Link from '@docusaurus/Link';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import type { RecipeRecord } from '../../types/recipe';
+import styles from './FlagshipCard.module.css';
+import catStyles from './categories.module.css';
+
+interface FlagshipCardProps {
+  recipe: RecipeRecord;
+}
+
+/**
+ * Flagship hero card per design handoff 4a: full-width, blue 1.5px border,
+ * light gradient, "Combines N recipes" mini-list on the right built from the
+ * recipe's `combines` frontmatter.
+ */
+export default function FlagshipCard({
+  recipe,
+}: FlagshipCardProps): React.ReactElement {
+  const combines = recipe.combines ?? [];
+
+  return (
+    <Link className={styles.card} to={recipe.permalink}>
+      <div>
+        <div className={styles.pill}>End-to-end build</div>
+        <h2 className={styles.title}>{recipe.title}</h2>
+        <p className={styles.body}>{recipe.summary}</p>
+        <span className={styles.cta}>
+          Open the build guide
+          {getIcon('ArrowRight', 'feather', {
+            width: 17,
+            height: 17,
+            color: 'currentColor',
+          })}
+        </span>
+      </div>
+      {combines.length > 0 ? (
+        <div className={styles.combines}>
+          <div className={styles.combinesLabel}>
+            Combines {combines.length === 3 ? 'three' : combines.length} recipes
+          </div>
+          {combines.map((item, i) => (
+            <div className={styles.combineRow} key={item.title}>
+              <span
+                className={`${styles.combineNum} ${catStyles[`tile_${item.category}`]}`}
+              >
+                {i + 1}
+              </span>
+              <div>
+                <div className={styles.combineTitle}>{item.title}</div>
+                <div className={styles.combineSurface}>{item.surface}</div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </Link>
+  );
+}

--- a/src/components/Cookbook/RecipeCard.module.css
+++ b/src/components/Cookbook/RecipeCard.module.css
@@ -1,0 +1,81 @@
+/* Recipe card — design handoff direction 4a, exact values */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  border-radius: 18px;
+  border: 1px solid var(--gdt-border-light);
+  background: var(--gdt-card-bg);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+  height: 100%;
+  transition:
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
+}
+
+.card:hover {
+  box-shadow: 0 14px 30px -12px rgba(0, 0, 0, 0.18);
+  border-color: var(--gdt-border-dark);
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+.tileRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.title {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.4px;
+  margin-bottom: 8px;
+}
+
+.summary {
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--gdt-text-secondary);
+  margin: 0 0 18px;
+  flex: 1;
+}
+
+.footer {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--gdt-bg-mid);
+  font-size: 12.5px;
+  color: var(--gdt-text-secondary);
+}
+
+.metaItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.dot {
+  margin: 0 -6px;
+}
+
+.chips {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+}
+
+.chip {
+  font-size: 11.5px;
+  color: var(--gdt-text-secondary);
+  padding: 3px 9px;
+  border-radius: 7px;
+  background: var(--gdt-bg-light);
+  border: 1px solid var(--gdt-border-light);
+  white-space: nowrap;
+}

--- a/src/components/Cookbook/RecipeCard.tsx
+++ b/src/components/Cookbook/RecipeCard.tsx
@@ -1,0 +1,60 @@
+import type React from 'react';
+import Link from '@docusaurus/Link';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import { RECIPE_SURFACE_LABELS, type RecipeRecord } from '../../types/recipe';
+import { CategoryTile } from './categories';
+import styles from './RecipeCard.module.css';
+
+/** Legacy export used by the homepage CookbookSection band. */
+export const SURFACE_ICONS: Record<string, string> = {
+  'web-sdk': 'Layout',
+  'connector-sdk': 'Database',
+  'indexing-api': 'Database',
+  mcp: 'GitBranch',
+  'platform-api': 'Code',
+  'sdk-client': 'Package',
+  actions: 'Zap',
+  agents: 'Cpu',
+};
+
+interface RecipeCardProps {
+  recipe: RecipeRecord;
+}
+
+/**
+ * Recipe card per design handoff direction 4a: pastel category tile,
+ * 18px title, 13.5px summary, footer row with time · level and up to two
+ * surface chips.
+ */
+export default function RecipeCard({
+  recipe,
+}: RecipeCardProps): React.ReactElement {
+  return (
+    <Link className={styles.card} to={recipe.permalink}>
+      <div className={styles.tileRow}>
+        <CategoryTile category={recipe.category} />
+      </div>
+      <span className={styles.title}>{recipe.title}</span>
+      <p className={styles.summary}>{recipe.summary}</p>
+      <div className={styles.footer}>
+        <span className={styles.metaItem}>
+          {getIcon('Clock', 'feather', {
+            width: 14,
+            height: 14,
+            color: 'currentColor',
+          })}
+          {recipe.time_estimate.replace(/\s*\(.*\)$/, '')}
+        </span>
+        <span className={styles.dot}>·</span>
+        <span>{recipe.level}</span>
+        <span className={styles.chips}>
+          {recipe.surfaces.slice(0, 2).map((surface) => (
+            <span className={styles.chip} key={surface}>
+              {RECIPE_SURFACE_LABELS[surface]}
+            </span>
+          ))}
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/Cookbook/RecipeIndex.module.css
+++ b/src/components/Cookbook/RecipeIndex.module.css
@@ -1,0 +1,98 @@
+/* Cookbook index — design handoff 4a, exact values */
+
+.wrap {
+  padding-top: 8px;
+  font-family: var(--gdt-font-text);
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  color: var(--gdt-primary);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+/* Compound selector: must out-rank brand.css `.main-wrapper h1` (0,1,1),
+ * which otherwise forces letter-spacing 0.025em and line-height 1.2 */
+.wrap h1.title {
+  font-family: var(--gdt-font-display);
+  font-size: 40px;
+  letter-spacing: 0;
+  font-weight: 700;
+  margin: 0 0 12px;
+  line-height: 1.05;
+}
+
+.subtitle {
+  font-size: 16.5px;
+  line-height: 1.55;
+  color: var(--gdt-text-secondary);
+  max-width: 620px;
+  margin: 0 0 36px;
+}
+
+.filterBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chip {
+  height: 34px;
+  padding: 0 16px;
+  border-radius: 9999px;
+  background: var(--gdt-card-bg);
+  border: 1px solid var(--gdt-border-light);
+  color: var(--gdt-text-primary);
+  font-size: 13.5px;
+  cursor: pointer;
+  transition:
+    background 0.12s ease,
+    border-color 0.12s ease,
+    color 0.12s ease;
+}
+
+.chip:hover {
+  border-color: var(--gdt-border-dark);
+}
+
+.chipActive {
+  background: var(--gdt-primary);
+  border-color: var(--gdt-primary);
+  color: #fff;
+  font-weight: 500;
+}
+
+.count {
+  font-size: 13px;
+  color: var(--gdt-text-secondary);
+  white-space: nowrap;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 18px;
+}
+
+@media (max-width: 860px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.empty {
+  padding: 2rem 0;
+  color: var(--gdt-text-secondary);
+}

--- a/src/components/Cookbook/RecipeIndex.tsx
+++ b/src/components/Cookbook/RecipeIndex.tsx
@@ -1,0 +1,104 @@
+import type React from 'react';
+import { useMemo, useState } from 'react';
+import { RECIPE_SURFACE_LABELS, type RecipeRecord } from '../../types/recipe';
+import FlagshipCard from './FlagshipCard';
+import RecipeCard from './RecipeCard';
+import styles from './RecipeIndex.module.css';
+
+interface RecipeIndexProps {
+  recipes: Array<RecipeRecord>;
+  /** Surface slugs present in the compiled data (from recipes.json). */
+  surfaces: Array<string>;
+}
+
+function label(slug: string): string {
+  return (
+    RECIPE_SURFACE_LABELS[slug as keyof typeof RECIPE_SURFACE_LABELS] ?? slug
+  );
+}
+
+function matches(recipe: RecipeRecord, filter: string): boolean {
+  if (filter === 'all') return true;
+  return (recipe.surfaces as Array<string>).includes(filter);
+}
+
+/**
+ * Cookbook index per design handoff 4a: header, flagship hero, single-select
+ * filter chips with a live count, and the 2-col recipe grid.
+ */
+export default function RecipeIndex({
+  recipes,
+  surfaces,
+}: RecipeIndexProps): React.ReactElement {
+  const [activeFilter, setActiveFilter] = useState('all');
+
+  const flagship = recipes.find((r) => r.tags.includes('flagship'));
+  const gridRecipes = recipes.filter((r) => r !== flagship);
+
+  const chips = useMemo(() => ['all', ...surfaces], [surfaces]);
+
+  const visibleRecipes = useMemo(
+    () => gridRecipes.filter((r) => matches(r, activeFilter)),
+    [gridRecipes, activeFilter],
+  );
+
+  const flagshipVisible = flagship ? matches(flagship, activeFilter) : false;
+  const count = visibleRecipes.length + (flagshipVisible ? 1 : 0);
+
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.eyebrow}>Cookbooks</div>
+      <h1 className={styles.title}>Recipes for building on Glean</h1>
+      <p className={styles.subtitle}>
+        Runnable patterns that go from problem to a working demo to scaffolded
+        starter code — with the architecture, auth, and permissions laid out for
+        each.
+      </p>
+
+      {recipes.length === 0 ? (
+        <div className={styles.empty}>
+          <p>Recipes are coming soon.</p>
+        </div>
+      ) : (
+        <>
+          {flagship && flagshipVisible ? (
+            <FlagshipCard recipe={flagship} />
+          ) : null}
+
+          <div className={styles.filterBar}>
+            <div className={styles.chipRow}>
+              {chips.map((chip) => (
+                <button
+                  aria-pressed={activeFilter === chip}
+                  className={`${styles.chip} ${
+                    activeFilter === chip ? styles.chipActive : ''
+                  }`}
+                  key={chip}
+                  onClick={() => setActiveFilter(chip)}
+                  type="button"
+                >
+                  {chip === 'all' ? 'All' : label(chip)}
+                </button>
+              ))}
+            </div>
+            <span className={styles.count}>
+              {count} recipe{count === 1 ? '' : 's'}
+            </span>
+          </div>
+
+          <div className={styles.grid}>
+            {visibleRecipes.map((recipe) => (
+              <RecipeCard key={recipe.id} recipe={recipe} />
+            ))}
+          </div>
+
+          {count === 0 ? (
+            <div className={styles.empty}>
+              <p>No recipes match the selected filter.</p>
+            </div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Cookbook/RecipeLayout.module.css
+++ b/src/components/Cookbook/RecipeLayout.module.css
@@ -1,0 +1,511 @@
+/* Recipe detail — design handoff direction 4b, exact values */
+
+.page {
+  margin: 0;
+  font-family: var(--gdt-font-text);
+}
+
+/* Header banner — full-bleed across the main column per 4b: negative
+ * margins escape the centered doc container (100cqw = main column width);
+ * matching inline padding keeps the text aligned with the content below. */
+.banner {
+  --bleed: max(calc((100cqw - 100%) / 2), 0px);
+  margin: calc(-1 * var(--ifm-spacing-vertical, 1rem)) calc(-1 * var(--bleed)) 0;
+  padding: 32px var(--bleed) 28px;
+  border-bottom: 1px solid var(--gdt-border-light);
+  background: linear-gradient(160deg, #f7f8ff 0%, #ffffff 60%);
+}
+
+html[data-theme='dark'] .banner {
+  background: linear-gradient(
+    160deg,
+    rgba(52, 60, 237, 0.12) 0%,
+    transparent 60%
+  );
+}
+
+.breadcrumb {
+  font-size: 13px;
+  color: var(--gdt-text-secondary);
+  margin-bottom: 16px;
+}
+
+.breadcrumb a {
+  color: var(--gdt-primary);
+}
+
+.breadcrumbSep {
+  color: var(--gdt-border-dark);
+  margin: 0 6px;
+}
+
+.bannerMain {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.banner h1.banner h1.bannerTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 32px;
+  letter-spacing: 0;
+  font-weight: 700;
+  margin: 0 0 4px;
+}
+
+.bannerDesc {
+  font-size: 15px;
+  line-height: 1.4;
+  color: var(--gdt-text-secondary);
+  margin: 0;
+  max-width: 560px;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 18px;
+}
+
+.metaPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 13px;
+  border-radius: 9999px;
+  background: var(--gdt-card-bg);
+  border: 1px solid var(--gdt-border-light);
+  font-size: 13px;
+  color: var(--gdt-text-primary);
+}
+
+/* Main + rail */
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  gap: 44px;
+  padding: 36px 0 48px;
+  align-items: start;
+  /* Design main column proportions — don't let text run the full viewport */
+  max-width: 1180px;
+}
+
+@media (max-width: 1200px) {
+  .columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.main {
+  min-width: 0;
+}
+
+.main :global(p) {
+  font-size: 15px;
+  line-height: 1.65;
+}
+
+/* Sections */
+.section {
+  margin-bottom: 36px;
+}
+
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--gdt-primary);
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+/* Architecture canvas */
+.archCanvas {
+  padding: 28px 24px;
+  border-radius: 18px;
+  border: 1px solid var(--gdt-border-light);
+  background-color: var(--gdt-bg-light);
+  background-image: radial-gradient(#e0e2ea 1px, transparent 1px);
+  background-size: 16px 16px;
+}
+
+html[data-theme='dark'] .archCanvas {
+  background-image: radial-gradient(
+    var(--ifm-color-emphasis-300) 1px,
+    transparent 1px
+  );
+}
+
+.archFlow {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+}
+
+.archArrow {
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  color: var(--gdt-primary);
+}
+
+.archNode {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 18px 12px;
+  border-radius: 14px;
+  border: 1px solid var(--gdt-border-light);
+  background: var(--gdt-card-bg);
+  text-align: center;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.06);
+}
+
+.archNodeEmphasized {
+  border: 1.5px solid var(--gdt-primary);
+  box-shadow: 0 8px 18px -6px rgba(52, 60, 237, 0.35);
+}
+
+.archNodeIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 9px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.archNodeIconNeutral {
+  background: var(--gdt-bg-mid);
+  color: var(--gdt-text-primary);
+}
+
+.archNodeEmphasized .archNodeIcon {
+  background: var(--gdt-primary);
+  color: #fff;
+}
+
+.archLabel {
+  font-size: 13.5px;
+  font-weight: 600;
+}
+
+.archCaption {
+  font-size: 11.5px;
+  color: var(--gdt-text-secondary);
+}
+
+@media (max-width: 700px) {
+  .archFlow {
+    flex-direction: column;
+  }
+
+  .archArrow {
+    justify-content: center;
+    padding: 6px 0;
+    transform: rotate(90deg);
+  }
+}
+
+/* Prerequisites */
+.prereqList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.prereqRow {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--gdt-border-light);
+  font-size: 14px;
+}
+
+.prereqRow svg {
+  flex-shrink: 0;
+}
+
+/* Steps timeline */
+.stepsWrap {
+  position: relative;
+  padding-left: 40px;
+}
+
+.stepsRail {
+  position: absolute;
+  left: 11px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: var(--gdt-border-light);
+}
+
+.stepRow {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.stepRow:last-child {
+  margin-bottom: 0;
+}
+
+.stepNum {
+  position: absolute;
+  left: -40px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.stepBody {
+  font-size: 14.5px;
+  line-height: 1.5;
+}
+
+.stepBody :global(p) {
+  font-size: 14.5px;
+  margin-bottom: 0.6rem;
+}
+
+.stepBody :global(code) {
+  background: var(--gdt-bg-mid);
+  padding: 1px 6px;
+  border-radius: 5px;
+  border: none;
+  font-size: 13px;
+}
+
+/* Take it further */
+.further {
+  border-radius: 16px;
+  border: 1px solid var(--gdt-warning-border);
+  background: var(--gdt-warning-bg);
+  padding: 24px;
+  margin-bottom: 36px;
+}
+
+.furtherHeader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--gdt-warning-fg);
+  text-transform: uppercase;
+}
+
+.furtherList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.furtherRow {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.furtherRow svg {
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.furtherRow :global(p) {
+  margin: 0;
+  font-size: 14px;
+}
+
+/* Right rail */
+.rail {
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 16px);
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+@media (max-width: 1200px) {
+  .rail {
+    position: static;
+  }
+}
+
+.actionCard {
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.06);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.primaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 46px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  font-size: 14px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.primaryAction:hover {
+  background: var(--gdt-primary-hover);
+}
+
+.secondaryAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 46px;
+  border-radius: 9999px;
+  background: var(--gdt-card-bg);
+  color: var(--gdt-text-primary);
+  border: 1px solid var(--gdt-border-dark);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.secondaryAction:hover {
+  background: #f4f4fb;
+  color: var(--gdt-text-primary);
+  text-decoration: none;
+}
+
+html[data-theme='dark'] .secondaryAction:hover {
+  background: var(--ifm-color-emphasis-200);
+}
+
+.actionHint {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: var(--gdt-text-secondary);
+  text-align: center;
+}
+
+.railCard {
+  border-radius: 16px;
+  border: 1px solid var(--gdt-border-light);
+  padding: 20px;
+}
+
+.railLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--gdt-text-secondary);
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+.glanceRows {
+  display: flex;
+  flex-direction: column;
+}
+
+.glanceRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--gdt-hairline);
+}
+
+.glanceRowLast {
+  border-bottom: none;
+}
+
+.glanceKey {
+  font-size: 13px;
+  color: var(--gdt-text-secondary);
+}
+
+.glanceVal {
+  font-size: 13.5px;
+  font-weight: 500;
+  text-align: right;
+  max-width: 62%;
+}
+
+/* Subtle inline note — replaces stock admonitions inside recipe bodies */
+.note {
+  border-left: 3px solid var(--gdt-primary);
+  background: var(--gdt-selected-bg);
+  border-radius: 0 10px 10px 0;
+  padding: 12px 16px;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--gdt-text-secondary);
+  margin: 0 0 36px;
+}
+
+.note :global(p) {
+  margin: 0;
+  font-size: 13.5px;
+}
+
+.scopes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.scopeChip {
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 12px;
+  padding: 4px 10px;
+  border-radius: 8px;
+  background: var(--gdt-selected-bg);
+  color: var(--gdt-info-fg);
+}
+
+.assets {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.assetRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 0;
+  font-size: 13.5px;
+  color: var(--gdt-primary);
+}
+
+.assetRow:hover {
+  color: var(--gdt-primary-hover);
+  text-decoration: none;
+}

--- a/src/components/Cookbook/RecipeLayout.tsx
+++ b/src/components/Cookbook/RecipeLayout.tsx
@@ -1,0 +1,387 @@
+import React, { useState } from 'react';
+import Link from '@docusaurus/Link';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import {
+  RECIPE_STATUS_LABELS,
+  RECIPE_SURFACE_LABELS,
+  type RecipeRecord,
+} from '../../types/recipe';
+import { CategoryTile, CATEGORY_ICONS } from './categories';
+import styles from './RecipeLayout.module.css';
+import catStyles from './categories.module.css';
+
+/** Base URL for runnable recipe code. One place to change when the repo lands. */
+export const COOKBOOK_REPO_URL =
+  'https://github.com/gleanwork/cookbook/tree/main';
+
+/** Set by RecipeLayout; lets MDX section components read the recipe record. */
+export const RecipeContext = React.createContext<RecipeRecord | null>(null);
+
+function useRecipe(component: string): RecipeRecord {
+  const recipe = React.useContext(RecipeContext);
+  if (!recipe) {
+    throw new Error(`${component} must be used inside a recipe page`);
+  }
+  return recipe;
+}
+
+function metaPill(icon: string, text: string): React.ReactElement {
+  return (
+    <span className={styles.metaPill} key={text}>
+      {getIcon(icon, 'feather', {
+        width: 14,
+        height: 14,
+        color: 'currentColor',
+      })}
+      {text}
+    </span>
+  );
+}
+
+function ActionCard({ recipe }: { recipe: RecipeRecord }): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const copyPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(recipe.ai_prompt);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable; prompt remains accessible via the recipe page.
+    }
+  };
+
+  const starter = recipe.code_assets[0];
+
+  return (
+    <div className={styles.actionCard}>
+      <button
+        className={styles.primaryAction}
+        onClick={copyPrompt}
+        type="button"
+      >
+        {getIcon('Play', 'feather', {
+          width: 16,
+          height: 16,
+          color: 'currentColor',
+        })}
+        {copied ? 'Prompt copied!' : 'Run minimal demo'}
+      </button>
+      {starter ? (
+        <a
+          className={styles.secondaryAction}
+          href={`${COOKBOOK_REPO_URL}/${starter.repo_path}`}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {getIcon('Plus', 'feather', {
+            width: 16,
+            height: 16,
+            color: 'currentColor',
+          })}
+          Scaffold starter code
+        </a>
+      ) : (
+        <button
+          className={styles.secondaryAction}
+          onClick={copyPrompt}
+          type="button"
+        >
+          {getIcon('Plus', 'feather', {
+            width: 16,
+            height: 16,
+            color: 'currentColor',
+          })}
+          Scaffold starter code
+        </button>
+      )}
+      <p className={styles.actionHint}>
+        Copies a prompt your AI assistant can build from.
+      </p>
+    </div>
+  );
+}
+
+/** Section label — 12px uppercase blue, per handoff 4b. */
+export function RecipeSection({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionLabel}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+/** Architecture flow diagram on the dotted canvas, from frontmatter nodes. */
+export function RecipeArchitecture(): React.ReactElement | null {
+  const recipe = useRecipe('RecipeArchitecture');
+  const nodes = recipe.architecture ?? [];
+  if (nodes.length === 0) return null;
+
+  return (
+    <RecipeSection label="Architecture">
+      <div className={styles.archCanvas}>
+        <div className={styles.archFlow}>
+          {nodes.map((node, i) => (
+            <React.Fragment key={node.label}>
+              {i > 0 ? (
+                <span className={styles.archArrow}>
+                  {getIcon('ArrowRight', 'feather', {
+                    width: 22,
+                    height: 22,
+                    color: 'currentColor',
+                  })}
+                </span>
+              ) : null}
+              <div
+                className={`${styles.archNode} ${
+                  node.emphasized ? styles.archNodeEmphasized : ''
+                }`}
+              >
+                <span
+                  className={`${styles.archNodeIcon} ${
+                    node.category
+                      ? catStyles[`tile_${node.category}`]
+                      : styles.archNodeIconNeutral
+                  }`}
+                >
+                  {node.emphasized
+                    ? getIcon('glean-logo', 'glean', {
+                        width: 20,
+                        height: 20,
+                        color: 'currentColor',
+                      })
+                    : node.icon
+                      ? getIcon(node.icon, 'glean', {
+                          width: 18,
+                          height: 18,
+                          color: 'currentColor',
+                        })
+                      : node.category
+                        ? getIcon(
+                            CATEGORY_ICONS[node.category] ?? 'glean-app',
+                            'glean',
+                            {
+                              width: 18,
+                              height: 18,
+                              color: 'currentColor',
+                            },
+                          )
+                        : getIcon('Box', 'feather', {
+                            width: 18,
+                            height: 18,
+                            color: 'currentColor',
+                          })}
+                </span>
+                <span className={styles.archLabel}>{node.label}</span>
+                <span className={styles.archCaption}>{node.caption}</span>
+              </div>
+            </React.Fragment>
+          ))}
+        </div>
+      </div>
+    </RecipeSection>
+  );
+}
+
+/** Prerequisite rows with green checks, from frontmatter. */
+export function RecipePrereqs(): React.ReactElement {
+  const recipe = useRecipe('RecipePrereqs');
+  return (
+    <RecipeSection label="Prerequisites">
+      <div className={styles.prereqList}>
+        {recipe.prerequisites.map((item) => (
+          <div className={styles.prereqRow} key={item}>
+            {getIcon('CheckCircle', 'feather', {
+              width: 18,
+              height: 18,
+              color: 'var(--gdt-success)',
+            })}
+            <span>{item}</span>
+          </div>
+        ))}
+      </div>
+    </RecipeSection>
+  );
+}
+
+/** Numbered vertical timeline; each child is one step. */
+export function RecipeSteps({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const steps = React.Children.toArray(children);
+  return (
+    <RecipeSection label="Steps">
+      <div className={styles.stepsWrap}>
+        <div className={styles.stepsRail} />
+        {steps.map((step, i) => (
+          <div className={styles.stepRow} key={i}>
+            <span className={styles.stepNum}>{i + 1}</span>
+            <div className={styles.stepBody}>{step}</div>
+          </div>
+        ))}
+      </div>
+    </RecipeSection>
+  );
+}
+
+/** Subtle inline note (replaces stock admonitions inside recipe bodies). */
+export function RecipeNote({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  return <div className={styles.note}>{children}</div>;
+}
+
+/** Warm "Take it further" callout; children are the extension bullets. */
+export function TakeItFurther({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const items = React.Children.toArray(children);
+  return (
+    <div className={styles.further}>
+      <div className={styles.furtherHeader}>
+        {getIcon('Zap', 'feather', {
+          width: 18,
+          height: 18,
+          color: 'var(--gdt-warning-fg)',
+        })}
+        <span>Take it further</span>
+      </div>
+      <div className={styles.furtherList}>
+        {items.map((item, i) => (
+          <div className={styles.furtherRow} key={i}>
+            {getIcon('ArrowRight', 'feather', {
+              width: 18,
+              height: 18,
+              color: 'var(--gdt-warning-fg)',
+            })}
+            <span>{item}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface RecipeLayoutProps {
+  recipe: RecipeRecord;
+  children: React.ReactNode;
+}
+
+/**
+ * Recipe detail template per design handoff 4b: gradient header banner
+ * (breadcrumb, category tile, title, meta pills) and a main + sticky-rail
+ * grid. Body sections come from the recipe MDX via the section components.
+ */
+export default function RecipeLayout({
+  recipe,
+  children,
+}: RecipeLayoutProps): React.ReactElement {
+  return (
+    <RecipeContext.Provider value={recipe}>
+      <div className={styles.page}>
+        <div className={styles.banner}>
+          <div className={styles.breadcrumb}>
+            <Link to="/cookbook">Cookbook</Link>
+            <span className={styles.breadcrumbSep}>/</span>
+            {recipe.title}
+          </div>
+          <div className={styles.bannerMain}>
+            <CategoryTile category={recipe.category} iconSize={26} size={52} />
+            <div>
+              <h1 className={styles.bannerTitle}>{recipe.title}</h1>
+              <p className={styles.bannerDesc}>{recipe.summary}</p>
+            </div>
+          </div>
+          <div className={styles.metaRow}>
+            {metaPill('Clock', recipe.time_estimate.replace(/\s*\(.*\)$/, ''))}
+            {metaPill('TrendingUp', recipe.level)}
+          </div>
+        </div>
+
+        <div className={styles.columns}>
+          <div className={styles.main}>{children}</div>
+
+          <div className={styles.rail}>
+            <ActionCard recipe={recipe} />
+
+            <div className={styles.railCard}>
+              <div className={styles.railLabel}>At a glance</div>
+              <div className={styles.glanceRows}>
+                <div className={styles.glanceRow}>
+                  <span className={styles.glanceKey}>Surfaces</span>
+                  <span className={styles.glanceVal}>
+                    {recipe.surfaces
+                      .map((s) => RECIPE_SURFACE_LABELS[s])
+                      .join(', ')}
+                  </span>
+                </div>
+                <div className={styles.glanceRow}>
+                  <span className={styles.glanceKey}>Status</span>
+                  <span className={styles.glanceVal}>
+                    {RECIPE_STATUS_LABELS[recipe.status]}
+                  </span>
+                </div>
+                <div className={`${styles.glanceRow} ${styles.glanceRowLast}`}>
+                  <span className={styles.glanceKey}>Time</span>
+                  <span className={styles.glanceVal}>
+                    {recipe.time_estimate}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {recipe.required_scopes.length > 0 ? (
+              <div className={styles.railCard}>
+                <div className={styles.railLabel}>Required scopes</div>
+                <div className={styles.scopes}>
+                  {recipe.required_scopes.map((scope) => (
+                    <span className={styles.scopeChip} key={scope}>
+                      {scope}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+
+            {recipe.code_assets.length > 0 ? (
+              <div className={styles.railCard}>
+                <div className={styles.railLabel}>Code assets</div>
+                <div className={styles.assets}>
+                  {recipe.code_assets.map((asset) => (
+                    <a
+                      className={styles.assetRow}
+                      href={`${COOKBOOK_REPO_URL}/${asset.repo_path}`}
+                      key={asset.repo_path}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <span>{asset.description}</span>
+                      {getIcon('ExternalLink', 'feather', {
+                        width: 14,
+                        height: 14,
+                        color: 'currentColor',
+                      })}
+                    </a>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </RecipeContext.Provider>
+  );
+}

--- a/src/components/Cookbook/RecipePage.tsx
+++ b/src/components/Cookbook/RecipePage.tsx
@@ -1,0 +1,37 @@
+import type React from 'react';
+import recipesData from '@site/src/data/recipes.json';
+import type { RecipesData } from '../../types/recipe';
+import RecipeLayout from './RecipeLayout';
+
+interface RecipePageProps {
+  recipeId: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Entry point used by recipe MDX pages:
+ *
+ *   <RecipePage recipeId="embed-search-chat"> ...body... </RecipePage>
+ *
+ * Looks up the page's compiled record from recipes.json and wraps the body
+ * in RecipeLayout. Throws on an unknown id so a typo fails the static build
+ * instead of shipping a page with an empty rail.
+ */
+export default function RecipePage({
+  recipeId,
+  children,
+}: RecipePageProps): React.ReactElement {
+  const recipe = (recipesData as RecipesData).recipes.find(
+    (r) => r.id === recipeId,
+  );
+
+  if (!recipe) {
+    throw new Error(
+      `RecipePage: no compiled recipe with id "${recipeId}". ` +
+        'Check the recipeId prop against the recipe frontmatter, and that ' +
+        'recipes:compile ran.',
+    );
+  }
+
+  return <RecipeLayout recipe={recipe}>{children}</RecipeLayout>;
+}

--- a/src/components/Cookbook/categories.module.css
+++ b/src/components/Cookbook/categories.module.css
@@ -1,0 +1,36 @@
+.tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.tile_search {
+  background: var(--gdt-cat-search-bg);
+  color: var(--gdt-cat-search-fg);
+}
+
+.tile_index {
+  background: var(--gdt-cat-index-bg);
+  color: var(--gdt-cat-index-fg);
+}
+
+.tile_mcp {
+  background: var(--gdt-cat-mcp-bg);
+  color: var(--gdt-cat-mcp-fg);
+}
+
+.tile_workflow {
+  background: var(--gdt-cat-workflow-bg);
+  color: var(--gdt-cat-workflow-fg);
+}
+
+.tile_agent {
+  background: var(--gdt-cat-agent-bg);
+  color: var(--gdt-cat-agent-fg);
+}
+
+.tile_portal {
+  background: var(--gdt-cat-portal-bg);
+  color: var(--gdt-cat-portal-fg);
+}

--- a/src/components/Cookbook/categories.tsx
+++ b/src/components/Cookbook/categories.tsx
@@ -1,0 +1,54 @@
+import type React from 'react';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import styles from './categories.module.css';
+
+/**
+ * Category → pastel tile treatment, per the design handoff
+ * (design-references/Cookbook.dc.html, direction 4a/4b).
+ *
+ * Glyphs come from the Glean icon set (theme Icons, iconSet 'glean') per
+ * the handoff's asset note: use Glean-custom glyphs, not generic feather
+ * substitutes, for category/product surfaces.
+ */
+export const CATEGORY_ICONS: Record<string, string> = {
+  search: 'deep-research',
+  index: 'sources',
+  mcp: 'mcp',
+  workflow: 'workflow',
+  agent: 'agent',
+  portal: 'glean-app',
+};
+
+export function categoryTileClass(category: string): string {
+  return `${styles.tile} ${styles[`tile_${category}`] ?? styles.tile_portal}`;
+}
+
+interface CategoryTileProps {
+  category: string;
+  /** Tile square size in px (44 on index cards, 52 on the detail banner). */
+  size?: number;
+  iconSize?: number;
+}
+
+export function CategoryTile({
+  category,
+  size = 44,
+  iconSize = 21,
+}: CategoryTileProps): React.ReactElement {
+  return (
+    <span
+      className={categoryTileClass(category)}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: Math.round(size * 0.27),
+      }}
+    >
+      {getIcon(CATEGORY_ICONS[category] ?? 'glean-app', 'glean', {
+        width: iconSize,
+        height: iconSize,
+        color: 'currentColor',
+      })}
+    </span>
+  );
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -12,6 +12,7 @@
 /* Import fonts */
 @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,100..1000&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..800&display=swap');
 
 :root {
   /* MCP Tooltip Variables - Light mode: white on blue */
@@ -651,4 +652,84 @@ li.tabs__item.openapi-tabs__code-item.openapi-tabs__code-item--javascript
 
 .mcp-tooltip[data-tooltip-place='right']:after {
   border-right-color: var(--mcp-tooltip-bg) !important;
+}
+
+/* ============================================================
+ * Cookbook design tokens — from the 2026-07 design handoff
+ * (design-references/glean-tokens.css). Scoped with a --gdt-
+ * prefix; used by src/components/Cookbook/*.
+ * ============================================================ */
+:root {
+  --gdt-primary: #343ced;
+  --gdt-primary-hover: #131bd4;
+  --gdt-selected-bg: #eef0ff;
+  --gdt-info-fg: #1d24b8;
+  --gdt-text-primary: #1f2024;
+  --gdt-text-secondary: #565a64;
+  --gdt-bg-light: #f7f8fa;
+  --gdt-bg-mid: #eef0f3;
+  --gdt-border-light: #e7e8ed;
+  --gdt-border-dark: #c9cbd2;
+  --gdt-hairline: #f0f1f4;
+  --gdt-card-bg: #ffffff;
+  --gdt-success: #22c55e;
+  --gdt-warning-fg: #92670a;
+  --gdt-warning-bg: #fff8e5;
+  --gdt-warning-border: #ffe0b3;
+
+  /* Category tiles (bg / fg) */
+  --gdt-cat-search-bg: #d6eeff;
+  --gdt-cat-search-fg: #1d6fb8;
+  --gdt-cat-index-bg: #f0f9d6;
+  --gdt-cat-index-fg: #6c7d17;
+  --gdt-cat-mcp-bg: #fadcff;
+  --gdt-cat-mcp-fg: #dd2ca5;
+  --gdt-cat-workflow-bg: #ffe9df;
+  --gdt-cat-workflow-fg: #ef601b;
+  --gdt-cat-agent-bg: #fff2bf;
+  --gdt-cat-agent-fg: #b8860b;
+  --gdt-cat-portal-bg: #eef0ff;
+  --gdt-cat-portal-fg: #343ced;
+}
+
+html[data-theme='dark'] {
+  --gdt-selected-bg: rgba(52, 60, 237, 0.22);
+  --gdt-info-fg: #aab5ff;
+  --gdt-text-primary: var(--ifm-font-color-base);
+  --gdt-text-secondary: var(--ifm-color-emphasis-600);
+  --gdt-bg-light: var(--ifm-background-surface-color);
+  --gdt-bg-mid: var(--ifm-color-emphasis-200);
+  --gdt-border-light: var(--ifm-color-emphasis-200);
+  --gdt-border-dark: var(--ifm-color-emphasis-400);
+  --gdt-hairline: var(--ifm-color-emphasis-200);
+  --gdt-card-bg: var(--ifm-card-background-color);
+  --gdt-warning-bg: rgba(146, 103, 10, 0.15);
+  --gdt-warning-border: rgba(146, 103, 10, 0.4);
+  --gdt-warning-fg: #e2b93d;
+}
+
+/* Cookbook typography — Inter first: deterministic across browsers.
+ * System-font resolution of SF varies by browser (text vs display optical
+ * sizing), which made headings render wide for some users; Inter's opsz
+ * axis gives the tight display cut everywhere. */
+:root {
+  --gdt-font-display:
+    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'DM Sans',
+    system-ui, sans-serif;
+  --gdt-font-text:
+    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'DM Sans',
+    system-ui, sans-serif;
+}
+
+/* Cookbook pages: hide the theme breadcrumbs and doc footer — the 4a/4b
+ * designs carry their own header/breadcrumb treatment */
+html[class*='docs-doc-id-cookbook'] .theme-doc-breadcrumbs,
+html[class*='docs-doc-id-cookbook'] .theme-doc-footer {
+  display: none;
+}
+
+/* Cookbook recipe pages: allow the 4b banner to bleed to the full main
+ * column (flush against sidebar/top bar) via container-query units */
+html[class*='docs-doc-id-cookbook'] main[class*='docMainContainer'] {
+  container-type: inline-size;
 }

--- a/src/test/mocks/docusaurus.tsx
+++ b/src/test/mocks/docusaurus.tsx
@@ -8,6 +8,26 @@ vi.mock('@site/src/theme/Root', () => ({
   }),
 }));
 
+// Mock Docusaurus Link (the real export fails to transform under vitest)
+vi.mock('@docusaurus/Link', () => ({
+  default: ({ to, href, children, ...rest }: any) => (
+    <a href={to ?? href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock useBaseUrl (pulls raw-JSX Docusaurus internals under vitest)
+vi.mock('@docusaurus/useBaseUrl', () => ({
+  default: (url: string) => url,
+}));
+
+// Mock theme icons (react-feather bundles its own React copy, which
+// React 19 rejects under vitest; the real build dedupes it fine)
+vi.mock('@gleanwork/docusaurus-theme-glean/Icons', () => ({
+  getIcon: (name: string) => <span data-icon={name} />,
+}));
+
 // Mock Docusaurus Tabs components
 vi.mock('@theme/Tabs', () => ({
   default: ({ children, className }: any) => (


### PR DESCRIPTION
## Summary
The Cookbook UI per the approved design handoff (directions 4a/4b), pixel-matched against the reference captures:
- **Index**: header, flagship hero card with the "Combines three recipes" mini-list, single-select filter chips with live count, recipe cards with pastel category tiles (Glean icon set)
- **Detail**: full-bleed gradient banner (container-query bleed), meta pills, main + 300px sticky rail (AI-assistant action card, at-a-glance, scope chips, code assets), and body section components (architecture flow diagram, prerequisite rows, steps timeline, note + take-it-further callouts)
- Handoff design tokens as `--gdt-*` vars with dark-mode mappings; Inter as the deterministic display face (SF Pro isn't web-licensable; system resolution varies by browser)
- Compound heading selectors deliberately out-rank `brand.css`'s `.main-wrapper h1` letter-spacing override (see comment in RecipeIndex.module.css)

Part 3 of 4; components are unreferenced by any page until #628.

## Verification
- `pnpm vitest run src/components/Cookbook` — index filtering, flagship, layout rail render tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots
_Cookbook index (4a) — flagship hero, filter chips, recipe cards:_
![Cookbook index](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/cookbook-index.png)

_Recipe detail (4b) — banner, architecture diagram, steps timeline, sticky rail:_
![Recipe detail](https://raw.githubusercontent.com/gleanwork/glean-developer-site/cookbook-pr-assets/recipe-embed.png)
