### PR TITLE
docs(claude-code): add install-first plugin guide

### DIFF
--- a/docs/guides/mcp/claude-code.mdx
+++ b/docs/guides/mcp/claude-code.mdx
@@ -4,29 +4,145 @@ description: Install the official Glean plugin for Claude Code — enterprise kn
 ---
 
 import PluginPage from '@site/src/components/PluginPage';
+import FeatureFlag from '@site/src/components/FeatureFlag';
+import TerminalPanel from '@site/src/components/home/TerminalPanel';
 
 {/* Install commands synced from https://github.com/gleanwork/claude-plugins/blob/main/README.md */}
 
-<PluginPage
-  name="Claude Code"
-  tagline="You use Claude Code. Glean brings the enterprise context."
-  clientId="claude-code"
-  steps={[
-    {
-      type: 'cta',
-      label: 'Set up the Glean MCP Server',
-      description: 'The plugins require a Glean MCP connection. Use the Glean configurator to connect Claude Code to your organization\'s Glean instance. Authentication uses Glean\'s OAuth server where enabled, or a Glean API token as a fallback.',
-      ctaText: 'Open MCP Configurator',
-      ctaHref: 'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=claude-code',
-    },
-    {
-      type: 'command',
-      label: 'Add the Glean marketplace and install the plugin',
-      description: 'Run these commands inside Claude Code to install the Glean enterprise-knowledge plugin. Its skills — search, code exploration, people, meetings, onboarding, productivity — auto-trigger by task.',
-      commands: [
-        { title: 'Add the Glean marketplace', code: '/plugin marketplace add gleanwork/claude-plugins' },
-        { title: 'Install the plugin', code: '/plugin install glean@glean-plugins' },
-      ],
-    },
-  ]}
-/>
+{/* New page is gated behind `claude-code-plugin-v2`. The previous page is
+    preserved as the fallback and renders whenever the flag is turned off. */}
+
+<FeatureFlag
+  flag="claude-code-plugin-v2"
+  fallback={
+    <PluginPage
+      name="Claude Code"
+      tagline="You use Claude Code. Glean brings the enterprise context."
+      clientId="claude-code"
+      steps={[
+        {
+          type: 'cta',
+          label: 'Set up the Glean MCP Server',
+          description:
+            "The plugins require a Glean MCP connection. Use the Glean configurator to connect Claude Code to your organization's Glean instance. Authentication uses Glean's OAuth server where enabled, or a Glean API token as a fallback.",
+          ctaText: 'Open MCP Configurator',
+          ctaHref:
+            'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=claude-code',
+        },
+        {
+          type: 'command',
+          label: 'Add the Glean marketplace and install the plugin',
+          description:
+            'Run these commands inside Claude Code to install the Glean enterprise-knowledge plugin. Its skills — search, code exploration, people, meetings, onboarding, productivity — auto-trigger by task.',
+          commands: [
+            {
+              title: 'Add the Glean marketplace',
+              code: '/plugin marketplace add gleanwork/claude-plugins',
+            },
+            { title: 'Install the plugin', code: '/plugin install glean@glean-plugins' },
+          ],
+        },
+      ]}
+    />
+  }
+>
+  <PluginPage
+    name="Claude Code"
+    tagline="You use Claude Code. Glean brings the enterprise context."
+    clientId="claude-code"
+    whatsIncluded={
+      <>
+        The Glean plugin turns Claude Code into a front door to your company:
+        Glean&rsquo;s expert skills — search, code exploration, people, meetings,
+        onboarding, productivity — the custom skills your team authors in Glean,
+        and every tool configured centrally in Glean, each paired with skills
+        tuned to use it well. Those tools are surfaced with Glean&rsquo;s security
+        and permission guardrails fully enforced, all running through a Glean
+        MCP server so it works right in your terminal.{' '}
+        <a
+          href="https://github.com/gleanwork/claude-plugins/blob/main/README.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          See everything included in the plugin →
+        </a>
+      </>
+    }
+    steps={[
+      {
+        type: 'command',
+        label: 'Add the Glean marketplace and install the plugin',
+        description: 'Run these commands inside Claude Code.',
+        commands: [
+          {
+            title: 'Add the Glean marketplace',
+            code: '/plugin marketplace add gleanwork/claude-plugins',
+          },
+          { title: 'Install the plugin', code: '/plugin install glean@glean-plugins' },
+        ],
+      },
+      {
+        type: 'list',
+        label: 'Setup the Glean MCP connection',
+        description:
+          "Connect the plugin to your Glean instance. Authentication uses Glean's OAuth server where enabled, or a Glean API token as a fallback. You only need to do this once per machine.",
+        items: [
+          <>
+            In Claude Code, run: <code>/glean_run setup my Glean</code>
+          </>,
+          'Enter your work email when prompted.',
+          'Finish authentication using the method configured for your Glean instance: OAuth in the browser where enabled, or the Glean API-token fallback provided by your administrator.',
+          'Back in Claude Code, confirm it reports connected — you now have every skill and tool provisioned for you in Glean, right in your terminal. Search company knowledge, take action across your connected apps, and move through real work faster without leaving the command line.',
+        ],
+      },
+    ]}
+    afterStepsLabel="Optional: fewer permission prompts"
+    afterSteps={
+      <>
+        <p>
+          Set <code>USE_CLAUDE_PROJECT_DIR</code> to <code>1</code> for fewer
+          approval prompts when the plugin reads its skill files.
+        </p>
+        <p>
+          It&rsquo;s an environment variable, so add it under the{' '}
+          <code>env</code> key of a Claude Code <code>settings.json</code> file:
+        </p>
+        <div style={{ marginBottom: 14, maxWidth: 560 }}>
+          <TerminalPanel
+            filename=".claude/settings.json"
+            copy
+            code={`{
+  // ...your other Claude Code settings
+  "env": {
+    // ...your other environment variables
+    "USE_CLAUDE_PROJECT_DIR": "1"
+  }
+}`}
+          />
+        </div>
+        <p>Pick the scope that fits:</p>
+        <ul>
+          <li>
+            <strong>One project</strong> — add it to{' '}
+            <code>.claude/settings.json</code> (checked into git, shared with
+            your team) or <code>.claude/settings.local.json</code> (just you).
+          </li>
+          <li>
+            <strong>Every project</strong> — ask your Claude Code admin to set
+            it in your organization&rsquo;s managed settings
+            (<code>managed-settings.json</code>), which applies to all projects
+            and can&rsquo;t be overridden locally.
+          </li>
+        </ul>
+        <p>
+          With this on, the plugin writes its skills cache to{' '}
+          <code>.claude/tmp/</code> in your repo, so add that path to your{' '}
+          <code>.gitignore</code>:
+        </p>
+        <div style={{ marginBottom: 14, maxWidth: 560 }}>
+          <TerminalPanel filename=".gitignore" copy code={`.claude/tmp/`} />
+        </div>
+      </>
+    }
+  />
+</FeatureFlag>

