### PR TITLE
feat(cookbook): add recipe pagination

### DIFF
--- a/docs/cookbook/a2a-client.mdx
+++ b/docs/cookbook/a2a-client.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
+pagination_label: "A2A Client"
 pagination_prev: null
-pagination_next: null
+pagination_next: "cookbook/build-engineering-portal"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/build-engineering-portal.mdx
+++ b/docs/cookbook/build-engineering-portal.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Engineering Portal"
+pagination_prev: "cookbook/a2a-client"
+pagination_next: "cookbook/company-answers"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/company-answers.mdx
+++ b/docs/cookbook/company-answers.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Company Answers"
+pagination_prev: "cookbook/build-engineering-portal"
+pagination_next: "cookbook/connect-mcp-hosts"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/connect-mcp-hosts.mdx
+++ b/docs/cookbook/connect-mcp-hosts.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Connect MCP"
+pagination_prev: "cookbook/company-answers"
+pagination_next: "cookbook/customer-360"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/customer-360.mdx
+++ b/docs/cookbook/customer-360.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Customer 360"
+pagination_prev: "cookbook/connect-mcp-hosts"
+pagination_next: "cookbook/embed-search-chat"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/embed-search-chat.mdx
+++ b/docs/cookbook/embed-search-chat.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Embed Search & Chat"
+pagination_prev: "cookbook/customer-360"
+pagination_next: "cookbook/incident-copilot"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/incident-copilot.mdx
+++ b/docs/cookbook/incident-copilot.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Incident copilot"
+pagination_prev: "cookbook/embed-search-chat"
+pagination_next: "cookbook/multi-step-agent"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/multi-step-agent.mdx
+++ b/docs/cookbook/multi-step-agent.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Multi-Step Agent"
+pagination_prev: "cookbook/incident-copilot"
+pagination_next: "cookbook/no-code-it-helpdesk-lovable"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/no-code-it-helpdesk-lovable.mdx
+++ b/docs/cookbook/no-code-it-helpdesk-lovable.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "IT Helpdesk (Lovable)"
+pagination_prev: "cookbook/multi-step-agent"
+pagination_next: "cookbook/no-code-pto-lookup-replit"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/no-code-pto-lookup-replit.mdx
+++ b/docs/cookbook/no-code-pto-lookup-replit.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "PTO Lookup (Replit)"
+pagination_prev: "cookbook/no-code-it-helpdesk-lovable"
+pagination_next: "cookbook/onboarding-hub"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/onboarding-hub.mdx
+++ b/docs/cookbook/onboarding-hub.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Onboarding Hub"
+pagination_prev: "cookbook/no-code-pto-lookup-replit"
+pagination_next: "cookbook/permissions-aware-retrieval"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/permissions-aware-retrieval.mdx
+++ b/docs/cookbook/permissions-aware-retrieval.mdx
@@ -4,8 +4,9 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: "Permissions-aware retrieval"
+pagination_prev: "cookbook/onboarding-hub"
+pagination_next: "cookbook/rfp-responder"
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';

--- a/docs/cookbook/rfp-responder.mdx
+++ b/docs/cookbook/rfp-responder.mdx
@@ -4,7 +4,8 @@
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
+pagination_label: "RFP responder"
+pagination_prev: "cookbook/permissions-aware-retrieval"
 pagination_next: null
 ---
 

