### PR TITLE
feat(cookbook): add recipe execution contracts

### DIFF
--- a/.github/workflows/sync-cookbook-registry.yml
+++ b/.github/workflows/sync-cookbook-registry.yml
@@ -1,6 +1,12 @@
 name: Sync Cookbook Registry
 
 on:
+  # The cookbook cannot dispatch across repositories with its scoped
+  # GITHUB_TOKEN. Poll the canonical registry so cookbook merges still
+  # produce a generated dev-site PR without a person remembering to sync.
+  schedule:
+    - cron: '*/15 * * * *'
+
   workflow_dispatch:
     inputs:
       reason:
@@ -55,7 +61,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "📋 Syncing recipe registry..."
-          echo "Reason: ${{ github.event.inputs.reason }}"
+          echo "Reason: ${{ github.event.inputs.reason || 'Scheduled cookbook sync' }}"
           pnpm registry:sync
           pnpm recipes:compile
           echo "✅ Registry synced and recipes recompiled"
@@ -88,7 +94,7 @@ jobs:
           body: |
             ## 🔄 Cookbook Registry Sync
 
-            **Trigger reason**: ${{ github.event.inputs.reason }}
+            **Trigger reason**: ${{ github.event.inputs.reason || 'Scheduled cookbook sync' }}
             **Triggered by**: ${{ github.actor }}
             **Run ID**: [${{ github.run_id }}](https://github.com/gleanwork/glean-developer-site/actions/runs/${{ github.run_id }})
 

--- a/schemas/recipe.schema.json
+++ b/schemas/recipe.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://developers.glean.com/schemas/recipe.schema.json",
   "title": "Glean Cookbook Recipe",
-  "description": "The `recipe` frontmatter block of a cookbook recipe MDX file. Generated from src/types/recipe.ts — do not edit by hand.",
+  "description": "Validation contract for recipe records authored in gleanwork/glean-cookbook at recipes/<id>/recipe.json. Generated from src/types/recipe.ts — do not edit by hand.",
   "type": "object",
   "properties": {
     "id": {
@@ -153,12 +153,281 @@
             "type": "string",
             "minLength": 1
           },
+          "execution": {
+            "type": "object",
+            "properties": {
+              "questions": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[a-z][a-z0-9-]*$"
+                    },
+                    "prompt": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "required": {
+                      "default": true,
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["id", "prompt"],
+                  "additionalProperties": false
+                }
+              },
+              "auth": {
+                "minItems": 1,
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "type": "string",
+                      "enum": [
+                        "none",
+                        "browser-cookie",
+                        "oauth-with-token-fallback",
+                        "host-managed",
+                        "hosted-secret",
+                        "external-api-key",
+                        "indexing-token"
+                      ]
+                    },
+                    "scopes": {
+                      "default": [],
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    },
+                    "setupCommand": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "configFile": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "backendVariable": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "credentialVariable": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["kind"],
+                  "additionalProperties": false
+                }
+              },
+              "verification": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "automated"
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expectedDuration": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "startsOwnServer": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["kind", "command", "expectedDuration"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "user-browser"
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expectedDuration": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "startsOwnServer": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["kind", "expectedDuration"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "third-party"
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expectedDuration": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "startsOwnServer": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["kind", "expectedDuration"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "manual-admin"
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expectedDuration": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "startsOwnServer": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["kind", "expectedDuration"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "manual"
+                      },
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "expectedDuration": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "startsOwnServer": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["kind", "expectedDuration"],
+                    "additionalProperties": false
+                  }
+                ]
+              },
+              "run": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "url": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "userBrowser": {
+                        "default": false,
+                        "type": "boolean",
+                        "const": false
+                      }
+                    },
+                    "required": ["command"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "command": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "url": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "userBrowser": {
+                        "default": false,
+                        "type": "boolean"
+                      }
+                    },
+                    "required": ["url"],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "type": "string",
+                        "const": "existing-app"
+                      },
+                      "userBrowser": {
+                        "type": "boolean",
+                        "const": true
+                      }
+                    },
+                    "required": ["kind", "userBrowser"],
+                    "additionalProperties": false
+                  }
+                ]
+              }
+            },
+            "required": ["auth", "verification"],
+            "additionalProperties": false
+          },
           "steps": {
             "minItems": 1,
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
+                "kind": {
+                  "type": "string",
+                  "enum": [
+                    "choose",
+                    "scaffold",
+                    "install",
+                    "configure",
+                    "authenticate",
+                    "verify-fixture",
+                    "verify-live",
+                    "run",
+                    "manual",
+                    "handoff"
+                  ]
+                },
                 "title": {
                   "type": "string",
                   "minLength": 1
@@ -200,6 +469,21 @@
       "items": {
         "type": "object",
         "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "choose",
+              "scaffold",
+              "install",
+              "configure",
+              "authenticate",
+              "verify-fixture",
+              "verify-live",
+              "run",
+              "manual",
+              "handoff"
+            ]
+          },
           "title": {
             "type": "string",
             "minLength": 1
@@ -216,6 +500,260 @@
         "required": ["title"],
         "additionalProperties": false
       }
+    },
+    "execution": {
+      "type": "object",
+      "properties": {
+        "questions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "pattern": "^[a-z][a-z0-9-]*$"
+              },
+              "prompt": {
+                "type": "string",
+                "minLength": 1
+              },
+              "required": {
+                "default": true,
+                "type": "boolean"
+              }
+            },
+            "required": ["id", "prompt"],
+            "additionalProperties": false
+          }
+        },
+        "auth": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "none",
+                  "browser-cookie",
+                  "oauth-with-token-fallback",
+                  "host-managed",
+                  "hosted-secret",
+                  "external-api-key",
+                  "indexing-token"
+                ]
+              },
+              "scopes": {
+                "default": [],
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "setupCommand": {
+                "type": "string",
+                "minLength": 1
+              },
+              "configFile": {
+                "type": "string",
+                "minLength": 1
+              },
+              "backendVariable": {
+                "type": "string",
+                "minLength": 1
+              },
+              "credentialVariable": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": ["kind"],
+            "additionalProperties": false
+          }
+        },
+        "verification": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "automated"
+                },
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expectedDuration": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "startsOwnServer": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["kind", "command", "expectedDuration"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "user-browser"
+                },
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expectedDuration": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "startsOwnServer": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["kind", "expectedDuration"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "third-party"
+                },
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expectedDuration": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "startsOwnServer": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["kind", "expectedDuration"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "manual-admin"
+                },
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expectedDuration": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "startsOwnServer": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["kind", "expectedDuration"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "manual"
+                },
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "expectedDuration": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "startsOwnServer": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["kind", "expectedDuration"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "run": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "userBrowser": {
+                  "default": false,
+                  "type": "boolean",
+                  "const": false
+                }
+              },
+              "required": ["command"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "url": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "userBrowser": {
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "required": ["url"],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "const": "existing-app"
+                },
+                "userBrowser": {
+                  "type": "boolean",
+                  "const": true
+                }
+              },
+              "required": ["kind", "userBrowser"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": ["auth", "verification"],
+      "additionalProperties": false
     },
     "combines": {
       "type": "array",

--- a/scripts/generate-recipe-schema.ts
+++ b/scripts/generate-recipe-schema.ts
@@ -22,7 +22,7 @@ const artifact = {
   $id: 'https://developers.glean.com/schemas/recipe.schema.json',
   title: 'Glean Cookbook Recipe',
   description:
-    'The `recipe` frontmatter block of a cookbook recipe MDX file. Generated from src/types/recipe.ts — do not edit by hand.',
+    'Validation contract for recipe records authored in gleanwork/glean-cookbook at recipes/<id>/recipe.json. Generated from src/types/recipe.ts — do not edit by hand.',
   ...jsonSchema,
 };
 

--- a/src/types/recipe.test.ts
+++ b/src/types/recipe.test.ts
@@ -44,6 +44,110 @@ describe('parseRecipeEntry', () => {
     expect(result.record.sidebarLabel).toBe('Embed');
   });
 
+  it('accepts a path-level customer execution contract', () => {
+    const entry = {
+      ...validEntry(),
+      execution: {
+        questions: [
+          {
+            id: 'email',
+            prompt: 'What is your work email?',
+          },
+        ],
+        auth: [
+          {
+            kind: 'oauth-with-token-fallback',
+            scopes: ['CHAT'],
+            setupCommand: 'npm run login',
+            configFile: '.env',
+            backendVariable: 'GLEAN_SERVER_URL',
+            credentialVariable: 'GLEAN_API_TOKEN',
+          },
+        ],
+        verification: {
+          kind: 'automated',
+          command: 'npm run verify',
+          expectedDuration: '1–3 minutes',
+          startsOwnServer: true,
+        },
+        run: {
+          command: 'npm start',
+          url: 'http://localhost:3000',
+          userBrowser: true,
+        },
+      },
+    };
+    const result = parseRecipeEntry(entry, 'embed-search-chat');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.record.execution?.auth[0].kind).toBe(
+      'oauth-with-token-fallback',
+    );
+  });
+
+  it('requires an executable command for automated verification', () => {
+    const entry = {
+      ...validEntry(),
+      execution: {
+        auth: [{ kind: 'none' }],
+        verification: {
+          kind: 'automated',
+          expectedDuration: 'about 1 minute',
+        },
+      },
+    };
+    expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(false);
+  });
+
+  it('accepts explicit manual verification without a command', () => {
+    const entry = {
+      ...validEntry(),
+      execution: {
+        auth: [{ kind: 'none' }],
+        verification: {
+          kind: 'manual',
+          expectedDuration: 'about 1 minute',
+        },
+      },
+    };
+    expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(true);
+  });
+
+  it('rejects run handoffs with no command or URL', () => {
+    for (const run of [{}, { userBrowser: true }]) {
+      const entry = {
+        ...validEntry(),
+        execution: {
+          auth: [{ kind: 'none' }],
+          verification: {
+            kind: 'manual',
+            expectedDuration: 'about 1 minute',
+          },
+          run,
+        },
+      };
+      expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(false);
+    }
+  });
+
+  it('accepts an explicit existing-app browser handoff', () => {
+    const entry = {
+      ...validEntry(),
+      execution: {
+        auth: [{ kind: 'browser-cookie' }],
+        verification: {
+          kind: 'user-browser',
+          expectedDuration: 'about 1 minute',
+        },
+        run: {
+          kind: 'existing-app',
+          userBrowser: true,
+        },
+      },
+    };
+    expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(true);
+  });
+
   it('rejects unknown top-level keys', () => {
     const entry = { ...validEntry(), surprise: true };
     const result = parseRecipeEntry(entry, 'embed-search-chat');

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
 /**
- * Recipe schema — the single source of truth for the Cookbooks section.
+ * Dev-site validation contract for cookbook recipe metadata.
  *
- * A recipe's metadata lives in `glean-cookbook`'s `registry.json`, synced
+ * Recipe records are authored only in `glean-cookbook` at
+ * `recipes/<id>/recipe.json`, compiled into that repo's `registry.json`, and synced
  * locally to `data/cookbook-registry.json` (see `scripts/sync-registry.mjs`).
  * The matching `docs/cookbook/{id}.mdx` file is prose-only — no metadata
  * frontmatter — and is matched to its registry entry by filename === id.
@@ -17,7 +18,8 @@ import { z } from 'zod';
  * across repos and consumers, not Docusaurus frontmatter.
  *
  * `schemas/recipe.schema.json` is generated from this file via
- * `pnpm recipes:schema` — do not edit that artifact by hand.
+ * `pnpm recipes:schema` for cookbook authoring validation. This file defines the
+ * contract; it is not a second store of recipe content.
  */
 
 export const RECIPE_SURFACES = [
@@ -132,6 +134,89 @@ export const RECIPE_CATEGORIES = [
 
 export const RECIPE_LEVELS = ['Beginner', 'Intermediate', 'Advanced'] as const;
 
+export const RECIPE_STEP_KINDS = [
+  'choose',
+  'scaffold',
+  'install',
+  'configure',
+  'authenticate',
+  'verify-fixture',
+  'verify-live',
+  'run',
+  'manual',
+  'handoff',
+] as const;
+
+export const recipeQuestionSchema = z.strictObject({
+  id: z.string().regex(/^[a-z][a-z0-9-]*$/),
+  prompt: z.string().min(1),
+  required: z.boolean().default(true),
+});
+
+const recipeVerificationFields = {
+  expectedDuration: z.string().min(1),
+  startsOwnServer: z.boolean().default(false),
+};
+
+export const recipeVerificationSchema = z.discriminatedUnion('kind', [
+  z.strictObject({
+    kind: z.literal('automated'),
+    command: z.string().min(1),
+    ...recipeVerificationFields,
+  }),
+  ...(['user-browser', 'third-party', 'manual-admin', 'manual'] as const).map(
+    (kind) =>
+      z.strictObject({
+        kind: z.literal(kind),
+        command: z.string().min(1).optional(),
+        ...recipeVerificationFields,
+      }),
+  ),
+]);
+
+export const recipeRunSchema = z.union([
+  z.strictObject({
+    command: z.string().min(1),
+    url: z.string().min(1).optional(),
+    userBrowser: z.literal(false).default(false),
+  }),
+  z.strictObject({
+    command: z.string().min(1).optional(),
+    url: z.string().min(1),
+    userBrowser: z.boolean().default(false),
+  }),
+  z.strictObject({
+    kind: z.literal('existing-app'),
+    userBrowser: z.literal(true),
+  }),
+]);
+
+export const recipeExecutionSchema = z.strictObject({
+  questions: z.array(recipeQuestionSchema).default([]),
+  auth: z
+    .array(
+      z.strictObject({
+        kind: z.enum([
+          'none',
+          'browser-cookie',
+          'oauth-with-token-fallback',
+          'host-managed',
+          'hosted-secret',
+          'external-api-key',
+          'indexing-token',
+        ]),
+        scopes: z.array(z.string().min(1)).default([]),
+        setupCommand: z.string().min(1).optional(),
+        configFile: z.string().min(1).optional(),
+        backendVariable: z.string().min(1).optional(),
+        credentialVariable: z.string().min(1).optional(),
+      }),
+    )
+    .min(1),
+  verification: recipeVerificationSchema,
+  run: recipeRunSchema.optional(),
+});
+
 /**
  * One step in a `buildMethod: 'scaffold'` recipe's real, runnable sequence.
  * `command` is a literal, copy-pasteable string when the step is one (a
@@ -141,6 +226,7 @@ export const RECIPE_LEVELS = ['Beginner', 'Intermediate', 'Advanced'] as const;
  * from this one source, instead of two independently hand-authored copies.
  */
 export const recipeStepSchema = z.strictObject({
+  kind: z.enum(RECIPE_STEP_KINDS).optional(),
   title: z.string().min(1),
   description: z.string().min(1).optional(),
   command: z.string().min(1).optional(),
@@ -150,6 +236,7 @@ export const recipeCodeAssetSchema = z.strictObject({
   repoPath: z.string().min(1),
   language: z.string().min(1),
   description: z.string().min(1),
+  execution: recipeExecutionSchema.optional(),
   /** Steps specific to this variant, for recipes with more than one (e.g. Web SDK vs. Chat API). */
   steps: z.array(recipeStepSchema).min(1).optional(),
 });
@@ -227,6 +314,8 @@ export const recipeMetaSchema = z.strictObject({
   scaffoldActions: z.array(z.enum(RECIPE_SCAFFOLD_ACTIONS)).default([]),
   /** Top-level runnable steps for `buildMethod: 'scaffold'` recipes with no variant split; variant-specific steps live on `codeAssets[].steps` instead. */
   steps: z.array(recipeStepSchema).min(1).optional(),
+  /** Customer setup contract when execution is not attached to a specific code asset. */
+  execution: recipeExecutionSchema.optional(),
   combines: z.array(recipeCombinesSchema).optional(),
   architecture: z.array(recipeArchitectureNodeSchema).optional(),
   aiPrompt: z.string().min(1),


### PR DESCRIPTION
## Summary
- add path-level recipe execution metadata for setup questions, auth, verification, and run handoff
- add typed recipe step phases
- generate the public JSON schema and cover the new contract in tests
- reject automated verification without a command and reject ambiguous run handoffs
- poll the cookbook every 15 minutes so canonical recipe changes produce a generated sync PR

## Source of truth
Recipe content is authored only in `gleanwork/glean-cookbook` at `recipes/<id>/recipe.json`. This repo syncs generated registry/page snapshots and owns the dev-site validation and presentation contract; it does not author recipe records.

## Rollout
The fields are optional so the current cookbook registry remains compatible. gleanwork/glean-cookbook#21 populates the hardened manual/existing-app branches and enforces completeness in cookbook CI. Merge this PR before #21.

## Test
- `mise exec -- pnpm exec vitest run src/types/recipe.test.ts` (15 passed)
- `mise exec -- pnpm test` (189 passed, 2 skipped)
- `mise exec -- pnpm build`