### PR TITLE
Plugin pages v2: design-forward refresh + Codex page

### DIFF
--- a/docs/guides/mcp/claude-code.mdx
+++ b/docs/guides/mcp/claude-code.mdx
@@ -10,9 +10,7 @@ import PluginPage from '@site/src/components/PluginPage';
 <PluginPage
   name="Claude Code"
   tagline="You use Claude Code. Glean brings the enterprise context."
-  logo="/img/mcp-clients/claude.png"
-  accentColor="#D97757"
-  gleanConfigureHref="https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=claude-code"
+  clientId="claude-code"
   steps={[
     {
       type: 'cta',

--- a/docs/guides/mcp/codex.mdx
+++ b/docs/guides/mcp/codex.mdx
@@ -1,0 +1,50 @@
+---
+title: Glean Plugins for Codex
+description: Install the official Glean plugins for Codex — enterprise knowledge, search, people, code, and Glean developer docs in your terminal.
+---
+
+import PluginPage from '@site/src/components/PluginPage';
+
+{/* Install commands synced from https://github.com/gleanwork/codex-plugins/blob/main/README.md */}
+
+<PluginPage
+  name="Codex"
+  tagline="You use Codex. Glean brings the enterprise context."
+  clientId="codex"
+  mono
+  title="Glean plugins for Codex"
+  steps={[
+    {
+      type: 'cta',
+      label: 'Get your Glean MCP server details',
+      description: 'The glean plugin requires a Glean MCP connection. Open the Glean MCP configurator to find your organization\'s server URL and server name — you\'ll use both in the last step.',
+      ctaText: 'Open MCP Configurator',
+      ctaHref: 'https://app.glean.com/settings/install?mcpConfigure=true',
+    },
+    {
+      type: 'command',
+      label: 'Add the Glean marketplace and install plugins',
+      description: 'Run these commands in your terminal. glean is the enterprise-knowledge plugin; glean-dev-docs adds search over Glean\'s developer documentation.',
+      commands: [
+        { title: 'Add the Glean marketplace', code: 'codex plugin marketplace add gleanwork/codex-plugins' },
+        { title: 'Install the plugins', code: 'codex plugin add glean@glean-codex-plugins\ncodex plugin add glean-dev-docs@glean-codex-plugins' },
+      ],
+    },
+    {
+      type: 'command',
+      label: 'Connect the MCP servers',
+      description: 'Before starting Codex, connect the MCP server each plugin uses — substitute the server URL and name from step 1. Then start a new Codex task so the bundled skills and MCP tools are available.',
+      commands: [
+        { title: 'Glean enterprise knowledge', code: 'codex mcp add glean --url <server-url>/mcp/<server-name>\ncodex mcp login glean' },
+        { title: 'Glean developer docs', code: 'codex mcp add glean-dev-docs --url https://developers.glean.com/mcp' },
+      ],
+    },
+  ]}
+/>
+
+## Which plugin do I need?
+
+| I want to… | Install |
+|------------|---------|
+| Search company docs, Slack, and email; explore code across repos; find people and experts; prep for meetings | `glean` |
+| Search Glean's developer documentation — APIs, SDKs, MCP, and integration guides | `glean-dev-docs` |

--- a/docs/guides/mcp/codex.mdx
+++ b/docs/guides/mcp/codex.mdx
@@ -1,6 +1,6 @@
 ---
-title: Glean Plugins for Codex
-description: Install the official Glean plugins for Codex — enterprise knowledge, search, people, code, and Glean developer docs in your terminal.
+title: Glean Plugin for Codex
+description: Install the official Glean plugin for Codex — enterprise knowledge, search, people, and code in your terminal.
 ---
 
 import PluginPage from '@site/src/components/PluginPage';
@@ -12,39 +12,30 @@ import PluginPage from '@site/src/components/PluginPage';
   tagline="You use Codex. Glean brings the enterprise context."
   clientId="codex"
   mono
-  title="Glean plugins for Codex"
   steps={[
     {
       type: 'cta',
       label: 'Get your Glean MCP server details',
-      description: 'The glean plugin requires a Glean MCP connection. Open the Glean MCP configurator to find your organization\'s server URL and server name — you\'ll use both in the last step.',
+      description: 'The plugin requires a Glean MCP connection. Open the Glean MCP configurator to find your organization\'s server URL and server name — you\'ll use both in the last step.',
       ctaText: 'Open MCP Configurator',
       ctaHref: 'https://app.glean.com/settings/install?mcpConfigure=true',
     },
     {
       type: 'command',
-      label: 'Add the Glean marketplace and install plugins',
-      description: 'Run these commands in your terminal. glean is the enterprise-knowledge plugin; glean-dev-docs adds search over Glean\'s developer documentation.',
+      label: 'Add the Glean marketplace and install the plugin',
+      description: 'Run these commands in your terminal to install the Glean enterprise-knowledge plugin.',
       commands: [
         { title: 'Add the Glean marketplace', code: 'codex plugin marketplace add gleanwork/codex-plugins' },
-        { title: 'Install the plugins', code: 'codex plugin add glean@glean-codex-plugins\ncodex plugin add glean-dev-docs@glean-codex-plugins' },
+        { title: 'Install the plugin', code: 'codex plugin add glean@glean-codex-plugins' },
       ],
     },
     {
       type: 'command',
-      label: 'Connect the MCP servers',
-      description: 'Before starting Codex, connect the MCP server each plugin uses — substitute the server URL and name from step 1. Then start a new Codex task so the bundled skills and MCP tools are available.',
+      label: 'Connect the Glean MCP server',
+      description: 'Before starting Codex, connect the MCP server — substitute the server URL and name from step 1. Then start a new Codex task so the bundled skills and MCP tools are available.',
       commands: [
-        { title: 'Glean enterprise knowledge', code: 'codex mcp add glean --url <server-url>/mcp/<server-name>\ncodex mcp login glean' },
-        { title: 'Glean developer docs', code: 'codex mcp add glean-dev-docs --url https://developers.glean.com/mcp' },
+        { title: 'Connect and sign in', code: 'codex mcp add glean --url <server-url>/mcp/<server-name>\ncodex mcp login glean' },
       ],
     },
   ]}
 />
-
-## Which plugin do I need?
-
-| I want to… | Install |
-|------------|---------|
-| Search company docs, Slack, and email; explore code across repos; find people and experts; prep for meetings | `glean` |
-| Search Glean's developer documentation — APIs, SDKs, MCP, and integration guides | `glean-dev-docs` |

--- a/docs/guides/mcp/cursor.mdx
+++ b/docs/guides/mcp/cursor.mdx
@@ -8,9 +8,8 @@ import PluginPage from '@site/src/components/PluginPage';
 <PluginPage
   name="Cursor"
   tagline="You use Cursor. Glean brings the enterprise context."
-  logo="/img/mcp-clients/cursor.png"
-  accentColor="#1c1c1c"
-  gleanConfigureHref="https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=cursor"
+  clientId="cursor"
+  mono
   steps={[
     {
       type: 'cta',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -306,6 +306,11 @@ const baseSidebars: SidebarsConfig = {
               id: 'guides/mcp/cursor',
               label: 'Cursor Plugin',
             },
+            {
+              type: 'doc',
+              id: 'guides/mcp/codex',
+              label: 'Codex Plugins',
+            },
           ],
         },
         {

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -309,7 +309,7 @@ const baseSidebars: SidebarsConfig = {
             {
               type: 'doc',
               id: 'guides/mcp/codex',
-              label: 'Codex Plugins',
+              label: 'Codex Plugin',
             },
           ],
         },

--- a/src/components/PluginPage/index.tsx
+++ b/src/components/PluginPage/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { Steps, Step } from '@theme/Steps';
-import CodeBlock from '@theme/CodeBlock';
-import Frame from '@theme/Frame';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import { getClientIcon } from '@gleanwork/mcp-config-schema/browser';
+import TerminalPanel from '../home/TerminalPanel';
 import styles from './styles.module.css';
 
 type PluginStep = {
@@ -19,85 +19,108 @@ type PluginStep = {
 type PluginPageProps = {
   name: string;
   tagline: string;
-  logo: string;
-  accentColor: string;
+  /** Client id from @gleanwork/mcp-config-schema (claude-code, cursor, codex). */
+  clientId: string;
+  /** Monochrome brand marks need inverting in dark mode (cursor, codex). */
+  mono?: boolean;
+  /** Banner heading; defaults to "Glean plugin for <name>". */
+  title?: string;
   steps: PluginStep[];
 };
 
+function StepBody({ step }: { step: PluginStep }): React.ReactElement {
+  const imageUrl = useBaseUrl(step.image ?? '');
+  return (
+    <>
+      <div className={styles.stepLabel}>{step.label}</div>
+      <p className={styles.stepDescription}>{step.description}</p>
+      {step.type === 'cta' ? (
+        <Link className={styles.ctaButton} to={step.ctaHref}>
+          {step.ctaText}
+          {getIcon('ArrowUpRight', 'feather', {
+            width: 16,
+            height: 16,
+            color: 'currentColor',
+          })}
+        </Link>
+      ) : null}
+      {step.type === 'list' ? (
+        <ol className={styles.stepList}>
+          {step.items.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
+        </ol>
+      ) : null}
+      {step.type === 'command'
+        ? step.commands.map((cmd) => (
+            <div className={styles.commandBlock} key={cmd.title}>
+              <TerminalPanel
+                className={styles.terminal}
+                code={cmd.code}
+                copy
+                filename={cmd.title}
+              />
+            </div>
+          ))
+        : null}
+      {step.image ? (
+        <img alt={step.label} className={styles.stepImage} src={imageUrl} />
+      ) : null}
+    </>
+  );
+}
+
+/**
+ * Plugin install page in the homepage-redesign design language: token-based
+ * banner with brand lockup, numbered step rail, terminal command panels.
+ */
 export default function PluginPage({
   name,
   tagline,
-  logo,
-  accentColor,
+  clientId,
+  mono = false,
+  title,
   steps,
-}: PluginPageProps) {
+}: PluginPageProps): React.ReactElement {
   return (
-    <div className={styles.page}>
-      {/* Hero */}
-      <div
-        className={styles.hero}
-        style={{ '--plugin-accent': accentColor } as React.CSSProperties}
-      >
-        <div className={styles.heroInner}>
-          <div className={styles.logoRow}>
-            <img
-              src={useBaseUrl('/img/glean-logo-white.svg')}
-              alt="Glean"
-              className={styles.gleanLogo}
-            />
-            <span className={styles.times}>×</span>
-            <img
-              src={useBaseUrl(logo)}
-              alt={name}
-              className={styles.pluginLogo}
-            />
-          </div>
-          <h1 className={styles.heroTitle}>Official Glean Plugin for {name}</h1>
-          <p className={styles.heroTagline}>{tagline}</p>
+    <div className={`${styles.page} plugin-page-root`}>
+      <div className={styles.banner}>
+        <span className={styles.eyebrow}>
+          <span className={styles.eyebrowDot} />
+          Official Glean plugin
+        </span>
+        <div className={styles.lockup}>
+          <span className={styles.brandTile}>
+            {getIcon('glean-logo', 'glean', {
+              width: 26,
+              height: 26,
+              color: 'currentColor',
+            })}
+          </span>
+          <span className={styles.times}>×</span>
+          <span
+            className={`${styles.brandTile} ${mono ? styles.brandTileMono : ''}`}
+            dangerouslySetInnerHTML={{ __html: getClientIcon(clientId) ?? '' }}
+          />
         </div>
+        <h1 className={styles.bannerTitle}>
+          {title ?? `Glean plugin for ${name}`}
+        </h1>
+        <p className={styles.bannerTagline}>{tagline}</p>
       </div>
 
-      <h2>Installation</h2>
-
-      {/* Steps */}
-      <Steps>
+      <div className={styles.sectionLabel}>Installation</div>
+      <div className={styles.stepsWrap}>
+        <div className={styles.stepsRail} />
         {steps.map((step, i) => (
-          <Step key={i} title={step.label} titleSize="h2">
-            <p>{step.description}</p>
-            {step.type === 'cta' && (
-              <Link
-                to={step.ctaHref}
-                className={styles.ctaButton}
-                style={{
-                  backgroundColor: accentColor,
-                  borderColor: accentColor,
-                }}
-              >
-                {step.ctaText}
-              </Link>
-            )}
-            {step.type === 'list' && (
-              <ol>
-                {step.items.map((item, j) => (
-                  <li key={j}>{item}</li>
-                ))}
-              </ol>
-            )}
-            {step.type === 'command' &&
-              step.commands.map((cmd, j) => (
-                <div key={j}>
-                  <p className={styles.commandLabel}>{cmd.title}</p>
-                  <CodeBlock language="bash">{cmd.code}</CodeBlock>
-                </div>
-              ))}
-            {step.image && (
-              <Frame>
-                <img src={useBaseUrl(step.image)} alt={step.label} />
-              </Frame>
-            )}
-          </Step>
+          <div className={styles.stepRow} key={step.label}>
+            <span className={styles.stepNum}>{i + 1}</span>
+            <div className={styles.stepBody}>
+              <StepBody step={step} />
+            </div>
+          </div>
         ))}
-      </Steps>
+      </div>
     </div>
   );
 }

--- a/src/components/PluginPage/styles.module.css
+++ b/src/components/PluginPage/styles.module.css
@@ -1,97 +1,230 @@
-/* HERO */
-.hero {
+/* Plugin install page v2 — homepage-redesign design language.
+ * Token-based (light-first, dark mode maps through --gdt-*). */
+
+.page {
+  font-family: var(--gdt-font-text);
+}
+
+/* ---- Banner ---- */
+
+.banner {
+  border-radius: 20px;
+  border: 1px solid var(--gdt-border-light);
   background: linear-gradient(
     135deg,
-    #0b0e51 0%,
-    var(--plugin-accent, #4785b0) 100%
+    var(--gdt-bg-light) 0%,
+    var(--gdt-selected-bg) 100%
   );
-  border-radius: 12px;
-  padding: 3rem 2.5rem;
-  margin-bottom: 2.5rem;
-  color: #ffffff;
+  padding: 40px 36px;
+  margin-bottom: 36px;
 }
 
-.heroInner {
-  max-width: 640px;
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 9999px;
+  background: var(--gdt-card-bg);
+  border: 1px solid var(--gdt-border-light);
+  color: var(--gdt-info-fg);
+  font-size: 12px;
+  font-weight: 500;
+  margin-bottom: 22px;
 }
 
-.logoRow {
+.eyebrowDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+}
+
+.lockup {
   display: flex;
   align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
+  gap: 14px;
+  margin-bottom: 20px;
 }
 
-.gleanLogo {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
+.brandTile {
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
+  background: var(--gdt-card-bg);
+  border: 1px solid var(--gdt-border-light);
+  color: var(--gdt-text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brandTile svg {
+  width: 26px;
+  height: 26px;
+}
+
+/* Monochrome brand marks (Cursor, Codex) need inverting on dark */
+html[data-theme='dark'] .brandTileMono svg {
+  filter: invert(1) hue-rotate(180deg);
 }
 
 .times {
-  font-size: 1.25rem;
-  opacity: 0.6;
-  font-weight: 300;
+  font-size: 18px;
+  color: var(--gdt-text-secondary);
 }
 
-.pluginLogo {
-  width: 32px;
-  height: 32px;
-  object-fit: contain;
-  border-radius: 6px;
+/* Compound selector out-ranks brand.css `.main-wrapper h1` (0,1,1), which
+ * otherwise forces letter-spacing +0.025em and line-height 1.2. */
+.banner h1.bannerTitle {
+  font-family: var(--gdt-font-display);
+  font-size: 34px;
+  line-height: 1.12;
+  letter-spacing: 0;
+  font-weight: 800;
+  margin: 0 0 10px;
 }
 
-.heroTitle {
-  font-size: 1.75rem;
-  font-weight: 700;
-  color: #ffffff !important;
-  margin-bottom: 0.75rem;
-  line-height: 1.2;
+.bannerTagline {
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--gdt-text-secondary);
+  max-width: 560px;
+  margin: 0;
 }
 
-.heroTagline {
-  font-size: 1.0625rem;
-  opacity: 0.85;
+@media (max-width: 768px) {
+  .banner {
+    padding: 28px 22px;
+  }
+
+  .banner h1.bannerTitle {
+    font-size: 26px;
+  }
+}
+
+/* ---- Section label (matches recipe pages) ---- */
+
+.sectionLabel {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  color: var(--gdt-primary);
+  text-transform: uppercase;
+  margin-bottom: 16px;
+}
+
+/* ---- Numbered step rail (matches recipe pages) ---- */
+
+.stepsWrap {
+  position: relative;
+  padding-left: 40px;
+  margin-bottom: 32px;
+}
+
+.stepsRail {
+  position: absolute;
+  left: 11px;
+  top: 8px;
+  bottom: 8px;
+  width: 2px;
+  background: var(--gdt-border-light);
+}
+
+.stepRow {
+  position: relative;
+  margin-bottom: 28px;
+}
+
+.stepRow:last-child {
   margin-bottom: 0;
+}
+
+.stepNum {
+  position: absolute;
+  left: -40px;
+  width: 24px;
+  height: 24px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.stepBody {
+  font-size: 14.5px;
   line-height: 1.55;
 }
 
-/* Command label */
-.commandLabel {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--ifm-color-content-secondary);
-  margin-bottom: 0.375rem;
-  margin-top: 0.75rem;
+.stepLabel {
+  font-family: var(--gdt-font-display);
+  font-size: 17px;
+  font-weight: 700;
+  margin-bottom: 6px;
 }
 
-/* CTA button */
+.stepDescription {
+  color: var(--gdt-text-secondary);
+  margin: 0 0 14px;
+  max-width: 640px;
+}
+
+/* ---- CTA step ---- */
+
 .ctaButton {
   display: inline-flex;
   align-items: center;
-  padding: 0.625rem 1.25rem;
-  border-radius: 6px;
+  gap: 8px;
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  background: var(--gdt-primary);
+  color: #fff;
+  font-size: 14px;
   font-weight: 600;
-  font-size: 0.9375rem;
-  color: #ffffff !important;
-  text-decoration: none !important;
-  border: 2px solid transparent;
-  transition: opacity 0.15s ease;
-  margin-top: 0.75rem;
+  transition: background 0.15s ease;
 }
 
 .ctaButton:hover {
-  opacity: 0.88;
-  color: #ffffff !important;
+  background: var(--gdt-primary-hover);
+  color: #fff;
+  text-decoration: none;
 }
 
-/* Responsive */
-@media (max-width: 768px) {
-  .hero {
-    padding: 2rem 1.5rem;
-  }
+/* ---- List step ---- */
 
-  .heroTitle {
-    font-size: 1.375rem;
-  }
+.stepList {
+  margin: 0 0 14px;
+  padding-left: 20px;
+}
+
+.stepList li {
+  margin-bottom: 6px;
+}
+
+/* ---- Command step ---- */
+
+.commandBlock {
+  max-width: 640px;
+  margin-bottom: 14px;
+}
+
+.commandBlock:last-child {
+  margin-bottom: 0;
+}
+
+/* ---- Screenshot ---- */
+
+.stepImage {
+  display: block;
+  max-width: 640px;
+  width: 100%;
+  border-radius: 14px;
+  border: 1px solid var(--gdt-border-light);
+  margin-top: 6px;
 }

--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -392,6 +392,33 @@ html[data-theme='dark'] .heroSecondary:hover {
   font-family: var(--ifm-font-family-monospace);
 }
 
+.terminalCopy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  margin-left: 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: #8b8f98;
+  cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
+}
+
+.terminalCopy:hover {
+  color: #e6e7ea;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* When there is no label, push the copy button to the right edge. */
+.terminalCopyEnd {
+  margin-left: auto;
+}
+
 .terminalPre {
   margin: 0;
   padding: 22px 20px;

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -390,8 +390,8 @@ const MCP_CARDS = [
   },
   {
     title: 'Codex',
-    body: 'Install the Glean plugins for Codex from the gleanwork marketplace.',
-    href: 'https://github.com/gleanwork/codex-plugins',
+    body: 'Install the Glean plugins for Codex — enterprise knowledge and dev docs in your terminal.',
+    href: '/guides/mcp/codex',
     clientId: 'codex',
     mono: true,
   },

--- a/src/components/home/HomeRedesign.tsx
+++ b/src/components/home/HomeRedesign.tsx
@@ -390,7 +390,7 @@ const MCP_CARDS = [
   },
   {
     title: 'Codex',
-    body: 'Install the Glean plugins for Codex — enterprise knowledge and dev docs in your terminal.',
+    body: 'Install the Glean plugin for Codex — enterprise knowledge in your terminal.',
     href: '/guides/mcp/codex',
     clientId: 'codex',
     mono: true,

--- a/src/components/home/TerminalPanel.tsx
+++ b/src/components/home/TerminalPanel.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
 import styles from './HomeRedesign.module.css';
 
 /** Minimal syntax tinting per the handoff token colors. */
@@ -41,6 +42,8 @@ interface TerminalPanelProps {
   label?: string;
   code: string;
   className?: string;
+  /** Show a copy-to-clipboard button in the header. */
+  copy?: boolean;
 }
 
 /** Dark editor/terminal card per the handoff: mac dots, filename, label. */
@@ -49,7 +52,20 @@ export default function TerminalPanel({
   label,
   code,
   className,
+  copy = false,
 }: TerminalPanelProps): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  const copyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable; the code stays selectable.
+    }
+  };
+
   return (
     <div className={`${styles.terminal} ${className ?? ''}`}>
       <div className={styles.terminalHeader}>
@@ -58,6 +74,21 @@ export default function TerminalPanel({
         <span className={styles.dotGreen} />
         <span className={styles.terminalFile}>{filename}</span>
         {label ? <span className={styles.terminalLabel}>{label}</span> : null}
+        {copy ? (
+          <button
+            aria-label="Copy to clipboard"
+            className={`${styles.terminalCopy} ${label ? '' : styles.terminalCopyEnd}`}
+            onClick={copyCode}
+            title="Copy to clipboard"
+            type="button"
+          >
+            {getIcon(copied ? 'Check' : 'Copy', 'feather', {
+              width: 13,
+              height: 13,
+              color: copied ? '#28c840' : 'currentColor',
+            })}
+          </button>
+        ) : null}
       </div>
       <pre className={styles.terminalPre}>{tint(code)}</pre>
     </div>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -741,6 +741,13 @@ article:has(.home-redesign-root) > header {
   display: none;
 }
 
+/* Plugin pages: the v2 banner carries the title — hide the duplicate
+ * doc-title header above it */
+article:has(.plugin-page-root) > .theme-doc-markdown > header,
+article:has(.plugin-page-root) > header {
+  display: none;
+}
+
 /* Home redesign fills the main column: the doc container's max-width is
  * sized for text + TOC layouts, which the redesigned homepage doesn't use.
  * Scoped via :has so it only applies while the redesign is rendering. */

--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -1,6 +1,170 @@
 {
   "entries": [
     {
+      "id": "2026-07-20-glean-agent-toolkit-0-7-0",
+      "slug": "glean-agent-toolkit-0-7-0",
+      "title": "glean-agent-toolkit 0.7.0",
+      "date": "2026-07-20",
+      "categories": [
+        "Glean Agent Toolkit"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Glean-agent-toolkit 0.7.0: <strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</p>\n",
+      "fullContent": "<p>Glean-agent-toolkit 0.7.0: <strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</p>\n<h2>Changes</h2>\n<ul>\n<li><strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</li>\n<li><strong>chat</strong>: read citations from fragments with legacy fallback.</li>\n<li><strong>core</strong>: ctx-aware as_*_tool, registry collision warnings, retry unit fix.</li>\n<li><strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.7.0\">Release notes</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/87\">PR #87</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/83\">PR #83</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/84\">PR #84</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/81\">PR #81</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-20-glean-agent-toolkit-0-7-0.md"
+    },
+    {
+      "id": "2026-07-19-glean-agent-toolkit-0-6-1",
+      "slug": "glean-agent-toolkit-0-6-1",
+      "title": "glean-agent-toolkit 0.6.1",
+      "date": "2026-07-19",
+      "categories": [
+        "Glean Agent Toolkit"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Glean-agent-toolkit 0.6.1: <strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</p>\n",
+      "fullContent": "<p>Glean-agent-toolkit 0.6.1: <strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</p>\n<h2>Changes</h2>\n<ul>\n<li><strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</li>\n<li><strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</li>\n<li><strong>adk</strong>: expose real typed signatures so declarations and invocation work.</li>\n<li><strong>openai</strong>: sanitize strict schemas and isolate per-tool conversion failures.</li>\n<li><strong>adapters</strong>: map anyOf/union and array item types correctly in get_field_type.</li>\n<li><strong>langchain</strong>: use StructuredTool so converted tools are invocable.</li>\n<li><strong>tools</strong>: stop closing shared Glean client on every tool call.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.1\">Release notes</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/81\">PR #81</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/73\">PR #73</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/77\">PR #77</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/76\">PR #76</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/75\">PR #75</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/74\">PR #74</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/72\">PR #72</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-19-glean-agent-toolkit-0-6-1.md"
+    },
+    {
+      "id": "2026-07-19-glean-agent-toolkit-0-6-0",
+      "slug": "glean-agent-toolkit-0-6-0",
+      "title": "glean-agent-toolkit 0.6.0",
+      "date": "2026-07-19",
+      "categories": [
+        "Glean Agent Toolkit"
+      ],
+      "impact": "action_required",
+      "attention": [
+        {
+          "level": "action_required",
+          "label": "Action required"
+        },
+        {
+          "level": "deprecated",
+          "label": "Deprecated"
+        }
+      ],
+      "summary": "<p>Glean-agent-toolkit 0.6.0: <strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</p>\n",
+      "fullContent": "<p>Glean-agent-toolkit 0.6.0: <strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</p>\n<h2>Action Required</h2>\n<ul>\n<li>Plan migration away from deprecated behavior.</li>\n</ul>\n<h2>Changes</h2>\n<ul>\n<li>Add installable skills for SDK usage and tool building.</li>\n<li>Search API alignment, chat tool, deprecation path, get_tools, async support, import docs.</li>\n<li>Injectable GleanContext replaces hidden api_client() global (#62).</li>\n<li><strong>deps</strong>: add [all] extra combining all framework adapters (CHK-001).</li>\n<li><strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</li>\n<li><strong>adk</strong>: expose real typed signatures so declarations and invocation work.</li>\n<li><strong>openai</strong>: sanitize strict schemas and isolate per-tool conversion failures.</li>\n<li><strong>adapters</strong>: map anyOf/union and array item types correctly in get_field_type.</li>\n<li><strong>langchain</strong>: use StructuredTool so converted tools are invocable.</li>\n<li><strong>tools</strong>: stop closing shared Glean client on every tool call.</li>\n<li>Correct web search tool name from &#39;Web Browser&#39; to &#39;Gemini Web Search&#39;.</li>\n<li>Resolve remaining P2 eval items (CHK-111, CHK-115, CHK-118, CHK-119).</li>\n<li>Resolve eval checklist items — dedup, dead code, error handling, imports.</li>\n<li>Namespace tool names and optimize descriptions for LLM consumption.</li>\n<li>Structured error results and consistent adapter return types.</li>\n<li>Depend on langchain-core instead of langchain to support LangGraph 1.x.</li>\n<li>Regenerate lockfile.</li>\n<li>Align publish workflow tag trigger with commitizen tag format.</li>\n<li>Use is not None checks in read_document validation.</li>\n<li>Export Registry from top-level package.</li>\n<li>Remove pydantic BaseModel from adapters public API.</li>\n<li>Preserve float values in retry backoff config (CHK-002).</li>\n<li><strong>release</strong>: correct broken version_files path in .cz.toml (CHK-006).</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.0\">Release notes</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/73\">PR #73</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/77\">PR #77</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/76\">PR #76</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/75\">PR #75</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/74\">PR #74</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/72\">PR #72</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/70\">PR #70</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/66\">PR #66</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/65\">PR #65</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/27\">PR #27</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/71\">PR #71</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/68\">PR #68</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/67\">PR #67</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/58\">PR #58</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/55\">PR #55</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/54\">PR #54</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/39\">PR #39</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/37\">PR #37</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/36\">PR #36</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/35\">PR #35</a></li>\n<li><a href=\"https://github.com/gleanwork/glean-agent-toolkit/pull/31\">PR #31</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-19-glean-agent-toolkit-0-6-0.md"
+    },
+    {
+      "id": "2026-07-15-rest-api-changes-open-api",
+      "slug": "rest-api-changes-open-api",
+      "title": "REST API: changes (endpoints) 2026-07-15",
+      "date": "2026-07-15",
+      "categories": [
+        "API"
+      ],
+      "impact": "noteworthy",
+      "attention": [
+        {
+          "level": "noteworthy",
+          "label": "Noteworthy"
+        }
+      ],
+      "summary": "<p>2 endpoints added.</p>\n",
+      "fullContent": "<p>2 endpoints added.</p>\n<h2>Changes</h2>\n<ul>\n<li>Added endpoint: /rest/api/index/submissions/{datasourceInstance}/{type}</li>\n<li>Added endpoint: /submissions/{datasourceInstance}/{type}</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/0014369d53ab6aeab9d28a4d3a24dea2361c43cd\">open-api 0014369</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/0dce2185d014565fa994ea8b485b2c354632bc35\">open-api 0dce218</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/0dfbcffd5e93be2858b792645a4ad878be2c6c80\">open-api 0dfbcff</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/2d5869e5349aa2221f85aa1b4e8138acc76e02f2\">open-api 2d5869e</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/2da199e3d09b50fb6e535ce8d682e8faea0d5c4f\">open-api 2da199e</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/2e069735ae7931e10a7fc35947465d1995fcdb48\">open-api 2e06973</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/32e7a5113a574eea522faa51c2d948e14af0c650\">open-api 32e7a51</a></li>\n<li><a href=\"https://github.com/gleanwork/open-api/commit/438762b2397cac4b50c63dba42784619bca9279c\">open-api 438762b</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-15-rest-api-changes-open-api.md"
+    },
+    {
+      "id": "2026-07-15-mcp-config-5-4-0",
+      "slug": "mcp-config-5-4-0",
+      "title": "mcp-config v5.4.0",
+      "date": "2026-07-15",
+      "categories": [
+        "MCP"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Mcp-config v5.4.0: <code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</p>\n",
+      "fullContent": "<p>Mcp-config v5.4.0: <code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</p>\n<h2>Changes</h2>\n<ul>\n<li><code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</li>\n<li><code>mcp-config-schema</code>: add Cursor Team MCP Servers client.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/mcp-config/releases/tag/v5.4.0\">Release notes</a></li>\n<li><a href=\"https://github.com/gleanwork/mcp-config/pull/126\">PR #126</a></li>\n<li><a href=\"https://github.com/gleanwork/mcp-config/pull/125\">PR #125</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-15-mcp-config-5-4-0.md"
+    },
+    {
+      "id": "2026-07-14-mcp-config-5-3-0",
+      "slug": "mcp-config-5-3-0",
+      "title": "mcp-config v5.3.0",
+      "date": "2026-07-14",
+      "categories": [
+        "MCP"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Mcp-config v5.3.0: <code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</p>\n",
+      "fullContent": "<p>Mcp-config v5.3.0: <code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</p>\n<h2>Changes</h2>\n<ul>\n<li><code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/mcp-config/releases/tag/v5.3.0\">Release notes</a></li>\n<li><a href=\"https://github.com/gleanwork/mcp-config/pull/124\">PR #124</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-14-mcp-config-5-3-0.md"
+    },
+    {
+      "id": "2026-07-10-api-client-typescript-0-17-3",
+      "slug": "api-client-typescript-0-17-3",
+      "title": "api-client-typescript v0.17.3",
+      "date": "2026-07-10",
+      "categories": [
+        "API Clients"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Api-client-typescript v0.17.3 includes 4 changes.</p>\n",
+      "fullContent": "<p>Api-client-typescript v0.17.3 includes 4 changes.</p>\n<h2>Changes</h2>\n<ul>\n<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.chatResult.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>\n<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.createstream()</code>.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.3\">Release notes</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-10-api-client-typescript-0-17-3.md"
+    },
+    {
+      "id": "2026-07-10-api-client-python-0-15-3",
+      "slug": "api-client-python-0-15-3",
+      "title": "api-client-python v0.15.3",
+      "date": "2026-07-10",
+      "categories": [
+        "API Clients"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Api-client-python v0.15.3 includes 4 changes.</p>\n",
+      "fullContent": "<p>Api-client-python v0.15.3 includes 4 changes.</p>\n<h2>Changes</h2>\n<ul>\n<li>Changed <code>request.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.chat_result.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>\n<li>Changed <code>request.messages[].fragments[]</code> on <code>client.chat.create_stream()</code>.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/api-client-python/releases/tag/v0.15.3\">Release notes</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-10-api-client-python-0-15-3.md"
+    },
+    {
+      "id": "2026-07-10-api-client-java-0-14-3",
+      "slug": "api-client-java-0-14-3",
+      "title": "api-client-java v0.14.3",
+      "date": "2026-07-10",
+      "categories": [
+        "API Clients"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Api-client-java v0.14.3 includes 4 changes.</p>\n",
+      "fullContent": "<p>Api-client-java v0.14.3 includes 4 changes.</p>\n<h2>Changes</h2>\n<ul>\n<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.chatResult.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>\n<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.createstream()</code>.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/api-client-java/releases/tag/v0.14.3\">Release notes</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-10-api-client-java-0-14-3.md"
+    },
+    {
+      "id": "2026-07-10-api-client-go-0-13-3",
+      "slug": "api-client-go-0-13-3",
+      "title": "api-client-go v0.13.3",
+      "date": "2026-07-10",
+      "categories": [
+        "API Clients"
+      ],
+      "impact": "routine",
+      "attention": [],
+      "summary": "<p>Api-client-go v0.13.3 includes 4 changes.</p>\n",
+      "fullContent": "<p>Api-client-go v0.13.3 includes 4 changes.</p>\n<h2>Changes</h2>\n<ul>\n<li>Changed <code>request.ChatRequest.Messages[].Fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.Messages[].Fragments[]</code> on <code>client.chat.create()</code>.</li>\n<li>Changed <code>response.ChatResult.Chat.Messages[].Fragments[]</code> on <code>client.chat.retrieve()</code>.</li>\n<li>Changed <code>request.ChatRequest.Messages[].Fragments[]</code> on <code>client.chat.createstream()</code>.</li>\n</ul>\n<h2>Source</h2>\n<ul>\n<li><a href=\"https://github.com/gleanwork/api-client-go/releases/tag/v0.13.3\">Release notes</a></li>\n</ul>\n",
+      "hasTruncation": true,
+      "fileName": "2026-07-10-api-client-go-0-13-3.md"
+    },
+    {
       "id": "2026-07-08-api-client-typescript-0-17-2",
       "slug": "api-client-typescript-0-17-2",
       "title": "api-client-typescript v0.17.2",
@@ -5459,6 +5623,6 @@
     "Website",
     "langchain-glean"
   ],
-  "generatedAt": "2026-07-08T00:00:00.000Z",
-  "totalEntries": 317
+  "generatedAt": "2026-07-20T00:00:00.000Z",
+  "totalEntries": 327
 }

--- a/static/changelog.xml
+++ b/static/changelog.xml
@@ -4,7 +4,7 @@
         <title>Glean Developer Changelog</title>
         <link>https://developers.glean.com</link>
         <description>Updates and changes to the Glean Developer Platform</description>
-        <lastBuildDate>Wed, 08 Jul 2026 00:00:00 GMT</lastBuildDate>
+        <lastBuildDate>Mon, 20 Jul 2026 00:00:00 GMT</lastBuildDate>
         <docs>https://validator.w3.org/feed/docs/rss2.html</docs>
         <generator>Glean Developer Site</generator>
         <language>en</language>
@@ -14,6 +14,297 @@
             <link>https://developers.glean.com</link>
         </image>
         <copyright>Copyright © 2026 Glean</copyright>
+        <item>
+            <title><![CDATA[glean-agent-toolkit 0.7.0]]></title>
+            <link>https://developers.glean.com/changelog#glean-agent-toolkit-0-7-0</link>
+            <guid isPermaLink="false">2026-07-20-glean-agent-toolkit-0-7-0</guid>
+            <pubDate>Mon, 20 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Glean-agent-toolkit 0.7.0: <strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Glean-agent-toolkit 0.7.0: <strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</p>
+<h2>Changes</h2>
+<ul>
+<li><strong>tools</strong>: add transport seam, typed search backend, result truncation, status-code errors.</li>
+<li><strong>chat</strong>: read citations from fragments with legacy fallback.</li>
+<li><strong>core</strong>: ctx-aware as_*_tool, registry collision warnings, retry unit fix.</li>
+<li><strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.7.0">Release notes</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/87">PR #87</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/83">PR #83</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/84">PR #84</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/81">PR #81</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>Glean Agent Toolkit</category>
+        </item>
+        <item>
+            <title><![CDATA[glean-agent-toolkit 0.6.1]]></title>
+            <link>https://developers.glean.com/changelog#glean-agent-toolkit-0-6-1</link>
+            <guid isPermaLink="false">2026-07-19-glean-agent-toolkit-0-6-1</guid>
+            <pubDate>Sun, 19 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Glean-agent-toolkit 0.6.1: <strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Glean-agent-toolkit 0.6.1: <strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</p>
+<h2>Changes</h2>
+<ul>
+<li><strong>read_document</strong>: support renamed retrieve kwarg across glean-api-client versions.</li>
+<li><strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</li>
+<li><strong>adk</strong>: expose real typed signatures so declarations and invocation work.</li>
+<li><strong>openai</strong>: sanitize strict schemas and isolate per-tool conversion failures.</li>
+<li><strong>adapters</strong>: map anyOf/union and array item types correctly in get_field_type.</li>
+<li><strong>langchain</strong>: use StructuredTool so converted tools are invocable.</li>
+<li><strong>tools</strong>: stop closing shared Glean client on every tool call.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.1">Release notes</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/81">PR #81</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/73">PR #73</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/77">PR #77</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/76">PR #76</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/75">PR #75</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/74">PR #74</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/72">PR #72</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>Glean Agent Toolkit</category>
+        </item>
+        <item>
+            <title><![CDATA[glean-agent-toolkit 0.6.0]]></title>
+            <link>https://developers.glean.com/changelog#glean-agent-toolkit-0-6-0</link>
+            <guid isPermaLink="false">2026-07-19-glean-agent-toolkit-0-6-0</guid>
+            <pubDate>Sun, 19 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Glean-agent-toolkit 0.6.0: <strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Glean-agent-toolkit 0.6.0: <strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</p>
+<h2>Action Required</h2>
+<ul>
+<li>Plan migration away from deprecated behavior.</li>
+</ul>
+<h2>Changes</h2>
+<ul>
+<li>Add installable skills for SDK usage and tool building.</li>
+<li>Search API alignment, chat tool, deprecation path, get_tools, async support, import docs.</li>
+<li>Injectable GleanContext replaces hidden api_client() global (#62).</li>
+<li><strong>deps</strong>: add [all] extra combining all framework adapters (CHK-001).</li>
+<li><strong>crewai</strong>: pass args_schema to BaseTool so the LLM sees real parameters.</li>
+<li><strong>adk</strong>: expose real typed signatures so declarations and invocation work.</li>
+<li><strong>openai</strong>: sanitize strict schemas and isolate per-tool conversion failures.</li>
+<li><strong>adapters</strong>: map anyOf/union and array item types correctly in get_field_type.</li>
+<li><strong>langchain</strong>: use StructuredTool so converted tools are invocable.</li>
+<li><strong>tools</strong>: stop closing shared Glean client on every tool call.</li>
+<li>Correct web search tool name from &#39;Web Browser&#39; to &#39;Gemini Web Search&#39;.</li>
+<li>Resolve remaining P2 eval items (CHK-111, CHK-115, CHK-118, CHK-119).</li>
+<li>Resolve eval checklist items — dedup, dead code, error handling, imports.</li>
+<li>Namespace tool names and optimize descriptions for LLM consumption.</li>
+<li>Structured error results and consistent adapter return types.</li>
+<li>Depend on langchain-core instead of langchain to support LangGraph 1.x.</li>
+<li>Regenerate lockfile.</li>
+<li>Align publish workflow tag trigger with commitizen tag format.</li>
+<li>Use is not None checks in read_document validation.</li>
+<li>Export Registry from top-level package.</li>
+<li>Remove pydantic BaseModel from adapters public API.</li>
+<li>Preserve float values in retry backoff config (CHK-002).</li>
+<li><strong>release</strong>: correct broken version_files path in .cz.toml (CHK-006).</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/releases/tag/0.6.0">Release notes</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/73">PR #73</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/77">PR #77</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/76">PR #76</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/75">PR #75</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/74">PR #74</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/72">PR #72</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/70">PR #70</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/66">PR #66</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/65">PR #65</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/27">PR #27</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/71">PR #71</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/68">PR #68</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/67">PR #67</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/58">PR #58</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/55">PR #55</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/54">PR #54</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/39">PR #39</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/37">PR #37</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/36">PR #36</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/35">PR #35</a></li>
+<li><a href="https://github.com/gleanwork/glean-agent-toolkit/pull/31">PR #31</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>Glean Agent Toolkit</category>
+        </item>
+        <item>
+            <title><![CDATA[REST API: changes (endpoints) 2026-07-15]]></title>
+            <link>https://developers.glean.com/changelog#rest-api-changes-open-api</link>
+            <guid isPermaLink="false">2026-07-15-rest-api-changes-open-api</guid>
+            <pubDate>Wed, 15 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>2 endpoints added.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>2 endpoints added.</p>
+<h2>Changes</h2>
+<ul>
+<li>Added endpoint: /rest/api/index/submissions/{datasourceInstance}/{type}</li>
+<li>Added endpoint: /submissions/{datasourceInstance}/{type}</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/open-api/commit/0014369d53ab6aeab9d28a4d3a24dea2361c43cd">open-api 0014369</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/0dce2185d014565fa994ea8b485b2c354632bc35">open-api 0dce218</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/0dfbcffd5e93be2858b792645a4ad878be2c6c80">open-api 0dfbcff</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/2d5869e5349aa2221f85aa1b4e8138acc76e02f2">open-api 2d5869e</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/2da199e3d09b50fb6e535ce8d682e8faea0d5c4f">open-api 2da199e</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/2e069735ae7931e10a7fc35947465d1995fcdb48">open-api 2e06973</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/32e7a5113a574eea522faa51c2d948e14af0c650">open-api 32e7a51</a></li>
+<li><a href="https://github.com/gleanwork/open-api/commit/438762b2397cac4b50c63dba42784619bca9279c">open-api 438762b</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>API</category>
+        </item>
+        <item>
+            <title><![CDATA[mcp-config v5.4.0]]></title>
+            <link>https://developers.glean.com/changelog#mcp-config-5-4-0</link>
+            <guid isPermaLink="false">2026-07-15-mcp-config-5-4-0</guid>
+            <pubDate>Wed, 15 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Mcp-config v5.4.0: <code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Mcp-config v5.4.0: <code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</p>
+<h2>Changes</h2>
+<ul>
+<li><code>mcp-config-glean</code>, <code>mcp-config-schema</code>: add managed setup URLs.</li>
+<li><code>mcp-config-schema</code>: add Cursor Team MCP Servers client.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/mcp-config/releases/tag/v5.4.0">Release notes</a></li>
+<li><a href="https://github.com/gleanwork/mcp-config/pull/126">PR #126</a></li>
+<li><a href="https://github.com/gleanwork/mcp-config/pull/125">PR #125</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>MCP</category>
+        </item>
+        <item>
+            <title><![CDATA[mcp-config v5.3.0]]></title>
+            <link>https://developers.glean.com/changelog#mcp-config-5-3-0</link>
+            <guid isPermaLink="false">2026-07-14-mcp-config-5-3-0</guid>
+            <pubDate>Tue, 14 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Mcp-config v5.3.0: <code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Mcp-config v5.3.0: <code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</p>
+<h2>Changes</h2>
+<ul>
+<li><code>mcp-config-schema</code>: add Copilot Studio, Gemini Enterprise, and LibreChat clients.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/mcp-config/releases/tag/v5.3.0">Release notes</a></li>
+<li><a href="https://github.com/gleanwork/mcp-config/pull/124">PR #124</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>MCP</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-typescript v0.17.3]]></title>
+            <link>https://developers.glean.com/changelog#api-client-typescript-0-17-3</link>
+            <guid isPermaLink="false">2026-07-10-api-client-typescript-0-17-3</guid>
+            <pubDate>Fri, 10 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Api-client-typescript v0.17.3 includes 4 changes.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Api-client-typescript v0.17.3 includes 4 changes.</p>
+<h2>Changes</h2>
+<ul>
+<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.chatResult.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>
+<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.createstream()</code>.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/api-client-typescript/releases/tag/v0.17.3">Release notes</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-python v0.15.3]]></title>
+            <link>https://developers.glean.com/changelog#api-client-python-0-15-3</link>
+            <guid isPermaLink="false">2026-07-10-api-client-python-0-15-3</guid>
+            <pubDate>Fri, 10 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Api-client-python v0.15.3 includes 4 changes.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Api-client-python v0.15.3 includes 4 changes.</p>
+<h2>Changes</h2>
+<ul>
+<li>Changed <code>request.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.chat_result.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>
+<li>Changed <code>request.messages[].fragments[]</code> on <code>client.chat.create_stream()</code>.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/api-client-python/releases/tag/v0.15.3">Release notes</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-java v0.14.3]]></title>
+            <link>https://developers.glean.com/changelog#api-client-java-0-14-3</link>
+            <guid isPermaLink="false">2026-07-10-api-client-java-0-14-3</guid>
+            <pubDate>Fri, 10 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Api-client-java v0.14.3 includes 4 changes.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Api-client-java v0.14.3 includes 4 changes.</p>
+<h2>Changes</h2>
+<ul>
+<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.messages[].fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.chatResult.chat.messages[].fragments[]</code> on <code>client.chat.retrieve()</code>.</li>
+<li>Changed <code>request.chatRequest.messages[].fragments[]</code> on <code>client.chat.createstream()</code>.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/api-client-java/releases/tag/v0.14.3">Release notes</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>API Clients</category>
+        </item>
+        <item>
+            <title><![CDATA[api-client-go v0.13.3]]></title>
+            <link>https://developers.glean.com/changelog#api-client-go-0-13-3</link>
+            <guid isPermaLink="false">2026-07-10-api-client-go-0-13-3</guid>
+            <pubDate>Fri, 10 Jul 2026 00:00:00 GMT</pubDate>
+            <description><![CDATA[<p>Api-client-go v0.13.3 includes 4 changes.</p>
+]]></description>
+            <content:encoded><![CDATA[<p>Api-client-go v0.13.3 includes 4 changes.</p>
+<h2>Changes</h2>
+<ul>
+<li>Changed <code>request.ChatRequest.Messages[].Fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.Messages[].Fragments[]</code> on <code>client.chat.create()</code>.</li>
+<li>Changed <code>response.ChatResult.Chat.Messages[].Fragments[]</code> on <code>client.chat.retrieve()</code>.</li>
+<li>Changed <code>request.ChatRequest.Messages[].Fragments[]</code> on <code>client.chat.createstream()</code>.</li>
+</ul>
+<h2>Source</h2>
+<ul>
+<li><a href="https://github.com/gleanwork/api-client-go/releases/tag/v0.13.3">Release notes</a></li>
+</ul>
+]]></content:encoded>
+            <author>Glean</author>
+            <category>API Clients</category>
+        </item>
         <item>
             <title><![CDATA[api-client-typescript v0.17.2]]></title>
             <link>https://developers.glean.com/changelog#api-client-typescript-0-17-2</link>


### PR DESCRIPTION
## What

Refreshes the plugin install pages to match the homepage-redesign design language, and gives Codex a real docs page instead of a GitHub deep link.

### PluginPage v2 template
- Token-gradient banner with hairline border, "Official Glean plugin" eyebrow pill, and a Glean × client brand lockup using `getClientIcon` from `@gleanwork/mcp-config-schema` (replaces static PNGs + accent-gradient hero)
- Numbered step rail matching the cookbook recipe pages
- Command steps render as dark terminal panels (mac dots) with a new copy-to-clipboard button; CTA steps are primary pills
- Doc-template h1 hidden on plugin pages — the banner carries the title
- `TerminalPanel` gains an opt-in `copy` prop (homepage panels unchanged)

### Pages
- `claude-code.mdx` / `cursor.mdx` migrated to the new `clientId`/`mono` props
- **New `codex.mdx`** — every command verified against the [gleanwork/codex-plugins README](https://github.com/gleanwork/codex-plugins): marketplace add, `codex plugin add glean@glean-codex-plugins` + `glean-dev-docs@glean-codex-plugins`, `codex mcp add`/`login` wiring, plus a "Which plugin do I need?" table
- Sidebar: "Codex Plugins" entry after Cursor
- Homepage (flag-gated): Codex card now links to `/guides/mcp/codex`

## Verification
- `pnpm build`, `pnpm test` (143 passing), prettier — all green
- CDP screenshots of all three pages, light + dark, captured post-`fonts.ready` and visually reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)