### PR TITLE
Fix a find-and-replace artifact on the rfp-responder page

### DIFF
--- a/docs/cookbook/rfp-responder.mdx
+++ b/docs/cookbook/rfp-responder.mdx
@@ -75,9 +75,10 @@ single-user — and makes the guarantee real: content you can't see can't reach 
 customer's document. Empty retrieval produces a refusal, not an answer from the
 model's own knowledge.
 
-The sample corpus demonstrates it. The a customer security response summary is
-restricted to a single group; run as someone outside it and every security row
-collapses to "needs SME" instead of quietly answering from somewhere else.
+Any restricted document demonstrates it. A security response summary readable by
+only one group collapses every security row to "needs SME" when the questionnaire
+is run as someone outside that group, instead of quietly answering from somewhere
+else.
 
 </RecipeSection>
 


### PR DESCRIPTION
**BLUF:** One sentence on the live `rfp-responder` page reads "The **a customer** security response summary".

De-naming the demo corpus in #658 left an article behind. Currently on `main` at `docs/cookbook/rfp-responder.mdx:78`.

I reworded the sentence rather than just repairing the article, because it had a second problem: it opened with "The sample corpus demonstrates it" — pointing the reader at the one dataset that same rewrite was removing dependencies on. Since `examples/sample-catalog` is an opt-in Indexing SDK dataset that has to be seeded first, a reader following the page has nothing to look at.

```diff
-The sample corpus demonstrates it. The a customer security response summary is
-restricted to a single group; run as someone outside it and every security row
-collapses to "needs SME" instead of quietly answering from somewhere else.
+Any restricted document demonstrates it. A security response summary readable by
+only one group collapses every security row to "needs SME" when the questionnaire
+is run as someone outside that group, instead of quietly answering from somewhere
+else.
```

The claim was never specific to that corpus — it holds for any group-restricted document — so it now says that, and works with content the reader already has.

Prose only: one file, +4/-3, no generated data touched (`check-generated-recipe-data.mjs` reports "untouched"). Full `pnpm build` passes including broken-link checking. I also grepped the other cookbook pages for similar double-article artifacts; this was the only one.