### PR TITLE
Add the incident-copilot cookbook page

### DIFF
--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -401,6 +401,149 @@
     "tags": ["embed", "web-sdk"]
   },
   {
+    "id": "incident-copilot",
+    "title": "On-call copilot with a real approval gate",
+    "description": "Triage an incident from your own runbooks and past incidents, propose one pre-registered action, and let a human approve it — where the gate refuses the wrong person, expiry escalates instead of auto-approving, and every attempt is audited.",
+    "sidebarLabel": "Incident copilot",
+    "surfaces": ["platform-api", "agents", "tools"],
+    "status": "showcase",
+    "category": "agent",
+    "level": "Advanced",
+    "levels": {
+      "minimal": true,
+      "wow": true
+    },
+    "timeEstimate": "~1.5 hr",
+    "icon": "badge",
+    "requiredScopes": ["SEARCH", "CHAT", "AGENTS"],
+    "authMethod": ["client-api-oauth-or-token"],
+    "buildMethod": "scaffold",
+    "languages": ["typescript"],
+    "prerequisites": [
+      "A Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
+      "Your own OAuth access token or Glean API token with SEARCH and CHAT scopes (add AGENTS for the agent-orchestrated path)",
+      "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+      "Node 20+"
+    ],
+    "demoQueries": [
+      {
+        "query": "Triage the payments canary alarm",
+        "expectedBehavior": "The copilot acks in the channel, resolves payments-service to its on-call engineer and owner from the service catalog, fans out retrieval, and posts a triage card. The past canary incident is cited as the precedent that supports a probable cause; the deploy runbook is cited only as the basis for the proposed action. One pre-registered action is offered, awaiting approval, with an expiry deadline."
+      },
+      {
+        "query": "Triage an alarm with no matching past incident",
+        "expectedBehavior": "The deploy runbook is the single highest-scoring document retrieved, so a relevance-ranked copilot would blame a deploy — but no deploy is in flight and no past incident matches the signature. This copilot asserts no cause, and the mutating action (draft a fix) is downgraded to filing a ticket, visibly and in the audit log, because you cannot draft a fix for a cause nobody established."
+      },
+      {
+        "query": "Approve the proposed action as someone who is not on call",
+        "expectedBehavior": "Refused with 403 and audited against that actor. The allowed set is the on-call engineer and service owner read from the service catalog, not a config file. The incident stays awaiting approval. Note the recipe implements authorization, not authentication — see the README.",
+        "permissionDifferentiated": true
+      },
+      {
+        "query": "Let the approval window expire",
+        "expectedBehavior": "The proposal escalates to the escalation target named in the service catalog and is NOT executed. Auto-approving on timeout would invert the point of a gate. The escalation is audited and posted to the channel."
+      },
+      {
+        "query": "Have the Glean agent propose an action that is not registered",
+        "expectedBehavior": "The proposal is refused at proposal time and audited, and no approval card is offered. An agent that can describe arbitrary actions into existence is an agent with production access, whatever its prompt says."
+      }
+    ],
+    "codeAssets": [
+      {
+        "repoPath": "recipes/incident-copilot",
+        "language": "typescript",
+        "description": "Webhook → service registry → retrieval fan-out → evidence classification → triage card → approval gate (authz, expiry, escalation, audit) → pre-registered actions → postmortem timeline. Both orchestrators render into one shell."
+      }
+    ],
+    "steps": [
+      {
+        "title": "Scaffold the project",
+        "command": "npx tiged --mode=git gleanwork/glean-cookbook/recipes/incident-copilot incident-copilot"
+      },
+      {
+        "title": "Install dependencies",
+        "command": "cd incident-copilot && npm install"
+      },
+      {
+        "title": "Watch the governance hold, with no credentials",
+        "command": "npm run verify:fixture",
+        "description": "Replays recorded responses and asserts the parts that matter: the gate refuses the wrong actor, expiry escalates without executing, an unregistered action is refused, a mutating action with no supported cause is downgraded, and every attempt is audited."
+      },
+      {
+        "title": "Set credentials",
+        "command": "cp .env.example .env",
+        "description": "Fill in GLEAN_INSTANCE and your own GLEAN_API_TOKEN. Optionally set GLEAN_AGENT_ID for the agent-orchestrated path, and INCIDENT_ACTOR to change who the dashboard acts as."
+      },
+      {
+        "title": "Run it",
+        "command": "npm start"
+      },
+      {
+        "title": "Verify",
+        "description": "Fire the sample alarm and check three things: the probable cause cites a past incident rather than a runbook, approving as someone who is not on call returns 403, and forcing expiry escalates without executing anything."
+      }
+    ],
+    "combines": [
+      {
+        "title": "Multi-step agent with governed tools",
+        "surface": "Agents API",
+        "category": "agent",
+        "language": "typescript"
+      },
+      {
+        "title": "Permissions-aware retrieval",
+        "surface": "Platform API",
+        "category": "search",
+        "language": "typescript"
+      }
+    ],
+    "architecture": [
+      {
+        "label": "PagerDuty webhook",
+        "caption": "severity + service filter",
+        "category": "workflow",
+        "icon": "plug"
+      },
+      {
+        "label": "Service registry",
+        "caption": "owner, runbook, escalation",
+        "category": "index"
+      },
+      {
+        "label": "Glean",
+        "caption": "permission-aware index",
+        "emphasized": true
+      },
+      {
+        "label": "Evidence check",
+        "caption": "precedent vs procedure",
+        "category": "search",
+        "icon": "badge"
+      },
+      {
+        "label": "Approval gate",
+        "caption": "authz, expiry, audit",
+        "category": "portal"
+      },
+      {
+        "label": "Governed actions",
+        "caption": "pre-registered only",
+        "category": "agent"
+      }
+    ],
+    "aiPrompt": "Build an on-call incident copilot on the Glean Platform API following the incident-copilot recipe. Resolve the alarming service to its owner, on-call engineer and escalation path from an indexed service catalog before retrieving anything. Fan out retrieval, then classify every retrieved document by the role it can play in an argument: a past incident with a matching alarm signature is a precedent and is the only thing that may support a claim about cause; a runbook is procedure and may only license a proposed action; everything else is context. Do not rank probable cause by relevance -- on a real corpus the runbook outranks the precedent because it is dense with the alarm's own vocabulary while containing no information about why anything broke. Assert no cause when no precedent matches. Gate every action behind a human: restrict approval to the on-call engineer and service owners from the catalog, expire unapproved proposals into an escalation that does not execute, allow only pre-registered actions, require an evidence-supported cause before any mutating action, and write an audit entry for every attempt including refusals and failures.",
+    "llmContext": "Platform Search POST /api/search -> results[].{title,url,snippets}. Platform Chat POST /api/chat with { input, stream: false, store: true } -> output[].content[] where type === 'output_text', with .annotations[].sources[]. Platform Agents POST /api/agents/{agent_id}/runs with { messages: [{role:'USER',content:[{text,type:'text'}]}], stream: false } -> messages[].content[].text, synchronous, no polling. All require X-GLEAN-INCLUDE-EXPERIMENTAL: true and platform.apiMigratedEndpointsEnabled. Auth is the caller's own token; impersonation/act-as was removed from the cookbook recipes, so actions cannot execute as the approving user and the approval gate is an app-level policy check -- say so rather than implying per-person enforcement. Design findings worth carrying over: (1) relevance is not evidence -- classify documents by evidentiary role, because a runbook always outranks the precedent for alarm-shaped queries; (2) a mutating action requires an evidence-supported cause, or the same relevance-is-not-evidence mistake reappears in the action choice; (3) expiry must escalate rather than auto-approve; (4) authorization (who may approve) and authentication (proving who you are) are different problems and this recipe only implements the first.",
+    "goDependency": false,
+    "featured": true,
+    "tags": [
+      "incident-response",
+      "human-in-the-loop",
+      "governed-actions",
+      "audit",
+      "agent"
+    ]
+  },
+  {
     "id": "index-custom-source",
     "title": "Index a custom data source",
     "description": "Bring an unsupported source into Glean with the Indexing API — documents, permissions, and people — and see it live in search. This recipe seeds the Acme corpus every other recipe searches.",

--- a/docs/cookbook/incident-copilot.mdx
+++ b/docs/cookbook/incident-copilot.mdx
@@ -1,0 +1,111 @@
+---
+hide_table_of_contents: true
+hide_title: true
+pagination_prev: null
+pagination_next: null
+---
+
+import RecipePage from '@site/src/components/Cookbook/RecipePage';
+import {
+  RecipeSection,
+  RecipePrereqs,
+  RecipeSteps,
+  TakeItFurther,
+} from '@site/src/components/Cookbook/RecipeLayout';
+
+<RecipePage recipeId="incident-copilot">
+
+<RecipeSection label="Problem">
+
+An alarm fires at 3am. Everything the responder needs already exists — the runbook,
+the review of the last time this happened, who owns the service, what it depends on
+— scattered across systems they now have to search one at a time, while the graphs
+get worse.
+
+The retrieval is the easy part. What makes an incident copilot safe to point at a
+production service is everything that refuses: a gate that turns away the wrong
+person, an expiry that escalates instead of quietly approving itself, an action
+registry the planner cannot talk its way out of, and an audit entry for every
+attempt including the ones that were refused.
+
+</RecipeSection>
+
+<RecipePrereqs />
+
+<RecipeSteps />
+
+<RecipeSection label="Relevance is not evidence">
+
+The obvious way to build "probable cause, ranked by evidence" is to rank retrieved
+documents by relevance and explain the top one. That produces confident wrong root
+causes, and it does so structurally rather than occasionally.
+
+A canary alarm on a payments service retrieves the deploy-and-rollback runbook at or
+near the top of any ranking, because that runbook is _dense with the alarm's own
+vocabulary_ — canary, rollout, error rate, authorization failure rate. It is
+genuinely the most relevant document in the corpus. It also contains nothing about
+why this particular deploy broke. It is procedure.
+
+Measured on the sample corpus:
+
+| Alarm                     | Top-scoring document           | Score    | Matching precedent            |
+| ------------------------- | ------------------------------ | -------- | ----------------------------- |
+| canary, deploy in flight  | past incident review           | 1.00     | yes — cause asserted          |
+| queue saturation, no deploy | **deploy & rollback runbook** | **0.40** | no (0.20) — no cause asserted |
+
+On the second alarm the runbook outranks everything, and there is no deploy in
+flight. A relevance-ranked copilot tells the on-call engineer that a deploy caused an
+incident which happened while nothing was deploying.
+
+So documents carry an **evidentiary role**, and roles have different powers. A
+`precedent` — a past incident whose signature matches — is the only thing that may
+license a claim about **cause**, because it is the only kind of document that records
+one. A `procedure` may license a proposed **action**. `context` gives you ownership
+and topology. No matching precedent means no cause is asserted, which is a correct
+outcome rather than a gap.
+
+Role comes from where a document lives, not from what it says. Inferring a document's
+evidentiary standing from its prose is exactly the inference this design exists to
+avoid.
+
+**The same mistake reappears one layer down.** That rule alone still produced a
+"draft a fix" card for the no-precedent alarm, because the runbook mentions
+rollbacks. So a mutating action requires an evidence-supported cause, and is
+otherwise downgraded to filing a ticket — visibly, in the channel and the audit log.
+You cannot draft a fix for a cause nobody established.
+
+</RecipeSection>
+
+<RecipeSection label="Authorization is not authentication">
+
+The approval gate enforces _who may approve_, read from the indexed service catalog:
+the on-call engineer and the service owners, nobody else. It does **not**
+authenticate — the acting user is asserted, so you can watch the gate refuse you
+without restarting anything.
+
+Those are different problems. This recipe solves the first; a deployment must solve
+the second before trusting the first, or it has an approval gate anyone can walk
+through by setting a header.
+
+Relatedly, actions do not execute _as the approving user_. Impersonation is not part
+of these recipes, so the executor is the app's own credential and the gate is an
+app-level policy check. That is a weaker claim than per-person permission
+enforcement, and worth stating plainly rather than implying.
+
+</RecipeSection>
+
+<TakeItFurther>
+
+<>Persist incidents and the audit log. An audit log you can lose by restarting a process is not an audit log.</>
+
+<>Add the rest of the dashboard: response-time rollups, an expiring-soon lane, and an end-of-shift handoff summary.</>
+
+<>Replace the simulated actions with real governed tools, keeping the registry boundary and the approval log exactly where they are.</>
+
+<>Write the postmortem draft back into your knowledge base so the next incident retrieves it as a precedent — the loop that makes the evidence rules get better over time.</>
+
+<>Expose the copilot itself over A2A so another agent can request triage, with the same gate in front of every action.</>
+
+</TakeItFurther>
+
+</RecipePage>

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -507,6 +507,168 @@
       "permalink": "/cookbook/embed-search-chat"
     },
     {
+      "id": "incident-copilot",
+      "title": "On-call copilot with a real approval gate",
+      "description": "Triage an incident from your own runbooks and past incidents, propose one pre-registered action, and let a human approve it — where the gate refuses the wrong person, expiry escalates instead of auto-approving, and every attempt is audited.",
+      "sidebarLabel": "Incident copilot",
+      "surfaces": [
+        "platform-api",
+        "agents",
+        "tools"
+      ],
+      "status": "showcase",
+      "category": "agent",
+      "level": "Advanced",
+      "levels": {
+        "minimal": true,
+        "wow": true
+      },
+      "timeEstimate": "~1.5 hr",
+      "icon": "badge",
+      "requiredScopes": [
+        "SEARCH",
+        "CHAT",
+        "AGENTS"
+      ],
+      "authMethod": [
+        "client-api-oauth-or-token"
+      ],
+      "buildMethod": "scaffold",
+      "languages": [
+        "typescript"
+      ],
+      "prerequisites": [
+        "A Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
+        "Your own OAuth access token or Glean API token with SEARCH and CHAT scopes (add AGENTS for the agent-orchestrated path)",
+        "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+        "Node 20+"
+      ],
+      "demoQueries": [
+        {
+          "query": "Triage the payments canary alarm",
+          "expectedBehavior": "The copilot acks in the channel, resolves payments-service to its on-call engineer and owner from the service catalog, fans out retrieval, and posts a triage card. The past canary incident is cited as the precedent that supports a probable cause; the deploy runbook is cited only as the basis for the proposed action. One pre-registered action is offered, awaiting approval, with an expiry deadline."
+        },
+        {
+          "query": "Triage an alarm with no matching past incident",
+          "expectedBehavior": "The deploy runbook is the single highest-scoring document retrieved, so a relevance-ranked copilot would blame a deploy — but no deploy is in flight and no past incident matches the signature. This copilot asserts no cause, and the mutating action (draft a fix) is downgraded to filing a ticket, visibly and in the audit log, because you cannot draft a fix for a cause nobody established."
+        },
+        {
+          "query": "Approve the proposed action as someone who is not on call",
+          "expectedBehavior": "Refused with 403 and audited against that actor. The allowed set is the on-call engineer and service owner read from the service catalog, not a config file. The incident stays awaiting approval. Note the recipe implements authorization, not authentication — see the README.",
+          "permissionDifferentiated": true
+        },
+        {
+          "query": "Let the approval window expire",
+          "expectedBehavior": "The proposal escalates to the escalation target named in the service catalog and is NOT executed. Auto-approving on timeout would invert the point of a gate. The escalation is audited and posted to the channel."
+        },
+        {
+          "query": "Have the Glean agent propose an action that is not registered",
+          "expectedBehavior": "The proposal is refused at proposal time and audited, and no approval card is offered. An agent that can describe arbitrary actions into existence is an agent with production access, whatever its prompt says."
+        }
+      ],
+      "codeAssets": [
+        {
+          "repoPath": "recipes/incident-copilot",
+          "language": "typescript",
+          "description": "Webhook → service registry → retrieval fan-out → evidence classification → triage card → approval gate (authz, expiry, escalation, audit) → pre-registered actions → postmortem timeline. Both orchestrators render into one shell."
+        }
+      ],
+      "scaffoldActions": [],
+      "steps": [
+        {
+          "title": "Scaffold the project",
+          "command": "npx tiged --mode=git gleanwork/glean-cookbook/recipes/incident-copilot incident-copilot"
+        },
+        {
+          "title": "Install dependencies",
+          "command": "cd incident-copilot && npm install"
+        },
+        {
+          "title": "Watch the governance hold, with no credentials",
+          "description": "Replays recorded responses and asserts the parts that matter: the gate refuses the wrong actor, expiry escalates without executing, an unregistered action is refused, a mutating action with no supported cause is downgraded, and every attempt is audited.",
+          "command": "npm run verify:fixture"
+        },
+        {
+          "title": "Set credentials",
+          "description": "Fill in GLEAN_INSTANCE and your own GLEAN_API_TOKEN. Optionally set GLEAN_AGENT_ID for the agent-orchestrated path, and INCIDENT_ACTOR to change who the dashboard acts as.",
+          "command": "cp .env.example .env"
+        },
+        {
+          "title": "Run it",
+          "command": "npm start"
+        },
+        {
+          "title": "Verify",
+          "description": "Fire the sample alarm and check three things: the probable cause cites a past incident rather than a runbook, approving as someone who is not on call returns 403, and forcing expiry escalates without executing anything."
+        }
+      ],
+      "combines": [
+        {
+          "title": "Multi-step agent with governed tools",
+          "surface": "Agents API",
+          "category": "agent",
+          "language": "typescript"
+        },
+        {
+          "title": "Permissions-aware retrieval",
+          "surface": "Platform API",
+          "category": "search",
+          "language": "typescript"
+        }
+      ],
+      "architecture": [
+        {
+          "label": "PagerDuty webhook",
+          "caption": "severity + service filter",
+          "category": "workflow",
+          "icon": "plug",
+          "emphasized": false
+        },
+        {
+          "label": "Service registry",
+          "caption": "owner, runbook, escalation",
+          "category": "index",
+          "emphasized": false
+        },
+        {
+          "label": "Glean",
+          "caption": "permission-aware index",
+          "emphasized": true
+        },
+        {
+          "label": "Evidence check",
+          "caption": "precedent vs procedure",
+          "category": "search",
+          "icon": "badge",
+          "emphasized": false
+        },
+        {
+          "label": "Approval gate",
+          "caption": "authz, expiry, audit",
+          "category": "portal",
+          "emphasized": false
+        },
+        {
+          "label": "Governed actions",
+          "caption": "pre-registered only",
+          "category": "agent",
+          "emphasized": false
+        }
+      ],
+      "aiPrompt": "Build an on-call incident copilot on the Glean Platform API following the incident-copilot recipe. Resolve the alarming service to its owner, on-call engineer and escalation path from an indexed service catalog before retrieving anything. Fan out retrieval, then classify every retrieved document by the role it can play in an argument: a past incident with a matching alarm signature is a precedent and is the only thing that may support a claim about cause; a runbook is procedure and may only license a proposed action; everything else is context. Do not rank probable cause by relevance -- on a real corpus the runbook outranks the precedent because it is dense with the alarm's own vocabulary while containing no information about why anything broke. Assert no cause when no precedent matches. Gate every action behind a human: restrict approval to the on-call engineer and service owners from the catalog, expire unapproved proposals into an escalation that does not execute, allow only pre-registered actions, require an evidence-supported cause before any mutating action, and write an audit entry for every attempt including refusals and failures.",
+      "llmContext": "Platform Search POST /api/search -> results[].{title,url,snippets}. Platform Chat POST /api/chat with { input, stream: false, store: true } -> output[].content[] where type === 'output_text', with .annotations[].sources[]. Platform Agents POST /api/agents/{agent_id}/runs with { messages: [{role:'USER',content:[{text,type:'text'}]}], stream: false } -> messages[].content[].text, synchronous, no polling. All require X-GLEAN-INCLUDE-EXPERIMENTAL: true and platform.apiMigratedEndpointsEnabled. Auth is the caller's own token; impersonation/act-as was removed from the cookbook recipes, so actions cannot execute as the approving user and the approval gate is an app-level policy check -- say so rather than implying per-person enforcement. Design findings worth carrying over: (1) relevance is not evidence -- classify documents by evidentiary role, because a runbook always outranks the precedent for alarm-shaped queries; (2) a mutating action requires an evidence-supported cause, or the same relevance-is-not-evidence mistake reappears in the action choice; (3) expiry must escalate rather than auto-approve; (4) authorization (who may approve) and authentication (proving who you are) are different problems and this recipe only implements the first.",
+      "goDependency": false,
+      "featured": true,
+      "tags": [
+        "incident-response",
+        "human-in-the-loop",
+        "governed-actions",
+        "audit",
+        "agent"
+      ],
+      "permalink": "/cookbook/incident-copilot"
+    },
+    {
       "id": "index-custom-source",
       "title": "Index a custom data source",
       "description": "Bring an unsupported source into Glean with the Indexing API — documents, permissions, and people — and see it live in search. This recipe seeds the Acme corpus every other recipe searches.",
@@ -1148,7 +1310,7 @@
     "agents"
   ],
   "generatedAt": "2026-07-28T00:00:00.000Z",
