### PR TITLE
docs: correct tools JWT signature header

### DIFF
--- a/docs/guides/tools/authentication.mdx
+++ b/docs/guides/tools/authentication.mdx
@@ -66,7 +66,7 @@ Without this, the OAuth integration may fail or show invalid redirect URI errors
 While optional, implementing request verification is highly recommended to enhance the security of your tool server endpoints.
 :::
 
-Glean provides a JWT-based signature in the `Glean-Actions-Signature` header, signed using RSA-SHA256. The signature can be verified using your Glean instance's public key.
+Glean provides a JWT-based signature in the `Glean-Tools-Signature` header, signed using RSA-SHA256. The signature can be verified using your Glean instance's public key.
 
 ### JWT Claims
 
@@ -91,7 +91,7 @@ YOUR_GLEAN_SERVER_URL=''
 # Find your server URL at app.glean.com/admin/about-glean
 
 # Use this function as is in your code (once you have filled out YOUR_GLEAN_SERVER_URL).
-# Pass the header value for Glean-Actions-Signature as the 'token' in this function.
+# Pass the header value for Glean-Tools-Signature as the 'token' in this function.
 
 def verify_jwt(token):
     try:
@@ -158,7 +158,7 @@ public static void verifySignature(String publicKey, String jwtFromHeader) throw
   try {
     jwtConsumer.processToClaims(jwtFromHeader);
   } catch (InvalidJwtException e) {
-    throw new IOException("Failed to verify actions signature: " + e.getMessage());
+    throw new IOException("Failed to verify tools signature: " + e.getMessage());
   }
 }
 ```

--- a/snippets/authentication/snippet-01.py
+++ b/snippets/authentication/snippet-01.py
@@ -7,7 +7,7 @@ YOUR_GLEAN_SERVER_URL=''
 # Find your server URL at app.glean.com/admin/about-glean
 
 # Use this function as is in your code (once you have filled out YOUR_GLEAN_SERVER_URL).
-# Pass the header value for Glean-Actions-Signature as the 'token' in this function.
+# Pass the header value for Glean-Tools-Signature as the 'token' in this function.
 
 def verify_jwt(token):
     try:

--- a/snippets/authentication/snippet-02.java
+++ b/snippets/authentication/snippet-02.java
@@ -39,6 +39,6 @@ public static void verifySignature(String publicKey, String jwtFromHeader) throw
   try {
     jwtConsumer.processToClaims(jwtFromHeader);
   } catch (InvalidJwtException e) {
-    throw new IOException("Failed to verify actions signature: " + e.getMessage());
+    throw new IOException("Failed to verify tools signature: " + e.getMessage());
   }
 }


### PR DESCRIPTION
## Summary

- Correct the documented JWT request header from `Glean-Actions-Signature` to `Glean-Tools-Signature`.
- Update the managed Python and Java authentication examples to use consistent tools-signature terminology.

## Why

The public authentication guide did not match the runtime implementation. In the `scio` codebase, the DSE runtime defines and sends `Glean-Tools-Signature` in `go/query_endpoint/core/dse_service_impl.go`, and the receiving verifier uses the same canonical name in `java/com/askscio/tools/auth/ToolsSignatureVerifier.java`. A consumer expecting `Glean-Actions-Signature` can therefore report a missing header even though the runtime sends the JWT under `Glean-Tools-Signature`.

## Validation

- `pnpm snippets:sync`
- `pnpm snippets:check`
- `pnpm format`
- `pnpm test` (197 passed, 2 skipped)
- `pnpm build`
