### PR TITLE
[Docs] Fix Platform API sidebar regeneration

### DIFF
--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -150,6 +150,18 @@ function slugify(text) {
     .replace(/^-|-$/g, '');
 }
 
+// Match docusaurus-plugin-openapi-docs / lodash kebabCase for operationId
+// filenames (getAgent → get-agent). Plain slugify would collapse to getagent.
+function kebabCase(text) {
+  return text
+    .trim()
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase();
+}
+
 function addTagMapping(slugToTags, slug, tag) {
   const tags = slugToTags.get(slug) ?? new Set();
   tags.add(tag);
@@ -187,6 +199,7 @@ function buildSlugToTagMap() {
         if (!tag) continue;
         if (op.operationId) {
           addTagMapping(map, op.operationId, tag);
+          addTagMapping(map, kebabCase(op.operationId), tag);
         }
         if (op.summary) {
           addTagMapping(map, slugify(op.summary), tag);

--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -87,7 +87,7 @@ function collectApiDocs(dir) {
 
   for (const entry of fs
     .readdirSync(dir, { withFileTypes: true })
-    .sort((a, b) => a.name.localeCompare(b.name))) {
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0))) {
     if (entry.isDirectory()) {
       results.push(...collectApiDocs(path.join(dir, entry.name)));
     } else if (entry.name.endsWith('.api.mdx') && !shouldSkip(entry.name)) {

--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -85,7 +85,9 @@ function collectApiDocs(dir) {
   const results = [];
   if (!fs.existsSync(dir)) return results;
 
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+  for (const entry of fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name))) {
     if (entry.isDirectory()) {
       results.push(...collectApiDocs(path.join(dir, entry.name)));
     } else if (entry.name.endsWith('.api.mdx') && !shouldSkip(entry.name)) {
@@ -148,6 +150,12 @@ function slugify(text) {
     .replace(/^-|-$/g, '');
 }
 
+function addTagMapping(slugToTags, slug, tag) {
+  const tags = slugToTags.get(slug) ?? new Set();
+  tags.add(tag);
+  slugToTags.set(slug, tags);
+}
+
 // Build a map: docId-slug -> tag-name from all OpenAPI source specs.
 // Used to determine which sidebar category a flat-structured doc (e.g.
 // indexing-api endpoints) belongs to, since the file path alone doesn't
@@ -176,12 +184,37 @@ function buildSlugToTagMap() {
         if (!HTTP_METHODS.includes(m)) continue;
         if (!op || typeof op !== 'object') continue;
         const tag = op.tags?.[0];
-        if (!op.summary || !tag) continue;
-        map.set(slugify(op.summary), tag);
+        if (!tag) continue;
+        if (op.operationId) {
+          addTagMapping(map, op.operationId, tag);
+        }
+        if (op.summary) {
+          addTagMapping(map, slugify(op.summary), tag);
+        }
       }
     }
   }
   return map;
+}
+
+function getStringProperty(node, name) {
+  const property = node.properties.find(
+    (prop) =>
+      prop.type === 'ObjectProperty' &&
+      prop.key?.name === name &&
+      prop.value?.type === 'StringLiteral',
+  );
+  return property?.value.value ?? null;
+}
+
+function getItemsProperty(node) {
+  const property = node.properties.find(
+    (prop) =>
+      prop.type === 'ObjectProperty' &&
+      prop.key?.name === 'items' &&
+      prop.value?.type === 'ArrayExpression',
+  );
+  return property?.value ?? null;
 }
 
 // Find the `items` array of the sidebar category whose label matches the
@@ -219,6 +252,58 @@ function findCategoryItemsByLabel(root, label) {
   return found;
 }
 
+function findCategoriesByLabel(elements, label) {
+  return elements.filter(
+    (element) =>
+      element?.type === 'ObjectExpression' &&
+      getStringProperty(element, 'type') === 'category' &&
+      getStringProperty(element, 'label') === label &&
+      getItemsProperty(element),
+  );
+}
+
+function findPlatformItems(root) {
+  const matches = [];
+  root.find(j.ObjectExpression).forEach((path) => {
+    if (
+      getStringProperty(path.node, 'type') === 'category' &&
+      getStringProperty(path.node, 'label') === 'Platform API Reference'
+    ) {
+      const items = getItemsProperty(path.node);
+      if (items) {
+        matches.push(items);
+      }
+    }
+  });
+  if (matches.length !== 1) {
+    return {
+      error: `expected one Platform API Reference category, found ${matches.length}`,
+    };
+  }
+  return { items: matches[0] };
+}
+
+function resolveTag(slugToTags, slug) {
+  const tags = slugToTags.get(slug);
+  if (!tags) {
+    return { error: `no OpenAPI tag found for slug '${slug}'` };
+  }
+  if (tags.size !== 1) {
+    return {
+      error: `ambiguous OpenAPI tags for slug '${slug}': ${[...tags].sort().join(', ')}`,
+    };
+  }
+  return { tag: [...tags][0] };
+}
+
+function makeCategoryNode(label) {
+  return j.objectExpression([
+    j.objectProperty(j.identifier('type'), j.stringLiteral('category')),
+    j.objectProperty(j.identifier('label'), j.stringLiteral(label)),
+    j.objectProperty(j.identifier('items'), j.arrayExpression([])),
+  ]);
+}
+
 // Remove sidebar entries whose `id` is in `orphanedIds` (typically because the
 // upstream OpenAPI spec renamed or removed the operation, leaving the entry
 // pointing at a doc that no longer exists). Operates on every `items: [...]`
@@ -246,55 +331,96 @@ function removeOrphanEntries(root, orphanedIds) {
   return removed;
 }
 
-function insertEntry(root, doc, slugToTag) {
-  const segments = doc.docId.split('/');
-  const overviewId = segments.slice(0, -1).join('/') + '/overview';
-
-  let inserted = false;
-
+function findOverviewTarget(root, overviewId) {
+  let found = null;
   root
     .find(j.ObjectProperty, { key: { name: 'items' } })
-    .filter((p) => {
-      const arr = p.node.value;
-      if (arr.type !== 'ArrayExpression') return false;
-      return arr.elements.some((el) => {
-        if (!el || el.type !== 'ObjectExpression') return false;
-        return el.properties.some(
-          (prop) =>
-            prop.type === 'ObjectProperty' &&
-            prop.key?.name === 'id' &&
-            prop.value?.type === 'StringLiteral' &&
-            prop.value?.value === overviewId,
-        );
-      });
-    })
-    .forEach((p) => {
-      if (inserted) return;
-      p.node.value.elements.push(
-        makeEntryNode(doc.docId, doc.label, doc.className),
+    .filter((path) => {
+      const items = path.node.value;
+      if (items.type !== 'ArrayExpression') return false;
+      return items.elements.some(
+        (element) =>
+          element?.type === 'ObjectExpression' &&
+          getStringProperty(element, 'id') === overviewId,
       );
-      inserted = true;
+    })
+    .forEach((path) => {
+      if (!found) {
+        found = path.node.value;
+      }
     });
+  return found;
+}
 
-  if (inserted) return true;
+function resolvePlatformTarget(root, tag, plannedCategories) {
+  const platform = findPlatformItems(root);
+  if (platform.error) {
+    return platform;
+  }
+  const matches = findCategoriesByLabel(platform.items.elements, tag);
+  if (matches.length > 1) {
+    return {
+      error: `ambiguous Platform API Reference categories labelled '${tag}'`,
+    };
+  }
+  if (matches.length === 1) {
+    return { items: getItemsProperty(matches[0]) };
+  }
+  if (tag !== 'Chat') {
+    return { error: `no Platform API Reference category labelled '${tag}'` };
+  }
+  const openApiSpecIndexes = platform.items.elements
+    .map((element, index) => ({ element, index }))
+    .filter(
+      ({ element }) =>
+        element?.type === 'ObjectExpression' &&
+        getStringProperty(element, 'type') === 'link' &&
+        getStringProperty(element, 'label') === 'OpenAPI Spec',
+    )
+    .map(({ index }) => index);
+  if (openApiSpecIndexes.length !== 1) {
+    return {
+      error: `expected one Platform OpenAPI Spec link, found ${openApiSpecIndexes.length}`,
+    };
+  }
+  if (!plannedCategories.has(tag)) {
+    const category = makeCategoryNode(tag);
+    plannedCategories.set(tag, {
+      category,
+      insertAt: openApiSpecIndexes[0],
+      parentItems: platform.items,
+    });
+  }
+  return { items: getItemsProperty(plannedCategories.get(tag).category) };
+}
+
+function resolveEntry(root, doc, slugToTags, plannedCategories) {
+  const segments = doc.docId.split('/');
+  const overviewId = segments.slice(0, -1).join('/') + '/overview';
+  const isPlatformDoc = doc.docId.startsWith('api/platform-api/');
+  if (!isPlatformDoc) {
+    const overviewTarget = findOverviewTarget(root, overviewId);
+    if (overviewTarget) {
+      return { items: overviewTarget };
+    }
+  }
 
   // Fallback: look up the operation's OpenAPI tag and find the category whose
   // label matches. This handles flat-structure APIs (e.g. indexing-api) where
   // all docs live in one directory and the category is determined by the tag,
   // not the file path.
   const slug = segments[segments.length - 1];
-  const tag = slugToTag.get(slug);
-  if (tag) {
-    const itemsArr = findCategoryItemsByLabel(root, tag);
-    if (itemsArr) {
-      itemsArr.elements.push(
-        makeEntryNode(doc.docId, doc.label, doc.className),
-      );
-      return true;
-    }
+  const tagResult = resolveTag(slugToTags, slug);
+  if (tagResult.error) {
+    return tagResult;
   }
-
-  return false;
+  if (isPlatformDoc) {
+    return resolvePlatformTarget(root, tagResult.tag, plannedCategories);
+  }
+  const items = findCategoryItemsByLabel(root, tagResult.tag);
+  return items
+    ? { items }
+    : { error: `no sidebar category labelled '${tagResult.tag}'` };
 }
 
 const { values: args } = parseArgs({
@@ -349,19 +475,35 @@ if (missing.length === 0 && orphaned.length === 0) {
   process.exit(0);
 }
 
-const warnings = [];
-const slugToTag = buildSlugToTagMap();
+const failures = [];
+const insertionPlans = [];
+const plannedCategories = new Map();
+const slugToTags = buildSlugToTagMap();
 
 for (const doc of missing) {
-  const ok = insertEntry(root, doc, slugToTag);
-  if (!ok) {
-    const slug = doc.docId.split('/').slice(-1)[0];
-    const tag = slugToTag.get(slug);
-    const reason = tag
-      ? `no sidebar category labelled '${tag}' (and no parent overview doc found)`
-      : `no OpenAPI tag found for slug '${slug}' and no parent overview doc found`;
-    warnings.push(`Could not auto-insert '${doc.docId}': ${reason}`);
+  const target = resolveEntry(root, doc, slugToTags, plannedCategories);
+  if (target.error) {
+    failures.push(`Could not auto-insert '${doc.docId}': ${target.error}`);
+  } else {
+    insertionPlans.push({ doc, items: target.items });
   }
+}
+
+if (failures.length > 0) {
+  console.error(
+    '\nThe following entries could not be auto-inserted; sidebars.ts was not changed:',
+  );
+  for (const failure of failures) {
+    console.error(`  ! ${failure}`);
+  }
+  process.exit(1);
+}
+
+for (const { category, insertAt, parentItems } of plannedCategories.values()) {
+  parentItems.elements.splice(insertAt, 0, category);
+}
+for (const { doc, items } of insertionPlans) {
+  items.elements.push(makeEntryNode(doc.docId, doc.label, doc.className));
 }
 
 const orphanedSet = new Set(orphaned);
@@ -376,9 +518,7 @@ const formatted = await prettier.format(transformed, {
 fs.writeFileSync(SIDEBARS_PATH, formatted, 'utf8');
 
 if (missing.length > 0) {
-  console.log(
-    `✓ Inserted ${missing.length - warnings.length} entry(ies) into sidebars.ts:`,
-  );
+  console.log(`✓ Inserted ${missing.length} entry(ies) into sidebars.ts:`);
   for (const doc of missing) {
     console.log(`  + ${doc.docId}  "${doc.label}"`);
   }
@@ -391,16 +531,4 @@ if (removedCount > 0) {
   for (const id of orphaned) {
     console.log(`  - ${id}`);
   }
-}
-
-if (warnings.length > 0) {
-  console.warn(
-    '\n⚠ The following entries could not be auto-inserted (new category?):',
-  );
-  for (const w of warnings) {
-    console.warn(`  ! ${w}`);
-  }
-  console.warn(
-    '\nAdd them manually to sidebars.ts. Continuing with partial fix so the regenerate workflow can still produce a PR for the entries that were auto-inserted.',
-  );
 }

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -1,0 +1,307 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const testDirs: string[] = [];
+
+function createFixture(options?: { ambiguous?: boolean; unresolved?: boolean }) {
+  const root = fs.mkdtempSync(path.join(process.cwd(), '.sidebar-sync-test-'));
+  testDirs.push(root);
+  fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs/api/client-api'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs/api/indexing-api'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'docs/api/platform-api'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'openapi/indexing'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'openapi/platform'), { recursive: true });
+  fs.mkdirSync(path.join(root, 'openapi/client/split-apis'), {
+    recursive: true,
+  });
+  fs.copyFileSync(
+    path.join(process.cwd(), 'scripts/sync-api-sidebar.mjs'),
+    path.join(root, 'scripts/sync-api-sidebar.mjs'),
+  );
+  fs.writeFileSync(
+    path.join(root, 'sidebars.ts'),
+    `const sidebars = [
+  {
+    type: 'category',
+    label: 'Guides',
+    items: [
+      {
+        type: 'category',
+        label: 'Chat',
+        items: [
+          {
+            type: 'doc',
+            id: 'guides/chat/overview',
+            label: 'Overview',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    type: 'category',
+    label: 'Platform API Reference',
+    items: [
+      {
+        type: 'doc',
+        id: 'api/platform-api/platform-overview',
+        label: 'Overview',
+      },
+      {
+        type: 'category',
+        label: 'Search',
+        items: [
+          {
+            type: 'doc',
+            id: 'api/platform-api/platform-search',
+            label: 'Search',
+            className: 'api-method post',
+          },
+        ],
+      },
+      {
+        type: 'category',
+        label: 'Skills',
+        items: [
+          {
+            type: 'doc',
+            id: 'api/platform-api/platform-skills-list',
+            label: 'List skills',
+            className: 'api-method get',
+          },
+        ],
+      },
+      {
+        type: 'link',
+        href: 'https://developers.glean.com/oas/platform',
+        label: 'OpenAPI Spec',
+      },
+    ],
+  },
+];
+
+export default sidebars;
+`,
+  );
+
+  const operations = [
+    ['post', '/chat', 'Chat', 'Create a chat response', 'platform-chat-create'],
+    [
+      'get',
+      '/search/filters',
+      'Search',
+      'List search filters',
+      'platform-search-filters',
+    ],
+    [
+      'post',
+      '/skills/import',
+      'Skills',
+      'Import skills from GitHub',
+      'platform-skills-import',
+    ],
+    [
+      'post',
+      '/skills/sources/preview',
+      'Skills',
+      'Preview a GitHub skill source',
+      'platform-skills-preview-source',
+    ],
+    [
+      'patch',
+      '/skills/{skill_id}',
+      'Skills',
+      'Update skill',
+      'platform-skills-update',
+    ],
+    [
+      'delete',
+      '/skills/{skill_id}',
+      'Skills',
+      'Delete skill',
+      'platform-skills-delete',
+    ],
+    [
+      'post',
+      '/skills/{skill_id}/sync',
+      'Skills',
+      'Sync a GitHub-imported skill',
+      'platform-skills-sync',
+    ],
+  ] as const;
+
+  for (const [method, , , summary, operationId] of operations) {
+    fs.writeFileSync(
+      path.join(root, `docs/api/platform-api/${operationId}.api.mdx`),
+      `---
+id: ${operationId}
+title: "${summary}"
+sidebar_label: "${summary}"
+sidebar_class_name: "${method} api-method"
+---
+`,
+    );
+  }
+  if (options?.unresolved) {
+    fs.writeFileSync(
+      path.join(root, 'docs/api/platform-api/platform-unknown.api.mdx'),
+      `---
+id: platform-unknown
+title: "Unknown"
+sidebar_label: "Unknown"
+sidebar_class_name: "get api-method"
+---
+`,
+    );
+  }
+
+  const paths = new Map<
+    string,
+    Array<{
+      method: string;
+      tag: string;
+      summary: string;
+      operationId: string;
+    }>
+  >();
+  for (const [method, apiPath, tag, summary, operationId] of operations) {
+    const pathOperations = paths.get(apiPath) ?? [];
+    pathOperations.push({ method, tag, summary, operationId });
+    paths.set(apiPath, pathOperations);
+  }
+  fs.writeFileSync(
+    path.join(root, 'openapi/platform/platform-capitalized.yaml'),
+    `openapi: 3.0.0
+paths:
+${[...paths.entries()]
+  .map(
+    ([apiPath, pathOperations]) => `  ${apiPath}:
+${pathOperations
+  .map(
+    ({ method, tag, summary, operationId }) => `    ${method}:
+      tags:
+        - ${tag}
+      summary: ${summary}
+      operationId: ${operationId}`,
+  )
+  .join('\n')}`,
+  )
+  .join('\n')}
+`,
+  );
+  fs.writeFileSync(
+    path.join(root, 'openapi/indexing/indexing-capitalized.yaml'),
+    options?.ambiguous
+      ? `openapi: 3.0.0
+paths:
+  /conflicting:
+    post:
+      tags:
+        - Search
+      summary: Conflicting chat operation
+      operationId: platform-chat-create
+`
+      : 'openapi: 3.0.0\npaths: {}\n',
+  );
+
+  return root;
+}
+
+function run(root: string, mode: '--check' | '--fix') {
+  return spawnSync(
+    process.execPath,
+    [path.join(root, 'scripts/sync-api-sidebar.mjs'), mode],
+    {
+      cwd: root,
+      encoding: 'utf8',
+    },
+  );
+}
+
+afterEach(() => {
+  for (const dir of testDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('sync-api-sidebar', () => {
+  it('inserts operationId-named Platform docs into scoped categories', () => {
+    const root = createFixture();
+
+    expect(run(root, '--check').status).toBe(1);
+    const result = run(root, '--fix');
+    const sidebar = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    expect(result.status).toBe(0);
+    expect(sidebar).toContain("label: 'Chat'");
+    expect(sidebar).toContain(
+      "id: 'api/platform-api/platform-chat-create'",
+    );
+    expect(sidebar).toContain(
+      "id: 'api/platform-api/platform-search-filters'",
+    );
+    for (const operation of [
+      'import',
+      'preview-source',
+      'update',
+      'delete',
+      'sync',
+    ]) {
+      expect(sidebar).toContain(
+        `id: 'api/platform-api/platform-skills-${operation}'`,
+      );
+    }
+    expect(
+      sidebar.indexOf("id: 'api/platform-api/platform-skills-list'"),
+    ).toBeLessThan(
+      sidebar.indexOf("id: 'api/platform-api/platform-skills-delete'"),
+    );
+    expect(
+      sidebar.indexOf("id: 'api/platform-api/platform-chat-create'"),
+    ).toBeLessThan(sidebar.indexOf("label: 'OpenAPI Spec'"));
+    expect(sidebar.match(/id: 'guides\/chat\/overview'/g)).toHaveLength(1);
+    expect(run(root, '--check').status).toBe(0);
+  });
+
+  it('is idempotent after inserting missing entries', () => {
+    const root = createFixture();
+
+    expect(run(root, '--fix').status).toBe(0);
+    const first = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+    const second = run(root, '--fix');
+
+    expect(second.status).toBe(0);
+    expect(second.stdout).toContain('already complete');
+    expect(fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8')).toBe(first);
+  });
+
+  it('fails without changing sidebars when an operation is unresolved', () => {
+    const root = createFixture({ unresolved: true });
+    const original = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    const result = run(root, '--fix');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('platform-unknown');
+    expect(fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8')).toBe(
+      original,
+    );
+  });
+
+  it('fails without changing sidebars when operationId tags are ambiguous', () => {
+    const root = createFixture({ ambiguous: true });
+    const original = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    const result = run(root, '--fix');
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('platform-chat-create');
+    expect(result.stderr).toContain('ambiguous');
+    expect(fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8')).toBe(
+      original,
+    );
+  });
+});

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -20,6 +20,12 @@ function createFixture(options?: {
   fs.mkdirSync(path.join(root, 'openapi/client/split-apis'), {
     recursive: true,
   });
+  fs.symlinkSync(
+    process.env.SIDEBAR_TEST_NODE_MODULES ??
+      path.join(process.cwd(), 'node_modules'),
+    path.join(root, 'node_modules'),
+    'dir',
+  );
   fs.copyFileSync(
     path.join(process.cwd(), 'scripts/sync-api-sidebar.mjs'),
     path.join(root, 'scripts/sync-api-sidebar.mjs'),
@@ -89,6 +95,25 @@ function createFixture(options?: {
 export default sidebars;
 `,
   );
+  fs.writeFileSync(
+    path.join(root, 'docs/api/platform-api/platform-overview.mdx'),
+    '---\ntitle: "Platform API Overview"\n---\n',
+  );
+  for (const [operationId, title, method] of [
+    ['platform-search', 'Search', 'post'],
+    ['platform-skills-list', 'List skills', 'get'],
+  ]) {
+    fs.writeFileSync(
+      path.join(root, `docs/api/platform-api/${operationId}.api.mdx`),
+      `---
+id: ${operationId}
+title: "${title}"
+sidebar_label: "${title}"
+sidebar_class_name: "${method} api-method"
+---
+`,
+    );
+  }
 
   const operations = [
     ['post', '/chat', 'Chat', 'Create a chat response', 'platform-chat-create'],
@@ -233,13 +258,17 @@ afterEach(() => {
 describe('sync-api-sidebar', () => {
   it('inserts operationId-named Platform docs into scoped categories', () => {
     const root = createFixture();
+    const original = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+    const platformMarker = "    label: 'Platform API Reference',";
+    const guides = original.slice(0, original.indexOf(platformMarker));
 
     expect(run(root, '--check').status).toBe(1);
     const result = run(root, '--fix');
     const sidebar = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
 
     expect(result.status).toBe(0);
-    expect(sidebar).toContain("label: 'Chat'");
+    expect(sidebar.match(/label: 'Chat'/g)).toHaveLength(2);
+    expect(sidebar.slice(0, sidebar.indexOf(platformMarker))).toBe(guides);
     expect(sidebar).toContain("id: 'api/platform-api/platform-chat-create'");
     expect(sidebar).toContain("id: 'api/platform-api/platform-search-filters'");
     for (const operation of [
@@ -258,6 +287,15 @@ describe('sync-api-sidebar', () => {
     ).toBeLessThan(
       sidebar.indexOf("id: 'api/platform-api/platform-skills-delete'"),
     );
+    const skillPositions = [
+      'platform-skills-list',
+      'platform-skills-delete',
+      'platform-skills-import',
+      'platform-skills-preview-source',
+      'platform-skills-sync',
+      'platform-skills-update',
+    ].map((id) => sidebar.indexOf(`id: 'api/platform-api/${id}'`));
+    expect(skillPositions).toEqual([...skillPositions].sort((a, b) => a - b));
     expect(
       sidebar.indexOf("id: 'api/platform-api/platform-chat-create'"),
     ).toBeLessThan(sidebar.indexOf("label: 'OpenAPI Spec'"));

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -8,6 +8,7 @@ const testDirs: string[] = [];
 
 function createFixture(options?: {
   ambiguous?: boolean;
+  camelCaseOpId?: boolean;
   preseed?: boolean;
   unresolved?: boolean;
 }) {
@@ -211,6 +212,18 @@ sidebar_class_name: "get api-method"
 `,
     );
   }
+  if (options?.camelCaseOpId) {
+    fs.writeFileSync(
+      path.join(root, 'docs/api/platform-api/get-platform-thing.api.mdx'),
+      `---
+id: get-platform-thing
+title: "Get platform thing"
+sidebar_label: "Get platform thing"
+sidebar_class_name: "get api-method"
+---
+`,
+    );
+  }
 
   const paths = new Map<
     string,
@@ -225,6 +238,16 @@ sidebar_class_name: "get api-method"
     const pathOperations = paths.get(apiPath) ?? [];
     pathOperations.push({ method, tag, summary, operationId });
     paths.set(apiPath, pathOperations);
+  }
+  if (options?.camelCaseOpId) {
+    paths.set('/things/{id}', [
+      {
+        method: 'get',
+        tag: 'Search',
+        summary: 'Retrieve the thing',
+        operationId: 'getPlatformThing',
+      },
+    ]);
   }
   fs.writeFileSync(
     path.join(root, 'openapi/platform/platform-capitalized.yaml'),
@@ -344,6 +367,20 @@ describe('sync-api-sidebar', () => {
     expect(second.status).toBe(0);
     expect(second.stdout).toContain('already complete');
     expect(fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8')).toBe(first);
+  });
+
+  it('resolves camelCase operationIds to kebab-case doc basenames', () => {
+    const root = createFixture({ camelCaseOpId: true });
+
+    expect(run(root, '--fix').status).toBe(0);
+    const sidebar = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    expect(sidebar).toContain("id: 'api/platform-api/get-platform-thing'");
+    expect(
+      sidebar.indexOf("id: 'api/platform-api/platform-search'"),
+    ).toBeLessThan(
+      sidebar.indexOf("id: 'api/platform-api/get-platform-thing'"),
+    );
   });
 
   it('does not duplicate Platform entries already present in the sidebar', () => {

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -7,9 +8,10 @@ const testDirs: string[] = [];
 
 function createFixture(options?: {
   ambiguous?: boolean;
+  preseed?: boolean;
   unresolved?: boolean;
 }) {
-  const root = fs.mkdtempSync(path.join(process.cwd(), '.sidebar-sync-test-'));
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'sidebar-sync-test-'));
   testDirs.push(root);
   fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
   fs.mkdirSync(path.join(root, 'docs/api/client-api'), { recursive: true });
@@ -25,6 +27,10 @@ function createFixture(options?: {
       path.join(process.cwd(), 'node_modules'),
     path.join(root, 'node_modules'),
     'dir',
+  );
+  fs.copyFileSync(
+    path.join(process.cwd(), '.prettierrc.json'),
+    path.join(root, '.prettierrc.json'),
   );
   fs.copyFileSync(
     path.join(process.cwd(), 'scripts/sync-api-sidebar.mjs'),
@@ -68,7 +74,17 @@ function createFixture(options?: {
             id: 'api/platform-api/platform-search',
             label: 'Search',
             className: 'api-method post',
-          },
+          },${
+            options?.preseed
+              ? `
+          {
+            type: 'doc',
+            id: 'api/platform-api/platform-search-filters',
+            label: 'List search filters',
+            className: 'api-method get',
+          },`
+              : ''
+          }
         ],
       },
       {
@@ -80,7 +96,17 @@ function createFixture(options?: {
             id: 'api/platform-api/platform-skills-list',
             label: 'List skills',
             className: 'api-method get',
-          },
+          },${
+            options?.preseed
+              ? `
+          {
+            type: 'doc',
+            id: 'api/platform-api/platform-skills-delete',
+            label: 'Delete skill',
+            className: 'api-method delete',
+          },`
+              : ''
+          }
         ],
       },
       {
@@ -283,6 +309,11 @@ describe('sync-api-sidebar', () => {
       );
     }
     expect(
+      sidebar.indexOf("id: 'api/platform-api/platform-search'"),
+    ).toBeLessThan(
+      sidebar.indexOf("id: 'api/platform-api/platform-search-filters'"),
+    );
+    expect(
       sidebar.indexOf("id: 'api/platform-api/platform-skills-list'"),
     ).toBeLessThan(
       sidebar.indexOf("id: 'api/platform-api/platform-skills-delete'"),
@@ -296,9 +327,9 @@ describe('sync-api-sidebar', () => {
       'platform-skills-update',
     ].map((id) => sidebar.indexOf(`id: 'api/platform-api/${id}'`));
     expect(skillPositions).toEqual([...skillPositions].sort((a, b) => a - b));
-    expect(
-      sidebar.indexOf("id: 'api/platform-api/platform-chat-create'"),
-    ).toBeLessThan(sidebar.indexOf("label: 'OpenAPI Spec'"));
+    expect(sidebar).toMatch(
+      /label: 'Chat',[\s\S]*?id: 'api\/platform-api\/platform-chat-create',[\s\S]*?\n {10}\},\n {8}\],\n {6}\},\n {6}\{\n {8}type: 'link',\n {8}href: 'https:\/\/developers\.glean\.com\/oas\/platform',\n {8}label: 'OpenAPI Spec',/,
+    );
     expect(sidebar.match(/id: 'guides\/chat\/overview'/g)).toHaveLength(1);
     expect(run(root, '--check').status).toBe(0);
   });
@@ -313,6 +344,81 @@ describe('sync-api-sidebar', () => {
     expect(second.status).toBe(0);
     expect(second.stdout).toContain('already complete');
     expect(fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8')).toBe(first);
+  });
+
+  it('does not duplicate Platform entries already present in the sidebar', () => {
+    const root = createFixture({ preseed: true });
+
+    expect(run(root, '--fix').status).toBe(0);
+    const sidebar = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    for (const id of [
+      'platform-chat-create',
+      'platform-search-filters',
+      'platform-skills-import',
+      'platform-skills-preview-source',
+      'platform-skills-update',
+      'platform-skills-delete',
+      'platform-skills-sync',
+    ]) {
+      expect(
+        sidebar.match(new RegExp(`id: 'api/platform-api/${id}'`, 'g')),
+      ).toHaveLength(1);
+    }
+  });
+
+  it('preserves client insertion through a parent overview entry', () => {
+    const root = createFixture();
+    const sidebarPath = path.join(root, 'sidebars.ts');
+    fs.writeFileSync(
+      sidebarPath,
+      fs.readFileSync(sidebarPath, 'utf8').replace(
+        '\n];',
+        `
+  {
+    type: 'category',
+    label: 'Client API Reference',
+    items: [
+      {
+        type: 'category',
+        label: 'Chat',
+        items: [
+          {
+            type: 'doc',
+            id: 'api/client-api/chat/overview',
+            label: 'Overview',
+          },
+        ],
+      },
+    ],
+  },
+];`,
+      ),
+    );
+    fs.mkdirSync(path.join(root, 'docs/api/client-api/chat'), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(root, 'docs/api/client-api/chat/overview.mdx'),
+      '---\ntitle: "Chat"\n---\n',
+    );
+    fs.writeFileSync(
+      path.join(root, 'docs/api/client-api/chat/create.api.mdx'),
+      `---
+title: "Create chat"
+sidebar_label: "Create chat"
+sidebar_class_name: "post api-method"
+---
+`,
+    );
+
+    expect(run(root, '--fix').status).toBe(0);
+    const sidebar = fs.readFileSync(sidebarPath, 'utf8');
+
+    expect(sidebar).toContain("id: 'api/client-api/chat/create'");
+    expect(sidebar.indexOf("id: 'api/client-api/chat/overview'")).toBeLessThan(
+      sidebar.indexOf("id: 'api/client-api/chat/create'"),
+    );
   });
 
   it('fails without changing sidebars when an operation is unresolved', () => {

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const testDirs: string[] = [];
 
-function createFixture(options?: { ambiguous?: boolean; unresolved?: boolean }) {
+function createFixture(options?: {
+  ambiguous?: boolean;
+  unresolved?: boolean;
+}) {
   const root = fs.mkdtempSync(path.join(process.cwd(), '.sidebar-sync-test-'));
   testDirs.push(root);
   fs.mkdirSync(path.join(root, 'scripts'), { recursive: true });
@@ -237,12 +240,8 @@ describe('sync-api-sidebar', () => {
 
     expect(result.status).toBe(0);
     expect(sidebar).toContain("label: 'Chat'");
-    expect(sidebar).toContain(
-      "id: 'api/platform-api/platform-chat-create'",
-    );
-    expect(sidebar).toContain(
-      "id: 'api/platform-api/platform-search-filters'",
-    );
+    expect(sidebar).toContain("id: 'api/platform-api/platform-chat-create'");
+    expect(sidebar).toContain("id: 'api/platform-api/platform-search-filters'");
     for (const operation of [
       'import',
       'preview-source',


### PR DESCRIPTION
**Internal Description for reviewers**:

Platform OpenAPI regeneration currently generates new operation pages but cannot add them to the Platform sidebar. Generated filenames use `operationId` (for example, `platform-chat-create`), while the sidebar sync maps tags by slugified summaries (`create-a-chat-response`) and searches the first category with a matching label across the entire site.

Resolve flat Platform docs by `operationId`, scope category changes to Platform API Reference, and create its Chat category before the OpenAPI Spec link. Sidebar updates are now transactional: unresolved or ambiguous mappings leave `sidebars.ts` unchanged and fail regeneration before it opens a doomed PR.

This unblocks [#663](https://github.com/gleanwork/glean-developer-site/pull/663), which contains the generated Platform Chat and six other operation pages but fails sidebar completeness. The missing Platform error remediations were addressed separately in [#671](https://github.com/gleanwork/glean-developer-site/pull/671).

**Context/Jira (Mandatory if external)**:

**Test plan**:
- [ ] _Need review from all reviewers (default: 1)_
- CI: [Test Build](https://github.com/gleanwork/glean-developer-site/actions/runs/31413886189) passes formatting, sidebar completeness, integration tests, and the full site build.
- Integration tests exercise all seven missing Platform operations, category scoping, deterministic placement, idempotency, unresolved mappings, ambiguous mappings, and no-write failure behavior.
---

_Release Notes ([go/relnotesfaq](https://go/relnotesfaq))_

**Change Categories (mandatory - check all that apply)**
* **Internal (This PR will not be included in the external release notes)**
  - [X] Flag-gated development/Internal fix
* **External (Choose one if applicable. A detailed external description is mandatory)**
  - [ ] Bug Fixes/Enhancements
  - [ ] Security or Permissions related change
  - [ ] Feature launch
  - [ ] UI change
  - [ ] 3rd party LLM integration change
  - [ ] External API breaking change
  - [ ] Scrubbed logs change
* **Platform (Choose one if applicable. Choose at least one other category from Internal or External)**
  - [ ] AWS only change
  - [ ] Azure only change
  - [ ] GCP only change

- [ ] Document Updates Needed

_(DO NOT include confidential details. Should be at least 40 characters long.)_
**External description for customers**:
