### PR TITLE
[NI][Platform API] Fix Skills multipart cURL samples

### DIFF
--- a/scripts/openapi-capitalize-language.mjs
+++ b/scripts/openapi-capitalize-language.mjs
@@ -50,6 +50,11 @@ const HTTP_METHODS = [
 ];
 
 const EXPERIMENTAL_HEADER_NAME = 'X-Glean-Include-Experimental';
+const SKILLS_MULTIPART_OPERATION_IDS = new Set([
+  'platform-skills-create',
+  'platform-skills-validate',
+  'platform-skills-create-version',
+]);
 
 /**
  * Inject the `X-Glean-Include-Experimental` header parameter into every
@@ -108,6 +113,82 @@ export function injectExperimentalHeaders(apiSpec) {
       });
       console.log(
         `   💉 Injected ${EXPERIMENTAL_HEADER_NAME} header on ${method.toUpperCase()} ${pathKey}`,
+      );
+    }
+  }
+}
+
+function resolveServerUrl(apiSpec) {
+  const server = apiSpec?.servers?.[0];
+  if (!server?.url) return 'https://instance-name-be.glean.com';
+
+  return server.url.replace(/\{([^}]+)\}/g, (_, variableName) => {
+    return server.variables?.[variableName]?.default ?? variableName;
+  });
+}
+
+function responseContentType(operation) {
+  for (const [status, response] of Object.entries(operation.responses ?? {})) {
+    if (/^2\d\d$/.test(status)) {
+      const contentTypes = Object.keys(response?.content ?? {});
+      if (contentTypes.length > 0) return contentTypes[0];
+    }
+  }
+  return 'application/json';
+}
+
+/**
+ * Add copy-pasteable cURL samples for the Skills multipart upload operations.
+ * The theme's generic snippet generator cannot seed a browser file input, so
+ * its default cURL omits the required form part and sets an unusable multipart
+ * Content-Type without a boundary. An explicit sample lets cURL construct the
+ * multipart body and boundary from the selected file.
+ */
+export function injectSkillsMultipartCurlSamples(apiSpec) {
+  const paths = apiSpec?.paths;
+  if (!paths || typeof paths !== 'object') return;
+
+  const serverUrl = resolveServerUrl(apiSpec);
+
+  for (const [pathKey, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== 'object') continue;
+
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method];
+      if (
+        !operation ||
+        typeof operation !== 'object' ||
+        !SKILLS_MULTIPART_OPERATION_IDS.has(operation.operationId) ||
+        !operation.requestBody?.content?.['multipart/form-data']
+      ) {
+        continue;
+      }
+
+      operation['x-codeSamples'] ??= [];
+      const alreadyDeclared = operation['x-codeSamples'].some(
+        (sample) => sample?.lang?.toLowerCase() === 'curl',
+      );
+      if (alreadyDeclared) continue;
+
+      const requestPath = pathKey.replace(
+        /\{([^}]+)\}/g,
+        (_, parameterName) => `<${parameterName}>`,
+      );
+      const lines = [
+        `curl -L -X ${method.toUpperCase()} '${serverUrl}${requestPath}' \\`,
+        `  -H 'Accept: ${responseContentType(operation)}' \\`,
+        `  -H '${EXPERIMENTAL_HEADER_NAME}: true' \\`,
+        `  -H 'Authorization: Bearer <token>' \\`,
+        `  -F 'file=@./SKILL.md'`,
+      ];
+
+      operation['x-codeSamples'].push({
+        lang: 'curl',
+        label: 'cURL (multipart upload)',
+        source: lines.join('\n'),
+      });
+      console.log(
+        `   Injected multipart cURL sample on ${method.toUpperCase()} ${pathKey}`,
       );
     }
   }
