### PR TITLE
Web SDK live demos: zero-config via app.glean.com

### DIFF
--- a/src/components/WebSdk/ComponentDemo.tsx
+++ b/src/components/WebSdk/ComponentDemo.tsx
@@ -2,69 +2,59 @@ import React, { useState } from 'react';
 import Link from '@docusaurus/Link';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import LiveWidget, { type LiveKind } from './live/LiveWidget';
-import { connect, disconnect, useLiveDemoState } from './live/store';
+import {
+  DEFAULT_WEB_APP_URL,
+  setOverrides,
+  useLiveDemoConfig,
+} from './live/store';
 import styles from './live/live.module.css';
 
 const GLEAN_URL = /^https:\/\/[^\s/]+\.glean\.com\/?$/i;
 
-function ConnectCard(): React.ReactElement {
-  const [webAppUrl, setWebAppUrl] = useState('');
-  const [backend, setBackend] = useState('');
+/** Overrides for custom-subdomain / non-Glean-hosted / staging tenants. */
+function ConfigureForm({
+  onClose,
+}: {
+  onClose: () => void;
+}): React.ReactElement {
+  const config = useLiveDemoConfig();
+  const [webAppUrl, setWebAppUrl] = useState(config.webAppUrl);
+  const [backend, setBackend] = useState(config.backend);
   const [error, setError] = useState('');
 
-  const submit = () => {
-    let app = webAppUrl.trim();
+  const save = () => {
+    const app = webAppUrl.trim();
     const be = backend.trim();
     if ((app && !GLEAN_URL.test(app)) || (be && !GLEAN_URL.test(be))) {
       setError(
-        "That doesn't look like a Glean URL — expected something like https://app.glean.com or https://acme-be.glean.com/.",
+        "That doesn't look like a Glean URL — expected something like https://acme.glean.com or https://acme-be.glean.com/.",
       );
       return;
     }
-    if (!app && be) {
-      // Derive the web app URL from a conventional {x}-be.glean.com backend.
-      const derived = be.replace(/-be\.glean\.com\/?$/i, '.glean.com');
-      if (derived === be) {
-        setError(
-          'Enter your web app URL too — it cannot be derived from this backend URL.',
-        );
-        return;
-      }
-      app = derived;
-    }
-    if (!app) {
-      setError(
-        'Enter at least your web app URL — the address where you normally access Glean.',
-      );
-      return;
-    }
-    connect(be, app);
+    setOverrides({ webAppUrl: app, backend: be });
+    onClose();
   };
-
-  const clearError = () => setError('');
 
   return (
     <div className={styles.connectCard}>
-      <p className={styles.connectTitle}>Connect your Glean instance</p>
       <p className={styles.connectBody}>
-        Live demos render the real components against your own Glean instance —
-        you sign in with your normal SSO inside the widget, and every result
-        respects your permissions. Data flows only between your browser and your
-        Glean tenant; nothing touches this site&apos;s servers.
+        The demos default to <code>app.glean.com</code>, which locates your
+        tenant automatically. Override only if your team accesses Glean at a
+        custom domain, or to pin a specific backend (e.g. staging). Both values
+        are shown at{' '}
+        <Link to="https://app.glean.com/admin/about-glean">
+          app.glean.com/admin/about-glean
+        </Link>
+        .
       </p>
       <div className={styles.connectRow}>
         <input
           className={styles.connectInput}
           onChange={(e) => {
             setWebAppUrl(e.target.value);
-            clearError();
+            setError('');
           }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              submit();
-            }
-          }}
-          placeholder="Web app URL — https://app.glean.com"
+          placeholder={`Web app URL — ${DEFAULT_WEB_APP_URL}`}
           value={webAppUrl}
         />
       </div>
@@ -73,67 +63,65 @@ function ConnectCard(): React.ReactElement {
           className={styles.connectInput}
           onChange={(e) => {
             setBackend(e.target.value);
-            clearError();
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              submit();
-            }
+            setError('');
           }}
           placeholder="Backend URL (optional) — https://{company}-be.glean.com/"
           value={backend}
         />
-        <button className={styles.connectBtn} onClick={submit} type="button">
-          Connect
+        <button className={styles.connectBtn} onClick={save} type="button">
+          Save
         </button>
       </div>
       {error ? <p className={styles.liveError}>{error}</p> : null}
-      <p className={styles.connectHint}>
-        The web app URL is where you normally access Glean (often{' '}
-        <code>app.glean.com</code>). Both values are shown at{' '}
-        <Link to="https://app.glean.com/admin/about-glean">
-          app.glean.com/admin/about-glean
-        </Link>
-        ; leave the backend blank and the widget will ask for your work email to
-        locate it. Already signed in to Glean in this browser? The widgets reuse
-        that session automatically.
-      </p>
     </div>
   );
 }
 
 function LivePane({ kind }: { kind: LiveKind }): React.ReactElement {
-  const state = useLiveDemoState();
-
-  if (!state.connected) {
-    return <ConnectCard />;
-  }
+  const config = useLiveDemoConfig();
+  const [configuring, setConfiguring] = useState(false);
+  const webAppUrl = config.webAppUrl || DEFAULT_WEB_APP_URL;
+  const overridden = Boolean(config.webAppUrl || config.backend);
 
   return (
     <>
-      <LiveWidget
-        backend={state.backend}
-        kind={kind}
-        webAppUrl={state.webAppUrl}
-      />
+      <LiveWidget backend={config.backend} kind={kind} webAppUrl={webAppUrl} />
       <p className={styles.liveCaption}>
         <span className={styles.liveCaptionBadge}>Live</span>
         <span>
-          Rendering against your Glean instance with your permissions. Having
-          trouble signing in? See{' '}
+          The real component, rendering against your Glean instance with your
+          permissions — sign in inside the widget if prompted (an existing Glean
+          session is reused automatically). Data flows only between your browser
+          and your tenant.{' '}
+          <button
+            className={styles.configureLink}
+            onClick={() => setConfiguring((c) => !c)}
+            type="button"
+          >
+            {configuring
+              ? 'Hide configuration'
+              : overridden
+                ? `Configured: ${new URL(webAppUrl).host} — change`
+                : 'Custom domain or backend?'}
+          </button>{' '}
+          Trouble signing in? See{' '}
           <Link to="/libraries/web-sdk/3rd-party-cookies">
             Third-Party Cookie Management
           </Link>
           .
         </span>
       </p>
+      {configuring ? (
+        <ConfigureForm onClose={() => setConfiguring(false)} />
+      ) : null}
     </>
   );
 }
 
 /** Tabbed demo block for the component pages: the illustrative mock by
  * default, with an opt-in live tab that renders the real component against
- * the reader's own Glean instance. */
+ * the reader's own Glean instance — zero-config via app.glean.com, with
+ * overrides for custom-domain and non-Glean-hosted deployments. */
 export default function ComponentDemo({
   kind,
   children,
@@ -142,7 +130,6 @@ export default function ComponentDemo({
   children: React.ReactNode;
 }): React.ReactElement {
   const [tab, setTab] = useState<'preview' | 'live'>('preview');
-  const state = useLiveDemoState();
 
   return (
     <div className={styles.demo}>
@@ -161,15 +148,6 @@ export default function ComponentDemo({
         >
           Live — your instance
         </button>
-        {tab === 'live' && state.connected ? (
-          <button
-            className={styles.disconnect}
-            onClick={disconnect}
-            type="button"
-          >
-            Disconnect
-          </button>
-        ) : null}
       </div>
       {tab === 'preview' ? (
         children

--- a/src/components/WebSdk/ComponentDemo.tsx
+++ b/src/components/WebSdk/ComponentDemo.tsx
@@ -1,10 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Link from '@docusaurus/Link';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import LiveWidget, { type LiveKind } from './live/LiveWidget';
+import { LiveTabContext } from './live/LiveTabContext';
 import {
   DEFAULT_WEB_APP_URL,
+  getPreferredTab,
   setOverrides,
+  setPreferredTab,
   useLiveDemoConfig,
 } from './live/store';
 import styles from './live/live.module.css';
@@ -131,26 +134,39 @@ export default function ComponentDemo({
 }): React.ReactElement {
   const [tab, setTab] = useState<'preview' | 'live'>('preview');
 
+  // Readers who have used Live before land on Live everywhere; applied
+  // after mount so SSR and first client render agree.
+  useEffect(() => {
+    setTab(getPreferredTab());
+  }, []);
+
+  const choose = (next: 'preview' | 'live') => {
+    setTab(next);
+    setPreferredTab(next);
+  };
+
   return (
     <div className={styles.demo}>
       <div className={styles.tabRow}>
         <button
           className={`${styles.tab} ${tab === 'preview' ? styles.tabActive : ''}`}
-          onClick={() => setTab('preview')}
+          onClick={() => choose('preview')}
           type="button"
         >
           Preview
         </button>
         <button
           className={`${styles.tab} ${tab === 'live' ? styles.tabActive : ''}`}
-          onClick={() => setTab('live')}
+          onClick={() => choose('live')}
           type="button"
         >
           Live — your instance
         </button>
       </div>
       {tab === 'preview' ? (
-        children
+        <LiveTabContext.Provider value={() => choose('live')}>
+          {children}
+        </LiveTabContext.Provider>
       ) : (
         <BrowserOnly fallback={<div />}>
           {() => <LivePane kind={kind} />}

--- a/src/components/WebSdk/WebSdk.test.tsx
+++ b/src/components/WebSdk/WebSdk.test.tsx
@@ -164,7 +164,7 @@ describe('ComponentDemo', () => {
     expect(sdkMocks.renderChat).not.toHaveBeenCalled();
   });
 
-  it('shows the connect card on the Live tab when disconnected', async () => {
+  it('renders the live widget zero-config via app.glean.com', async () => {
     mockMatchMedia(true);
     render(
       <ComponentDemo kind="chat">
@@ -172,11 +172,19 @@ describe('ComponentDemo', () => {
       </ComponentDemo>,
     );
     await userEvent.click(screen.getByText('Live — your instance'));
-    expect(screen.getByText('Connect your Glean instance')).toBeInTheDocument();
-    expect(sdkMocks.renderChat).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(sdkMocks.renderChat).toHaveBeenCalledWith(
+        expect.any(HTMLElement),
+        expect.objectContaining({ webAppUrl: 'https://app.glean.com' }),
+      );
+    });
+    expect(sdkMocks.renderChat).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.not.objectContaining({ backend: expect.anything() }),
+    );
   });
 
-  it('rejects a non-Glean backend URL', async () => {
+  it('rejects a non-Glean override URL', async () => {
     mockMatchMedia(true);
     render(
       <ComponentDemo kind="chat">
@@ -184,43 +192,16 @@ describe('ComponentDemo', () => {
       </ComponentDemo>,
     );
     await userEvent.click(screen.getByText('Live — your instance'));
+    await userEvent.click(screen.getByText('Custom domain or backend?'));
     await userEvent.type(
       screen.getByPlaceholderText(/Backend URL/),
       'https://evil.example.com/',
     );
-    await userEvent.click(screen.getByText('Connect'));
+    await userEvent.click(screen.getByText('Save'));
     expect(screen.getByText(/doesn't look like a Glean URL/)).toBeVisible();
-    expect(sdkMocks.renderChat).not.toHaveBeenCalled();
   });
 
-  it('derives the web app URL from a conventional backend URL', async () => {
-    mockMatchMedia(true);
-    render(
-      <ComponentDemo kind="chat">
-        <ChatPreview />
-      </ComponentDemo>,
-    );
-    await userEvent.click(screen.getByText('Live — your instance'));
-    await userEvent.type(
-      screen.getByPlaceholderText(/Backend URL/),
-      'https://acme-be.glean.com/',
-    );
-    await userEvent.click(screen.getByText('Connect'));
-    await vi.waitFor(() => {
-      expect(sdkMocks.renderChat).toHaveBeenCalledWith(
-        expect.any(HTMLElement),
-        expect.objectContaining({
-          backend: 'https://acme-be.glean.com/',
-          webAppUrl: 'https://acme.glean.com',
-        }),
-      );
-    });
-    expect(screen.getByText('Disconnect')).toBeInTheDocument();
-    await userEvent.click(screen.getByText('Disconnect'));
-    expect(screen.getByText('Connect your Glean instance')).toBeInTheDocument();
-  });
-
-  it('connects with only a web app URL for email discovery', async () => {
+  it('applies saved overrides to the live widget', async () => {
     mockMatchMedia(true);
     render(
       <ComponentDemo kind="settings">
@@ -228,34 +209,26 @@ describe('ComponentDemo', () => {
       </ComponentDemo>,
     );
     await userEvent.click(screen.getByText('Live — your instance'));
+    await userEvent.click(screen.getByText('Custom domain or backend?'));
     await userEvent.type(
       screen.getByPlaceholderText(/Web app URL/),
-      'https://app.glean.com',
+      'https://acme.glean.com',
     );
-    await userEvent.click(screen.getByText('Connect'));
+    await userEvent.type(
+      screen.getByPlaceholderText(/Backend URL/),
+      'https://acme-be.glean.com/',
+    );
+    await userEvent.click(screen.getByText('Save'));
     await vi.waitFor(() => {
       expect(sdkMocks.renderSettings).toHaveBeenCalledWith(
         expect.any(HTMLElement),
-        expect.objectContaining({ webAppUrl: 'https://app.glean.com' }),
+        expect.objectContaining({
+          webAppUrl: 'https://acme.glean.com',
+          backend: 'https://acme-be.glean.com/',
+        }),
       );
     });
-    expect(sdkMocks.renderSettings).toHaveBeenCalledWith(
-      expect.any(HTMLElement),
-      expect.not.objectContaining({ backend: expect.anything() }),
-    );
-  });
-
-  it('requires a web app URL when none can be derived', async () => {
-    mockMatchMedia(true);
-    render(
-      <ComponentDemo kind="chat">
-        <ChatPreview />
-      </ComponentDemo>,
-    );
-    await userEvent.click(screen.getByText('Live — your instance'));
-    await userEvent.click(screen.getByText('Connect'));
-    expect(screen.getByText(/Enter at least your web app URL/)).toBeVisible();
-    expect(sdkMocks.renderChat).not.toHaveBeenCalled();
+    expect(screen.getByText(/Configured: acme\.glean\.com/)).toBeVisible();
   });
 });
 

--- a/src/components/WebSdk/WebSdk.test.tsx
+++ b/src/components/WebSdk/WebSdk.test.tsx
@@ -201,6 +201,37 @@ describe('ComponentDemo', () => {
     expect(screen.getByText(/doesn't look like a Glean URL/)).toBeVisible();
   });
 
+  it('jumps to Live from the mock caption and remembers the choice', async () => {
+    mockMatchMedia(true);
+    const first = render(
+      <ComponentDemo kind="chat">
+        <ChatPreview />
+      </ComponentDemo>,
+    );
+    await userEvent.click(screen.getByText('Try it live \u2192'));
+    await vi.waitFor(() => {
+      expect(sdkMocks.renderChat).toHaveBeenCalled();
+    });
+    first.unmount();
+    // A fresh demo block starts on Live thanks to the sticky preference.
+    render(
+      <ComponentDemo kind="settings">
+        <SettingsPreview />
+      </ComponentDemo>,
+    );
+    await vi.waitFor(() => {
+      expect(sdkMocks.renderSettings).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('Illustrative preview')).not.toBeInTheDocument();
+  });
+
+  it('keeps the caption plain outside a demo block', () => {
+    mockMatchMedia(true);
+    render(<ChatPreview />);
+    expect(screen.getByText('Illustrative preview')).toBeInTheDocument();
+    expect(screen.queryByText('Try it live \u2192')).not.toBeInTheDocument();
+  });
+
   it('applies saved overrides to the live widget', async () => {
     mockMatchMedia(true);
     render(

--- a/src/components/WebSdk/live/LiveTabContext.ts
+++ b/src/components/WebSdk/live/LiveTabContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from 'react';
+
+/** Provided by ComponentDemo so the mock's caption can offer a
+ * "Try it live" jump into the Live tab. Null outside a demo block
+ * (e.g. the overview gallery), where the caption stays plain. */
+export const LiveTabContext = createContext<(() => void) | null>(null);

--- a/src/components/WebSdk/live/live.module.css
+++ b/src/components/WebSdk/live/live.module.css
@@ -46,6 +46,18 @@
   color: var(--gdt-text-primary);
 }
 
+/* Inline configure toggle inside the live caption */
+.configureLink {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  color: var(--gdt-info-fg);
+  font-family: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
 /* ---- Connect card ---- */
 
 .connectCard {

--- a/src/components/WebSdk/live/store.ts
+++ b/src/components/WebSdk/live/store.ts
@@ -67,6 +67,21 @@ export function setOverrides(config: LiveDemoConfig): void {
   notify();
 }
 
+const TAB_KEY = 'websdk-live-demo:tab';
+
+/** Sticky tab preference: once a reader uses Live, open Live first on
+ * every component page. No login detection — users self-select. */
+export function getPreferredTab(): 'preview' | 'live' {
+  if (typeof window === 'undefined') {
+    return 'preview';
+  }
+  return window.localStorage.getItem(TAB_KEY) === 'live' ? 'live' : 'preview';
+}
+
+export function setPreferredTab(tab: 'preview' | 'live'): void {
+  window.localStorage.setItem(TAB_KEY, tab);
+}
+
 export function useLiveDemoConfig(): LiveDemoConfig {
   return useSyncExternalStore(
     (cb) => {

--- a/src/components/WebSdk/live/store.ts
+++ b/src/components/WebSdk/live/store.ts
@@ -1,36 +1,33 @@
-/** Shared connect-state for the in-page live demos: the reader's Glean
- * backend URL (optional — the SDK falls back to email-based discovery),
- * persisted in localStorage so one connect powers every component page. */
+/** Optional overrides for the in-page live demos. By default the demos
+ * render via https://app.glean.com with no backend — the SDK reuses an
+ * existing glean.com session or runs its own email-based discovery, the
+ * same zero-config path as a script-tag integration. Overrides exist for
+ * custom-subdomain, non-Glean-hosted, and staging deployments, persisted
+ * in localStorage so one configuration covers every component page. */
 
 import { useSyncExternalStore } from 'react';
 
 const KEY = 'websdk-live-demo';
 
-export interface LiveDemoState {
-  connected: boolean;
-  /** Backend URL like https://acme-be.glean.com/ — may be empty, in which
-   * case the widget prompts for the user's email to discover it. */
-  backend: string;
-  /** Web app URL like https://app.glean.com — required by the npm build to
-   * know where the widget iframes are hosted (the script tag derives this
-   * from its own src; the npm bundle cannot). */
+export const DEFAULT_WEB_APP_URL = 'https://app.glean.com';
+
+export interface LiveDemoConfig {
+  /** Web app URL hosting the widget frames. Empty means the default. */
   webAppUrl: string;
+  /** Backend URL override; empty lets the SDK discover it. */
+  backend: string;
 }
 
-const DISCONNECTED: LiveDemoState = {
-  connected: false,
-  backend: '',
-  webAppUrl: '',
-};
+const DEFAULTS: LiveDemoConfig = { webAppUrl: '', backend: '' };
 
-let cached: LiveDemoState = DISCONNECTED;
+let cached: LiveDemoConfig = DEFAULTS;
 let cachedRaw: string | null = null;
 
 const listeners = new Set<() => void>();
 
-function read(): LiveDemoState {
+function read(): LiveDemoConfig {
   if (typeof window === 'undefined') {
-    return DISCONNECTED;
+    return DEFAULTS;
   }
   const raw = window.localStorage.getItem(KEY);
   if (raw === cachedRaw) {
@@ -38,18 +35,17 @@ function read(): LiveDemoState {
   }
   cachedRaw = raw;
   if (!raw) {
-    cached = DISCONNECTED;
+    cached = DEFAULTS;
     return cached;
   }
   try {
     const parsed = JSON.parse(raw);
     cached = {
-      connected: parsed.connected === true,
-      backend: typeof parsed.backend === 'string' ? parsed.backend : '',
       webAppUrl: typeof parsed.webAppUrl === 'string' ? parsed.webAppUrl : '',
+      backend: typeof parsed.backend === 'string' ? parsed.backend : '',
     };
   } catch {
-    cached = DISCONNECTED;
+    cached = DEFAULTS;
   }
   return cached;
 }
@@ -60,24 +56,18 @@ function notify() {
   }
 }
 
-export function connect(backend: string, webAppUrl: string): void {
-  window.localStorage.setItem(
-    KEY,
-    JSON.stringify({
-      connected: true,
-      backend: backend.trim(),
-      webAppUrl: webAppUrl.trim(),
-    }),
-  );
+export function setOverrides(config: LiveDemoConfig): void {
+  const webAppUrl = config.webAppUrl.trim();
+  const backend = config.backend.trim();
+  if (!webAppUrl && !backend) {
+    window.localStorage.removeItem(KEY);
+  } else {
+    window.localStorage.setItem(KEY, JSON.stringify({ webAppUrl, backend }));
+  }
   notify();
 }
 
-export function disconnect(): void {
-  window.localStorage.removeItem(KEY);
-  notify();
-}
-
-export function useLiveDemoState(): LiveDemoState {
+export function useLiveDemoConfig(): LiveDemoConfig {
   return useSyncExternalStore(
     (cb) => {
       listeners.add(cb);
@@ -88,6 +78,6 @@ export function useLiveDemoState(): LiveDemoState {
       };
     },
     read,
-    () => DISCONNECTED,
+    () => DEFAULTS,
   );
 }

--- a/src/components/WebSdk/mocks/mocks.module.css
+++ b/src/components/WebSdk/mocks/mocks.module.css
@@ -858,6 +858,22 @@ html[data-theme='dark'] .resultTitle {
   color: var(--gdt-info-fg);
 }
 
+/* Jump from the mock straight into the Live tab */
+.tryLive {
+  border: none;
+  background: none;
+  padding: 0;
+  font-size: inherit;
+  font-weight: 600;
+  color: var(--gdt-info-fg);
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.tryLive:hover {
+  text-decoration: underline;
+}
+
 /* ---- Motion ---- */
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/components/WebSdk/mocks/primitives.tsx
+++ b/src/components/WebSdk/mocks/primitives.tsx
@@ -1,5 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { getIcon } from '@gleanwork/docusaurus-theme-glean/Icons';
+import { LiveTabContext } from '../live/LiveTabContext';
 import styles from './mocks.module.css';
 import { SOURCE_LABELS, type DemoResult, type SourceKey } from './demoData';
 
@@ -160,14 +161,24 @@ export function PortalPage({
   );
 }
 
-/** Honest-labeling caption rendered under every mock. */
+/** Honest-labeling caption rendered under every mock. Inside a demo
+ * block it also offers the jump to the Live tab. */
 export function MockCaption(): React.ReactElement {
+  const goLive = useContext(LiveTabContext);
   return (
     <p className={styles.caption}>
       <span className={styles.captionBadge}>Illustrative preview</span>
       <span>
         Rendered with sample data — in your app, this component renders live
         against your organization&apos;s Glean instance.
+        {goLive ? (
+          <>
+            {' '}
+            <button className={styles.tryLive} onClick={goLive} type="button">
+              Try it live →
+            </button>
+          </>
+        ) : null}
       </span>
     </p>
   );


### PR DESCRIPTION
Removes the connect gate from the live demos. app.glean.com locates the reader's tenant itself — reusing an existing Glean session or running the SDK's own email-based discovery inside the widget — so the Live tab now renders the real component immediately with no form. Overrides for custom-subdomain / non-Glean-hosted / staging tenants live behind a small 'Custom domain or backend?' link in the live caption (validated to *.glean.com, persisted across pages).

Verified headlessly: zero-config Live tab loads the chat frame from https://app.glean.com/frame/chat; overrides apply and persist; 167 tests green; clean build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)