### PR TITLE
Add remediation entries for three missing Platform error codes

### DIFF
--- a/src/data/platform-error-remediations.yaml
+++ b/src/data/platform-error-remediations.yaml
@@ -98,6 +98,20 @@ insufficient_permissions:
   relatedDocs:
     - title: Authentication Overview
       href: /get-started/authentication
+spend_limit_exceeded:
+  meaning: The request was rejected because a configured spend limit for the deployment has been reached.
+  commonCauses:
+    - The deployment has consumed its allotted spend for the current billing period.
+    - High-volume or automated traffic exhausted the budget faster than expected.
+    - The configured limit is lower than the workload requires.
+  clientRemediation:
+    - Stop retrying and reduce request volume until the limit is raised or the period resets.
+    - Check the response `detail` for which limit was reached.
+    - Contact a Glean administrator for your deployment to review the limit.
+  adminRemediation:
+    - Review and adjust the spend limit in the Admin Console.
+    - Investigate which integrations or workloads consumed the budget before raising the limit.
+  retryGuidance: Retrying will continue to fail until the limit is raised or the spend period resets.
 resource_not_found:
   meaning: The requested resource or endpoint could not be found or is not visible to the caller.
   commonCauses:
@@ -159,6 +173,18 @@ request_too_large:
     - Split large batches into smaller requests.
     - Remove fields the endpoint does not require.
   retryGuidance: Retry only after reducing the request size.
+token_limit_exceeded:
+  meaning: The request exceeded the model's token limit, which caps how much content the model can process in one operation.
+  commonCauses:
+    - The supplied input is longer than the model's context window.
+    - A continued conversation has accumulated too much history.
+    - Large pasted documents or transcripts were included in the input.
+  clientRemediation:
+    - Shorten the input, or summarize long content before sending it.
+    - Start a new conversation instead of continuing one with a long history.
+    - Split large content into smaller requests and combine the results client-side.
+    - Note that this limit counts tokens, not payload bytes, unlike `request_too_large`.
+  retryGuidance: Retrying the same input will continue to fail. Retry only after reducing the amount of content.
 rate_limit_exceeded:
   meaning: The caller has sent too many requests in a time window.
   commonCauses:
@@ -205,6 +231,22 @@ unprocessable_query:
   relatedDocs:
     - title: Platform Search API
       href: /api/platform-api/search-overview
+tools_unauthorized:
+  meaning: The request targets an agent that uses tools the end user has not authorized, so the run cannot start.
+  commonCauses:
+    - The agent uses a tool server the end user has never connected.
+    - The end user previously revoked access to a connected tool.
+    - The agent was built by someone else and depends on tools the current user has not authorized.
+  clientRemediation:
+    - Read `authentication_suggestions` in the response to see which tools require authorization.
+    - POST each `server_id` to the Client API `/tool-servers/{serverId}/auth` with a `returnUrl` to obtain an `authorizationUrl`.
+    - Redirect the end user to that `authorizationUrl`, then start the run again once OAuth completes.
+  adminRemediation:
+    - Confirm the required tool servers are enabled for the deployment and available to the user.
+  retryGuidance: Retrying before the user authorizes the tools will continue to fail. Retry once authorization completes.
+  relatedDocs:
+    - title: Agents API Overview
+      href: /api/platform-api/agents-overview
 invalid_filter:
   meaning: A filter in the request is not valid for the endpoint or datasource scope.
   commonCauses:


### PR DESCRIPTION
## Problem

