### PR TITLE
Add the rfp-responder cookbook page

### DIFF
--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -793,5 +793,138 @@
     "goDependency": false,
     "featured": true,
     "tags": ["rag", "differentiator"]
+  },
+  {
+    "id": "rfp-responder",
+    "title": "Answer an RFP or security questionnaire",
+    "description": "Turn a customer questionnaire into grounded, cited draft answers — where every claim carries a source, unsupported rows route to a human, and nothing reaches the customer without approval.",
+    "sidebarLabel": "RFP responder",
+    "surfaces": ["platform-api"],
+    "status": "showcase",
+    "category": "workflow",
+    "level": "Intermediate",
+    "levels": {
+      "minimal": true,
+      "wow": true
+    },
+    "timeEstimate": "~45 min",
+    "icon": "qna",
+    "requiredScopes": ["CHAT"],
+    "authMethod": ["client-api-oauth-or-token"],
+    "buildMethod": "scaffold",
+    "languages": ["typescript"],
+    "prerequisites": [
+      "A Glean instance with your company content indexed",
+      "Your own OAuth access token or Glean API token with the CHAT scope (no admin or global token — the app runs as you)",
+      "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+      "Node 20+"
+    ],
+    "demoQueries": [
+      {
+        "query": "Draft answers to the Globex security questionnaire",
+        "expectedBehavior": "All 20 rows are parsed across 4 tabs, the one exact duplicate is merged, and each row is classified by the evidence behind it: strongly grounded rows get a cited draft, adjacent-evidence rows are flagged for verification, and rows the corpus cannot support are left blank and routed to an SME. No row receives a fluent answer without a citation."
+      },
+      {
+        "query": "Do you conduct independent penetration testing at least annually?",
+        "expectedBehavior": "The corpus contains no pen-testing evidence, so the model returns INSUFFICIENT_EVIDENCE and the row renders as 'needs SME' with no draft text. Accepting it is refused by the API. This is the behaviour to check first — an RFP tool that answers this question anyway is worse than no tool."
+      },
+      {
+        "query": "Describe your self-service credential reset flow.",
+        "expectedBehavior": "Retrieval finds an internal IT support article that is genuinely on-topic, so the row is flagged weak rather than strong: the answer is drafted but labelled as resting on internal documentation that a person must clear before it goes to a customer. Topicality and approval are scored separately."
+      },
+      {
+        "query": "Run the same questionnaire as a user outside the sales group",
+        "expectedBehavior": "The Globex security response summary is restricted to the Sample-Sales group, so a caller outside it retrieves nothing and those rows collapse to 'needs SME' rather than being answered from elsewhere. Your own credential is the permission boundary — there is no impersonation — so content you cannot see can never be laundered into a customer-facing document. A single identity cannot show 'user A sees it, user B doesn't'; what it can show is that empty retrieval produces a refusal instead of a fabrication, which is the property that actually protects people.",
+        "permissionDifferentiated": true
+      }
+    ],
+    "codeAssets": [
+      {
+        "repoPath": "recipes/rfp-responder",
+        "language": "typescript",
+        "description": "Parse + dedup -> batched Chat calls -> review grid with evidence classification -> approval gate -> structure-preserving export"
+      }
+    ],
+    "steps": [
+      {
+        "title": "Scaffold the project",
+        "command": "npx tiged --mode=git gleanwork/glean-cookbook/recipes/rfp-responder rfp-responder"
+      },
+      {
+        "title": "Install dependencies",
+        "command": "cd rfp-responder && npm install"
+      },
+      {
+        "title": "Try it with no credentials",
+        "command": "npm run verify:fixture",
+        "description": "Runs the whole flow against recorded responses and asserts the failure contract: no ungrounded row carries an answer, every answered row carries a citation, and export is gated on approval."
+      },
+      {
+        "title": "Set credentials",
+        "command": "cp .env.example .env",
+        "description": "Fill in GLEAN_INSTANCE and your own GLEAN_API_TOKEN. The app runs as you; there is no act-as."
+      },
+      {
+        "title": "Run it",
+        "command": "npm start"
+      },
+      {
+        "title": "Verify",
+        "description": "Load the questionnaire, confirm the column mapping, and draft. Check that a supported question (SOC 2, encryption at rest) returns a cited answer, and that an unsupported one (ISO 27001, RTO/RPO) is left blank and assigned to an SME rather than answered."
+      }
+    ],
+    "combines": [
+      {
+        "title": "Permissions-aware retrieval",
+        "surface": "Platform API",
+        "category": "search",
+        "language": "typescript"
+      }
+    ],
+    "architecture": [
+      {
+        "label": "Questionnaire",
+        "caption": "xlsx / docx / CSV",
+        "category": "workflow",
+        "icon": "layout-outlined"
+      },
+      {
+        "label": "Parse + dedup",
+        "caption": "exact merges only",
+        "category": "workflow"
+      },
+      {
+        "label": "Platform Chat",
+        "caption": "one call per question",
+        "category": "search"
+      },
+      {
+        "label": "Glean",
+        "caption": "permission-aware index",
+        "emphasized": true
+      },
+      {
+        "label": "Evidence check",
+        "caption": "topicality + approval",
+        "category": "workflow",
+        "icon": "badge"
+      },
+      {
+        "label": "Review + approve",
+        "caption": "human gate, audit log",
+        "category": "portal"
+      }
+    ],
+    "aiPrompt": "Build an RFP and security-questionnaire responder on the Glean Platform API, following the rfp-responder recipe. Parse a questionnaire into rows, deduplicate only exact matches (near-duplicate merging is unsafe: 'encrypted at rest' and 'encrypted in transit' score highly similar but are different controls), then run one Chat call per unique question with instructions that constrain the answer to retrieved evidence and return INSUFFICIENT_EVIDENCE when the evidence is absent. Classify every row on two independent axes -- whether the citation is topically relevant, and whether its source is on a declared approved-for-external-use list -- and never render a draft answer for a row with no citation. Route unsupported rows to a human SME. Gate export behind an explicit confirmation and record an approval log.",
+    "llmContext": "Platform Chat: POST /api/chat with { input, stream: false, store: true }; parse output[].content[] where type === 'output_text' for .text and .annotations[].sources[] { title, url }. Requires X-GLEAN-INCLUDE-EXPERIMENTAL: true and platform.apiMigratedEndpointsEnabled. Auth is the caller's own OAuth token or API token with CHAT scope -- impersonation/act-as was removed from the cookbook recipes, so these apps are single-user and the caller's credential is the permission boundary. Two design findings worth carrying into similar builds: (1) lexical similarity cannot dedupe security questionnaires -- on the sample corpus the unsafe pair (at-rest vs in-transit encryption) scores 0.60 while the true duplicates score 0.29-0.30, so only exact matches can be merged automatically; (2) topicality and approval-for-external-use are independent -- an internal IT article can be the single most on-topic document for a question and still be unusable as customer-facing evidence, so approval must be declared rather than inferred from a relevance score.",
+    "goDependency": false,
+    "featured": false,
+    "tags": [
+      "rfp",
+      "questionnaire",
+      "citations",
+      "human-in-the-loop",
+      "workflow"
+    ]
   }
 ]