--- a/src/components/PluginPage/index.tsx
+++ b/src/components/PluginPage/index.tsx
@@ -13,7 +13,7 @@ type PluginStep = {
 } & (
   | { type: 'cta'; ctaText: string; ctaHref: string }
   | { type: 'command'; commands: { code: string; title: string }[] }
-  | { type: 'list'; items: string[] }
+  | { type: 'list'; items: React.ReactNode[] }
 );
 
 type PluginPageProps = {
@@ -23,6 +23,12 @@ type PluginPageProps = {
   clientId: string;
   /** Monochrome brand marks need inverting in dark mode (cursor, codex). */
   mono?: boolean;
+  /** Optional "What's included" blurb rendered between the banner and Installation. */
+  whatsIncluded?: React.ReactNode;
+  /** Optional content rendered below the numbered steps, under its own section label. */
+  afterSteps?: React.ReactNode;
+  /** Section label shown above afterSteps content. Defaults to "Configuration". */
+  afterStepsLabel?: string;
   /** Banner heading; defaults to "Glean plugin for <name>". */
   title?: string;
   steps: PluginStep[];
@@ -46,8 +52,8 @@ function StepBody({ step }: { step: PluginStep }): React.ReactElement {
       ) : null}
       {step.type === 'list' ? (
         <ol className={styles.stepList}>
-          {step.items.map((item) => (
-            <li key={item}>{item}</li>
+          {step.items.map((item, index) => (
+            <li key={index}>{item}</li>
           ))}
         </ol>
       ) : null}
@@ -79,6 +85,9 @@ export default function PluginPage({
   tagline,
   clientId,
   mono = false,
+  whatsIncluded,
+  afterSteps,
+  afterStepsLabel,
   title,
   steps,
 }: PluginPageProps): React.ReactElement {
@@ -109,6 +118,13 @@ export default function PluginPage({
         <p className={styles.bannerTagline}>{tagline}</p>
       </div>
 
+      {whatsIncluded ? (
+        <>
+          <div className={styles.sectionLabel}>What&rsquo;s included</div>
+          <p className={styles.whatsIncluded}>{whatsIncluded}</p>
+        </>
+      ) : null}
+
       <div className={styles.sectionLabel}>Installation</div>
       <div className={styles.stepsWrap}>
         <div className={styles.stepsRail} />
@@ -121,6 +137,15 @@ export default function PluginPage({
           </div>
         ))}
       </div>
+
+      {afterSteps ? (
+        <>
+          <div className={styles.sectionLabel}>
+            {afterStepsLabel ?? 'Configuration'}
+          </div>
+          <div className={styles.afterSteps}>{afterSteps}</div>
+        </>
+      ) : null}
     </div>
   );
 }

--- a/src/components/PluginPage/styles.module.css
+++ b/src/components/PluginPage/styles.module.css
@@ -104,6 +104,43 @@ html[data-theme='dark'] .brandTileMono svg {
   }
 }
 
+/* ---- After-steps (optional configuration) ---- */
+
+.afterSteps {
+  max-width: 660px;
+  font-size: 14.5px;
+  line-height: 1.6;
+}
+
+.afterSteps p {
+  color: var(--gdt-text-secondary);
+  margin: 0 0 14px;
+}
+
+.afterSteps ul {
+  color: var(--gdt-text-secondary);
+  margin: 0 0 14px;
+  padding-left: 20px;
+}
+
+.afterSteps li {
+  margin-bottom: 6px;
+}
+
+.afterSteps code {
+  font-size: 0.9em;
+}
+
+/* ---- What's included ---- */
+
+.whatsIncluded {
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--gdt-text-secondary);
+  max-width: 640px;
+  margin: 0 0 32px;
+}
+
 /* ---- Section label (matches recipe pages) ---- */
 
 .sectionLabel {


### PR DESCRIPTION
## Summary

Updates `/guides/mcp/claude-code` with an install-first experience for the Glean Claude Code plugin, gated behind the existing `claude-code-plugin-v2` feature flag.

The previous page is preserved as the fallback and remains visible while the flag is off. The new page can be enabled through the existing runtime feature-flag configuration when the plugin is ready to launch.

### New page

- **What's included** — explains that the plugin brings Glean's expert skills, custom skills authored by teams in Glean, and centrally configured Glean tools with security and permission guardrails enforced.
- Links to the [`claude-plugins` README](https://github.com/gleanwork/claude-plugins/blob/main/README.md) for more detail about the plugin contents.
- **Installation** — add the Glean marketplace, install the plugin, then set up the connection with `/glean_run setup my Glean`.
- Includes OAuth/API-token authentication guidance.
- **Optional: fewer permission prompts** — documents `USE_CLAUDE_PROJECT_DIR=1`, Claude Code `settings.json` scopes, and the `.claude/tmp/` `.gitignore` entry.

### Implementation

- Adds optional `whatsIncluded` and `afterSteps` slots to `PluginPage`; existing plugin pages are unaffected.
- Keeps `claude-code-plugin-v2` off when absent; no new default-flag mechanism is introduced.
- Preserves the current page in the `FeatureFlag` fallback.
- Does not modify generated API Reference content.

## Rollout

After this PR is deployed, enable the page for everyone by adding this entry to the existing `feature-flags` item in the `glean-developer-feature-flags` Edge Config:

```json
{
  "claude-code-plugin-v2": {
    "enabled": true
  }
}
```

For local or preview testing, use:

```text
/guides/mcp/claude-code?ff_claude-code-plugin-v2=true
```

To force the fallback page:

```text
/guides/mcp/claude-code?ff_claude-code-plugin-v2=false
```

## Validation

- `pnpm prettier --check .` ✅
- `pnpm test` ✅ — 169 passed, 2 skipped
- `pnpm build` ✅ — fallback page renders when the flag is absent
- `FF_CLAUDE_CODE_PLUGIN_V2=true pnpm build` ✅ — new page renders with the install flow and optional configuration guidance