-  "totalRecipes": 11,
+  "totalRecipes": 12,
   "plugin": {
     "marketplaceName": "glean-cookbook",
     "pluginName": "cookbook",


### PR DESCRIPTION
**BLUF (stack):** Publish cookbook pages for the two remaining Glean:GO sample apps.

**BLUF (this PR):** Adds the cookbook page for the `incident-copilot` recipe.

[PACT-452](https://linear.app/gleanwork/issue/PACT-452). Steps, prereqs, scopes and demo queries render from the recipe registry, so the mdx carries only what the registry can't hold. Pairs with gleanwork/glean-cookbook#4.

## Stack

1. **main**
2. #654 — rfp-responder page + registry schema fix
3. 👉 #655 — incident-copilot page

### Details

Beyond the problem statement, the page makes the recipe's central argument, because it generalises past this one app:

**Relevance is not evidence.** A canary alarm retrieves the deploy-and-rollback runbook at the top of any ranking, because that runbook is dense with the alarm's own vocabulary while containing nothing about why this deploy broke. On the sample corpus, an alarm with no precedent (queue saturation, no deploy in flight) puts the runbook highest at 0.40 while the only past incident falls to 0.20 — so a relevance-ranked copilot blames a deploy that never happened. Documents therefore carry an evidentiary role: only a matching past incident may license a claim about cause; a runbook may license a proposed action.

**Authorization is not authentication.** The gate enforces who may approve, read from the indexed service catalog, but does not authenticate. Stated plainly on the page because a reader who copies the pattern without noticing has built a gate anyone can walk through.

Two mechanical changes, same shape as #654:

**Registry snapshot, inserted in alphabetical position.** The page can't compile without a matching entry, and `registry:sync` fetches from the cookbook repo's `main` where this recipe hasn't merged. Inserted at its sorted position so the file matches what the real sync will produce, leaving every existing byte untouched — the diff is pure addition. Deliberately only that entry: a full sync today would drop `acme-answers`, `index-custom-source` and `permissions-aware-rag`, whose pages still exist here under pre-rename ids, and break the build.

**Depends on #654's zod schema change.** `incident-copilot` also declares `demoQueries[].permissionDifferentiated`, which `recipeMetaSchema` rejects until that lands. That's why this is stacked rather than independent.

### Verification

`pnpm recipes:compile` generates 12 recipes from 12 registry entries. Full `pnpm build` passes locally, including Docusaurus broken-link checking. `pnpm test` green (181 passed). The `snippets/typescript/snippet-08.ts` typecheck errors are pre-existing on `main` and untouched.

**Note on the empty checks list:** `ci.yml` is scoped to `pull_request: branches: [main]`, so a PR targeting a stacked base gets no automatic CI — the absence of checks here is the trigger config, not a skipped build. Triggered manually via `workflow_dispatch` on this branch and Test Build passed: [run 30859440951](https://github.com/gleanwork/glean-developer-site/actions/runs/30859440951). Checks will run normally once this retargets to `main` after #654 merges. Vercel is red on every PR I open, including ones that have merged (#602) — an account authorization thing, not this change.