--- a/docs/cookbook/rfp-responder.mdx
+++ b/docs/cookbook/rfp-responder.mdx
@@ -1,0 +1,97 @@
+---
+hide_table_of_contents: true
+hide_title: true
+pagination_prev: null
+pagination_next: null
+---
+
+import RecipePage from '@site/src/components/Cookbook/RecipePage';
+import {
+  RecipeSection,
+  RecipePrereqs,
+  RecipeSteps,
+  TakeItFurther,
+} from '@site/src/components/Cookbook/RecipeLayout';
+
+<RecipePage recipeId="rfp-responder">
+
+<RecipeSection label="Problem">
+
+A security questionnaire arrives with 200 rows. The answers all exist somewhere —
+in last quarter's SOC 2 report, in a policy doc, in the response you sent a
+different customer in March. Someone spends a week finding them again.
+
+Everyone has seen an RFP bot that drafts those answers. The hard part isn't
+drafting. It's what happens on the rows where the evidence isn't there, because a
+fluent, confident, wrong answer about your own security controls doesn't get
+caught in review — it gets pasted into a customer's document over your signature.
+
+So this recipe is built around the failure contract rather than the happy path.
+Only permitted, approved evidence enters the prompt. Every claim keeps its
+citation. Missing evidence stays unanswered. A person approves before anything
+leaves.
+
+</RecipeSection>
+
+<RecipePrereqs />
+
+<RecipeSteps />
+
+<RecipeSection label="Two things that surprised us">
+
+Both look fine in a demo and fail in production, so they're worth carrying into
+anything similar you build.
+
+**Lexical similarity cannot deduplicate a security questionnaire.** The obvious
+design scores question similarity and merges above a threshold. On the sample
+questionnaire, "is customer data encrypted **at rest**?" and "is customer data
+encrypted **in transit**?" score **0.60** — while two genuine duplicates,
+"is customer data encrypted at rest?" and "describe your at-rest encryption,
+including key length," score **0.29**. The false positive outranks the true
+positive. No threshold is safe: any cutoff that catches the real duplicate also
+merges two different security controls. So only normalized-exact matches merge
+automatically, and similarity is used purely to *order* a manual-merge list for
+the reviewer. The cross-tab exact repeat — the common real-world case — is still
+handled for free.
+
+**Topicality and approval are independent.** Asked to "describe your self-service
+credential reset flow," retrieval surfaces an internal IT support article. That
+citation is genuinely excellent — it is literally about credential resets. It is
+also unusable as evidence in a customer's questionnaire, because it's internal
+operational guidance, not a reviewed statement of a control. No relevance score
+catches this, because the problem isn't linguistic. So the recipe scores two
+separate axes, and approval is *declared* in a list a customer owns rather than
+inferred: **strong** means an approved source that answers directly, **weak**
+means on-topic-but-internal or approved-but-adjacent, and **none** means no draft
+at all.
+
+</RecipeSection>
+
+<RecipeSection label="Permissions">
+
+The app runs as you. There's no impersonation and no act-as, which makes it
+single-user — and makes the guarantee real: content you can't see can't reach the
+customer's document. Empty retrieval produces a refusal, not an answer from the
+model's own knowledge.
+
+The sample corpus demonstrates it. The Globex security response summary is
+restricted to a single group; run as someone outside it and every security row
+collapses to "needs SME" instead of quietly answering from somewhere else.
+
+</RecipeSection>
+
+<TakeItFurther>
+
+<>Add an xlsx and docx reader so real questionnaires can be uploaded directly — the parser here reads CSV to keep the interesting logic legible.</>
+
+<>Write answers back into the source document with a custom tool instead of exporting, keeping the confirm step and the approval log.</>
+
+<>Give the answer library its own access control before sharing it across a team. It's a cache of retrieved content, so it can leak across the permission boundary the rest of the app respects.</>
+
+<>Route "needs SME" rows to their owners automatically, and track which ones came back — the assignment field here is deliberately inert.</>
+
+<>Combine with [permissions-aware retrieval](/cookbook/permissions-aware-rag) to see the same refusal property in a smaller, single-question app.</>
+
+</TakeItFurther>
+
+</RecipePage>

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -986,6 +986,154 @@
         "differentiator"
       ],
       "permalink": "/cookbook/permissions-aware-rag"