Platform API doc regeneration has been failing on **every run since 2026-08-07 02:54 UTC**. The last successful run was 2026-08-07 00:53 UTC, and the last merged `Regenerate OpenAPI Documentation` PR was [#636](https://github.com/gleanwork/glean-developer-site/pull/636) on 2026-07-21.

Every run since then dies here:

```
Error: missing remediation entries for: spend_limit_exceeded, token_limit_exceeded, tools_unauthorized
    at assertSameCodes (scripts/platform-errors-lib.ts:220:11)
    at buildPlatformErrorsOutput (scripts/platform-errors-lib.ts:97:3)
```

`generate:platform-errors` requires exact parity between the `PlatformProblemDetailCode` enum in the downloaded Platform spec and `src/data/platform-error-remediations.yaml`. Scio added three new ProblemDetail codes — `tools_unauthorized` ([askscio/scio#265163](https://github.com/askscio/scio/pull/265163)) and `spend_limit_exceeded` / `token_limit_exceeded` ([askscio/scio#270910](https://github.com/askscio/scio/pull/270910)) — and this catalog was never updated to match.

Because `generate:platform-errors` runs inside `openapi:regenerate:all` *before* `openapi:generate:all` and the "Create Pull Request" step, the throw aborts the entire job. No docs PR is ever opened, so the vendored spec and all generated MDX stay frozen.

### Impact

Seven published Platform operations are missing from the site, including the new `POST /api/chat` endpoint, which is what surfaced this:

| Operation | Status |
|---|---|
| `platform-chat-create` | missing |
| `platform-skills-import` | missing |
| `platform-skills-preview-source` | missing |
| `platform-skills-update` | missing |
| `platform-skills-delete` | missing |
| `platform-skills-sync` | missing |
| `platform-search-filters` | missing |

All seven are present and correct in the published spec at `https://gleanwork.github.io/open-api/specs/final/platform.yaml`, so nothing upstream needs to change. The upstream `trigger-developer-site-redeploy` workflow in `gleanwork/open-api` has succeeded on every run — only the consumer here fails.

## Solution

Adds the three missing remediation entries. Each is placed next to the existing entries that share its HTTP status, matching the file's existing grouping:

- **`spend_limit_exceeded`** (403) after `insufficient_permissions`
- **`token_limit_exceeded`** (413) after `request_too_large`, and explicitly distinguished from it since they share a status code but mean different things (model context vs. HTTP payload bytes)
- **`tools_unauthorized`** (422) after `unprocessable_query`

The `tools_unauthorized` client remediation follows the flow documented in the scio contract for `UnauthorizedAgentToolsProblem`: read `authentication_suggestions`, POST each `server_id` to the Client API `/tool-servers/{serverId}/auth` with a `returnUrl`, redirect the user to the returned `authorizationUrl`, then retry the run.

## Test plan

`pnpm` could not be installed locally (`pnpm@10.13.1` is blocked by Socket Firewall for 11 HIGH CVEs), so I reproduced the failing assertions directly against the live published spec instead of running the full Docusaurus build.

- [x] Fetched the real published spec from `https://gleanwork.github.io/open-api/specs/final/platform.yaml` and confirmed its enum contains all 23 codes, including the three added here
- [x] Reproduced `validateCatalog` — all 23 entries have non-empty `meaning` / `commonCauses` / `clientRemediation` / `retryGuidance`, no entry duplicates the generator-owned `status`, `title`, `slug`, `canonicalUrl`, or `example` fields, and every `relatedDocs` entry has a non-empty `title` and `href`
- [x] Reproduced both `assertSameCodes` calls (`metadata` ↔ `enum` and `remediation` ↔ `enum`) — both pass in both directions, 23/23/23
- [x] Confirmed generation would emit 23 error pages, up from the 20 currently in `docs/errors/`
- [x] Verified `relatedDocs` targets resolve to real pages: `docs/api/platform-api/agents-overview.mdx` exists, and the `/api/platform-api/<filename>` route convention matches the already-referenced `/api/platform-api/search-overview`
- [x] Kept all added lines within the file's existing width (longest added line is 129 chars vs. 138 already present) so `prettier --check .` is unaffected
- [ ] **Needs CI confirmation:** the full `pnpm build` and a green `trigger-redeploy` run

### Note on the follow-up regeneration

Fixing this unblocks the generation step, but [#663](https://github.com/gleanwork/glean-developer-site/pull/663) is still open on `ci/regenerate-openapi-docs` in `CONFLICTING`/`DIRTY` state with auto-merge enabled. Since `trigger-redeploy.yml` reuses that branch, the next successful run will push onto a conflicted branch and auto-merge will stay blocked. That conflict needs clearing separately before docs actually reach production.

## Suggested follow-ups

Not included here, but this class of outage will recur:

1. **Move the check upstream.** Nothing in scio knows this catalog exists, so an author adding a ProblemDetail code passes all their own CI and the breakage lands hours later in this repo, in a scheduled workflow whose failures notify nobody on the scio side. A scio-side assertion against this catalog would fail on the PR that causes it.
2. **Shrink the blast radius.** A missing entry for an *agents* error code is why a *chat* endpoint has no docs. Warning and skipping unknown codes, rather than throwing, would keep one missing entry from hiding every Platform operation.
3. **Note the removal ordering.** `assertSameCodes` also throws on `extra` codes, so removing a code from scio breaks this build until the entry here is deleted. Removals have to be sequenced site-first.