--- a/scripts/sync-registry.mjs
+++ b/scripts/sync-registry.mjs
@@ -275,7 +275,13 @@ function splitOrderedList(markdown) {
  * The page Docusaurus sees. Layout order is decided here, not upstream: the
  * data-driven blocks take no content, so the cookbook never mentions them.
  */
-function renderPage(recipeId, markdown) {
+export function renderPage(
+  recipe,
+  markdown,
+  previousRecipe = null,
+  nextRecipe = null,
+) {
+  const recipeId = recipe.id;
   const sections = parseSections(stripSnippetDirectives(markdown));
   const find = (title) => sections.find((section) => section.title === title);
   const problem = find('Problem');
@@ -318,8 +324,9 @@ function renderPage(recipeId, markdown) {
 # sync. Components and layout are chosen by scripts/sync-registry.mjs in this repo.
 hide_table_of_contents: true
 hide_title: true
-pagination_prev: null
-pagination_next: null
+pagination_label: ${JSON.stringify(recipe.sidebarLabel ?? recipe.title)}
+pagination_prev: ${previousRecipe ? JSON.stringify(`cookbook/${previousRecipe.id}`) : 'null'}
+pagination_next: ${nextRecipe ? JSON.stringify(`cookbook/${nextRecipe.id}`) : 'null'}
 ---
 
 import RecipePage from '@site/src/components/Cookbook/RecipePage';
@@ -370,7 +377,7 @@ async function main() {
   console.log(`🧱 Rendering ${parsed.length} page(s) from cookbook data...`);
   fs.mkdirSync(pagesDir, { recursive: true });
   const written = new Set();
-  for (const entry of parsed) {
+  for (const [index, entry] of parsed.entries()) {
     const sections = [
       `## Problem\n\n${entry.content.problem}`,
       ...(entry.content.guardrails ?? []).map(
@@ -384,7 +391,7 @@ async function main() {
     const markdown = sections.join('\n\n');
     fs.writeFileSync(
       path.join(pagesDir, `${entry.id}.mdx`),
-      renderPage(entry.id, markdown),
+      renderPage(entry, markdown, parsed[index - 1], parsed[index + 1]),
     );
     written.add(entry.id);
   }

--- a/scripts/sync-registry.test.ts
+++ b/scripts/sync-registry.test.ts
@@ -6,6 +6,7 @@ import path from 'node:path';
 // @ts-ignore - plain .mjs module without type declarations
 import {
   extractPluginCoordinates,
+  renderPage,
   syncPreviewAssets,
 } from './sync-registry.mjs';
 
@@ -100,6 +101,49 @@ describe('extractPluginCoordinates', () => {
     expect(() => extractPluginCoordinates(noRepo)).toThrow(
       /Could not derive a GitHub slug/,
     );
+  });
+});
+
+describe('renderPage', () => {
+  const markdown = [
+    '## Problem',
+    '',
+    'People need a useful recipe.',
+    '',
+    '## Take it further',
+    '',
+    '- Add another capability.',
+  ].join('\n');
+
+  const recipe = {
+    id: 'customer-360',
+    title: 'Customer 360: an account page',
+    sidebarLabel: 'Customer 360',
+  };
+
+  it('generates native Docusaurus pagination between adjacent recipes', () => {
+    const page = renderPage(
+      recipe,
+      markdown,
+      { id: 'company-answers' },
+      { id: 'embed-search-chat' },
+    );
+
+    expect(page).toContain('pagination_label: "Customer 360"');
+    expect(page).toContain('pagination_prev: "cookbook/company-answers"');
+    expect(page).toContain('pagination_next: "cookbook/embed-search-chat"');
+  });
+
+  it('keeps the sequence bounded to recipes at either end', () => {
+    const first = renderPage(recipe, markdown, null, {
+      id: 'embed-search-chat',
+    });
+    const last = renderPage(recipe, markdown, { id: 'company-answers' }, null);
+
+    expect(first).toContain('pagination_prev: null');
+    expect(first).toContain('pagination_next: "cookbook/embed-search-chat"');
+    expect(last).toContain('pagination_prev: "cookbook/company-answers"');
+    expect(last).toContain('pagination_next: null');
   });
 });
 


### PR DESCRIPTION
## Summary

- generate native Docusaurus previous/next links for cookbook recipes
- keep navigation bounded to recipes in deterministic registry order
- use concise recipe labels in pagination cards
- test middle and boundary pagination behavior

## Verification

- mise exec -- pnpm test
- mise exec -- pnpm format:check
- FF_COOKBOOKS=true mise exec -- pnpm build
- visually verified first, middle, and last recipe pages