+    },
+    {
+      "id": "rfp-responder",
+      "title": "Answer an RFP or security questionnaire",
+      "description": "Turn a customer questionnaire into grounded, cited draft answers — where every claim carries a source, unsupported rows route to a human, and nothing reaches the customer without approval.",
+      "sidebarLabel": "RFP responder",
+      "surfaces": [
+        "platform-api"
+      ],
+      "status": "showcase",
+      "category": "workflow",
+      "level": "Intermediate",
+      "levels": {
+        "minimal": true,
+        "wow": true
+      },
+      "timeEstimate": "~45 min",
+      "icon": "qna",
+      "requiredScopes": [
+        "CHAT"
+      ],
+      "authMethod": [
+        "client-api-oauth-or-token"
+      ],
+      "buildMethod": "scaffold",
+      "languages": [
+        "typescript"
+      ],
+      "prerequisites": [
+        "A Glean instance with your company content indexed",
+        "Your own OAuth access token or Glean API token with the CHAT scope (no admin or global token — the app runs as you)",
+        "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+        "Node 20+"
+      ],
+      "demoQueries": [
+        {
+          "query": "Draft answers to the Globex security questionnaire",
+          "expectedBehavior": "All 20 rows are parsed across 4 tabs, the one exact duplicate is merged, and each row is classified by the evidence behind it: strongly grounded rows get a cited draft, adjacent-evidence rows are flagged for verification, and rows the corpus cannot support are left blank and routed to an SME. No row receives a fluent answer without a citation."
+        },
+        {
+          "query": "Do you conduct independent penetration testing at least annually?",
+          "expectedBehavior": "The corpus contains no pen-testing evidence, so the model returns INSUFFICIENT_EVIDENCE and the row renders as 'needs SME' with no draft text. Accepting it is refused by the API. This is the behaviour to check first — an RFP tool that answers this question anyway is worse than no tool."
+        },
+        {
+          "query": "Describe your self-service credential reset flow.",
+          "expectedBehavior": "Retrieval finds an internal IT support article that is genuinely on-topic, so the row is flagged weak rather than strong: the answer is drafted but labelled as resting on internal documentation that a person must clear before it goes to a customer. Topicality and approval are scored separately."
+        },
+        {
+          "query": "Run the same questionnaire as a user outside the sales group",
+          "expectedBehavior": "The Globex security response summary is restricted to the Sample-Sales group, so a caller outside it retrieves nothing and those rows collapse to 'needs SME' rather than being answered from elsewhere. Your own credential is the permission boundary — there is no impersonation — so content you cannot see can never be laundered into a customer-facing document. A single identity cannot show 'user A sees it, user B doesn't'; what it can show is that empty retrieval produces a refusal instead of a fabrication, which is the property that actually protects people.",
+          "permissionDifferentiated": true
+        }
+      ],
+      "codeAssets": [
+        {
+          "repoPath": "recipes/rfp-responder",
+          "language": "typescript",
+          "description": "Parse + dedup -> batched Chat calls -> review grid with evidence classification -> approval gate -> structure-preserving export"
+        }
+      ],
+      "scaffoldActions": [],
+      "steps": [
+        {
+          "title": "Scaffold the project",
+          "command": "npx tiged --mode=git gleanwork/glean-cookbook/recipes/rfp-responder rfp-responder"
+        },
+        {
+          "title": "Install dependencies",
+          "command": "cd rfp-responder && npm install"
+        },
+        {
+          "title": "Try it with no credentials",
+          "description": "Runs the whole flow against recorded responses and asserts the failure contract: no ungrounded row carries an answer, every answered row carries a citation, and export is gated on approval.",
+          "command": "npm run verify:fixture"
+        },
+        {
+          "title": "Set credentials",
+          "description": "Fill in GLEAN_INSTANCE and your own GLEAN_API_TOKEN. The app runs as you; there is no act-as.",
+          "command": "cp .env.example .env"
+        },
+        {
+          "title": "Run it",
+          "command": "npm start"
+        },
+        {
+          "title": "Verify",
+          "description": "Load the questionnaire, confirm the column mapping, and draft. Check that a supported question (SOC 2, encryption at rest) returns a cited answer, and that an unsupported one (ISO 27001, RTO/RPO) is left blank and assigned to an SME rather than answered."
+        }
+      ],
+      "combines": [
+        {
+          "title": "Permissions-aware retrieval",
+          "surface": "Platform API",
+          "category": "search",
+          "language": "typescript"
+        }
+      ],
+      "architecture": [
+        {
+          "label": "Questionnaire",
+          "caption": "xlsx / docx / CSV",
+          "category": "workflow",
+          "icon": "layout-outlined",
+          "emphasized": false
+        },
+        {
+          "label": "Parse + dedup",
+          "caption": "exact merges only",
+          "category": "workflow",
+          "emphasized": false
+        },
+        {
+          "label": "Platform Chat",
+          "caption": "one call per question",
+          "category": "search",
+          "emphasized": false
+        },
+        {
+          "label": "Glean",
+          "caption": "permission-aware index",
+          "emphasized": true
+        },
+        {
+          "label": "Evidence check",
+          "caption": "topicality + approval",
+          "category": "workflow",
+          "icon": "badge",
+          "emphasized": false
+        },
+        {
+          "label": "Review + approve",
+          "caption": "human gate, audit log",
+          "category": "portal",
+          "emphasized": false
+        }
+      ],
+      "aiPrompt": "Build an RFP and security-questionnaire responder on the Glean Platform API, following the rfp-responder recipe. Parse a questionnaire into rows, deduplicate only exact matches (near-duplicate merging is unsafe: 'encrypted at rest' and 'encrypted in transit' score highly similar but are different controls), then run one Chat call per unique question with instructions that constrain the answer to retrieved evidence and return INSUFFICIENT_EVIDENCE when the evidence is absent. Classify every row on two independent axes -- whether the citation is topically relevant, and whether its source is on a declared approved-for-external-use list -- and never render a draft answer for a row with no citation. Route unsupported rows to a human SME. Gate export behind an explicit confirmation and record an approval log.",
+      "llmContext": "Platform Chat: POST /api/chat with { input, stream: false, store: true }; parse output[].content[] where type === 'output_text' for .text and .annotations[].sources[] { title, url }. Requires X-GLEAN-INCLUDE-EXPERIMENTAL: true and platform.apiMigratedEndpointsEnabled. Auth is the caller's own OAuth token or API token with CHAT scope -- impersonation/act-as was removed from the cookbook recipes, so these apps are single-user and the caller's credential is the permission boundary. Two design findings worth carrying into similar builds: (1) lexical similarity cannot dedupe security questionnaires -- on the sample corpus the unsafe pair (at-rest vs in-transit encryption) scores 0.60 while the true duplicates score 0.29-0.30, so only exact matches can be merged automatically; (2) topicality and approval-for-external-use are independent -- an internal IT article can be the single most on-topic document for a question and still be unusable as customer-facing evidence, so approval must be declared rather than inferred from a relevance score.",
+      "goDependency": false,
+      "featured": false,
+      "tags": [
+        "rfp",
+        "questionnaire",
+        "citations",
+        "human-in-the-loop",
+        "workflow"
+      ],
+      "permalink": "/cookbook/rfp-responder"
     }
   ],
   "surfaces": [
@@ -1000,7 +1148,7 @@
     "agents"
   ],
   "generatedAt": "2026-07-28T00:00:00.000Z",