@@ -177,6 +258,9 @@ export async function capitalizeCodeSamples(inputFile, outputFile) {
   try {
     const fileContent = await readContent(inputFile);
     const apiSpec = yaml.load(fileContent);
+
+    console.log('📦 Injecting Skills multipart cURL samples...');
+    injectSkillsMultipartCurlSamples(apiSpec);
 
     console.log('🔤 Processing x-codeSamples...');
     processCodeSamples(apiSpec);

--- a/scripts/openapi-capitalize-language.test.ts
+++ b/scripts/openapi-capitalize-language.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import yaml from 'js-yaml';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - plain .mjs module without type declarations
-import { injectExperimentalHeaders } from './openapi-capitalize-language.mjs';
+import {
+  injectExperimentalHeaders,
+  injectSkillsMultipartCurlSamples,
+} from './openapi-capitalize-language.mjs';
 
 const HEADER_NAME = 'X-Glean-Include-Experimental';
 
@@ -122,5 +125,104 @@ paths:
   it('handles specs without paths', () => {
     expect(() => injectExperimentalHeaders({})).not.toThrow();
     expect(() => injectExperimentalHeaders(undefined)).not.toThrow();
+  });
+});
+
+describe('injectSkillsMultipartCurlSamples', () => {
+  it('adds a runnable file upload sample for each Skills multipart operation', () => {
+    const spec = loadSpec(`
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+servers:
+  - url: https://{instance}-be.glean.com
+    variables:
+      instance:
+        default: instance-name
+paths:
+  /api/skills:
+    post:
+      operationId: platform-skills-create
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+      responses:
+        200:
+          content:
+            application/json: {}
+  /api/skills/{skill_id}/versions:
+    post:
+      operationId: platform-skills-create-version
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+      responses:
+        200:
+          content:
+            application/json: {}
+`);
+
+    injectSkillsMultipartCurlSamples(spec);
+
+    const createSample = spec.paths['/api/skills'].post['x-codeSamples'][0];
+    expect(createSample).toEqual({
+      lang: 'curl',
+      label: 'cURL (multipart upload)',
+      source: [
+        "curl -L -X POST 'https://instance-name-be.glean.com/api/skills' \\",
+        "  -H 'Accept: application/json' \\",
+        "  -H 'X-Glean-Include-Experimental: true' \\",
+        "  -H 'Authorization: Bearer <token>' \\",
+        "  -F 'file=@./SKILL.md'",
+      ].join('\n'),
+    });
+    expect(createSample.source).not.toContain('Content-Type');
+
+    const versionSample =
+      spec.paths['/api/skills/{skill_id}/versions'].post['x-codeSamples'][0];
+    expect(versionSample.source).toContain('/api/skills/<skill_id>/versions');
+  });
+
+  it('is idempotent and leaves unrelated multipart operations untouched', () => {
+    const spec = loadSpec(`
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /api/skills:
+    post:
+      operationId: platform-skills-create
+      requestBody:
+        content:
+          multipart/form-data: {}
+      x-codeSamples:
+        - lang: cURL
+          source: existing sample
+  /rest/api/v1/upload:
+    post:
+      operationId: unrelated-upload
+      requestBody:
+        content:
+          multipart/form-data: {}
+`);
+
+    injectSkillsMultipartCurlSamples(spec);
+    injectSkillsMultipartCurlSamples(spec);
+
+    expect(spec.paths['/api/skills'].post['x-codeSamples']).toHaveLength(1);
+    expect(spec.paths['/rest/api/v1/upload'].post['x-codeSamples']).toBe(
+      undefined,
+    );
+  });
+
+  it('handles specs without paths', () => {
+    expect(() => injectSkillsMultipartCurlSamples({})).not.toThrow();
+    expect(() => injectSkillsMultipartCurlSamples(undefined)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

- Add explicit cURL samples for Create skill, Validate skill bundle, and Create skill version.
- Include the required `file` form part and let cURL generate the multipart boundary.
- Keep the transform idempotent and scoped to the three Skills upload operations.

## Context

The generic API explorer cURL generator cannot seed a browser file input, so the published examples omit the upload body and manually set an unusable multipart Content-Type.

- Live reference: https://developers.glean.com/api/platform-api/platform-skills-create
- Skills publication source: https://github.com/askscio/scio/pull/263049

## Test plan

- `pnpm test` (146 passed, 2 skipped)
- `pnpm build`
- Ran the transform against the published Platform OpenAPI spec and verified exactly three cURL samples were added with the expected URLs, headers, and `-F file=@./SKILL.md`.
- Rendered the generated Create skill page locally and verified the multipart cURL sample is selected and displayed.