-  "totalRecipes": 10,
+  "totalRecipes": 11,
   "plugin": {
     "marketplaceName": "glean-cookbook",
     "pluginName": "cookbook",

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -184,6 +184,8 @@ export const recipeArchitectureNodeSchema = z.strictObject({
 export const recipeDemoQuerySchema = z.strictObject({
   query: z.string().min(1),
   expectedBehavior: z.string().min(1),
+  /** Marks a query whose point is what the user *cannot* see — the answer changes with the caller's permissions, or an empty retrieval must produce a refusal rather than a fabrication. Present in the cookbook's own recipe schema; accepted here so a recipe that declares it doesn't fail compilation. */
+  permissionDifferentiated: z.boolean().optional(),
 });
 
 export const recipeMetaSchema = z.strictObject({


### PR DESCRIPTION
**BLUF (stack):** Publish cookbook pages for the two remaining Glean:GO sample apps.

**BLUF (this PR):** Adds the cookbook page for the `rfp-responder` recipe.

[PACT-451](https://linear.app/gleanwork/issue/PACT-451). Steps, prereqs, scopes and demo queries all render from the recipe registry, so the mdx carries only what the registry can't hold. Pairs with gleanwork/glean-cookbook#3.

## Stack

1. **main**
2. 👉 #654 — rfp-responder page + registry schema fix
3. #655 — incident-copilot page

### Details

Beyond the problem statement and the permissions note, the page documents two findings from building the recipe, because both are the kind of thing that looks fine in a demo and fails in production:

- **Lexical similarity can't deduplicate a security questionnaire.** "Encrypted at rest" vs "encrypted in transit" scores 0.60 while two genuine duplicates score 0.29 — the false positive outranks the true positive, so no merge threshold is safe.
- **Topicality and approval-for-external-use are independent.** An internal IT article can be the single most on-topic document for a question and still be unusable as customer-facing evidence.

Two changes here beyond the page itself:

**Registry snapshot, added surgically.** The page can't compile without a matching registry entry, and `registry:sync` fetches from the cookbook repo's `main`, where this recipe hasn't merged yet. So the `rfp-responder` entry is added by hand — same thing #644 and #645 did. Deliberately *only* that entry: a full `registry:sync` today would drop `acme-answers`, `index-custom-source` and `permissions-aware-rag`, whose pages still exist here under their pre-rename ids, and break the build. The splice leaves every existing byte untouched, so the diff is pure addition.

**`demoQueries[].permissionDifferentiated` added to the zod schema.** The cookbook's own `schemas/recipe.schema.json` already allows this field, but `recipeDemoQuerySchema` here is a `strictObject` that rejects it. Not specific to this recipe — `permissions-aware-retrieval` uses the same field, so `recipes:compile` would have broken here the moment that rename synced. One optional boolean, and #655 needs it too — `incident-copilot` declares the same field.

### Follow-up worth someone owning

The three stale pages above are a real mismatch: page filename must equal recipe id, and the cookbook renamed `acme-answers` → `company-answers` and `permissions-aware-rag` → `permissions-aware-retrieval`, and retired `index-custom-source` to `examples/sample-catalog`. Left alone here to keep this PR reviewable. Happy to take it in a follow-up if nobody's already on it.

### Verification

`pnpm recipes:compile` generates 11 recipes from 11 registry entries. `pnpm test` green (181 passed). Prettier clean. The `snippets/typescript/snippet-08.ts` typecheck errors are pre-existing on `main` and untouched here.
