### PR TITLE
feat: add cookbook execution types

### DIFF
--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -373,7 +373,7 @@
           },
           "run": {
             "command": "cd company-answers && npm start",
-            "url": "http://localhost:3000",
+            "url": "the Local URL printed by the server",
             "userBrowser": true
           }
         },
@@ -630,7 +630,7 @@
           },
           "run": {
             "command": "cd customer-360 && npm start",
-            "url": "http://localhost:3000",
+            "url": "the Local URL printed by the server",
             "userBrowser": true
           }
         },
@@ -699,7 +699,7 @@
           },
           "run": {
             "command": "cd customer-360 && npm start",
-            "url": "http://localhost:3000",
+            "url": "the Local URL printed by the server",
             "userBrowser": true
           }
         },
@@ -1397,7 +1397,7 @@
           },
           "run": {
             "command": "cd onboarding-hub && npm start",
-            "url": "http://localhost:3000",
+            "url": "the Local URL printed by the server",
             "userBrowser": true
           }
         },
@@ -1491,7 +1491,7 @@
       },
       "run": {
         "command": "cd oncall-copilot && npm start",
-        "url": "http://localhost:3000",
+        "url": "the Local URL printed by the server",
         "userBrowser": true
       }
     },
@@ -1916,7 +1916,7 @@
       },
       "run": {
         "command": "cd rfp-responder && npm start",
-        "url": "http://localhost:3000",
+        "url": "the Local URL printed by the server",
         "userBrowser": true
       }
     },

--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -15,6 +15,7 @@
     "authMethod": ["client-api-oauth-or-token"],
     "buildMethod": "scaffold",
     "execution": {
+      "type": "cli",
       "questions": [
         {
           "id": "email",
@@ -44,6 +45,10 @@
         "command": "cd a2a-client && uv run main.py",
         "expectedDuration": "about 1 minute after sign-in",
         "startsOwnServer": false
+      },
+      "run": {
+        "command": "cd a2a-client && uv run main.py",
+        "userBrowser": false
       }
     },
     "languages": ["python"],
@@ -122,6 +127,7 @@
     "authMethod": ["indexing-token", "web-sdk-cookie"],
     "buildMethod": "integrate",
     "execution": {
+      "type": "existing-app",
       "questions": [
         {
           "id": "email",
@@ -273,6 +279,7 @@
         "language": "typescript",
         "description": "Web SDK variant — renderChat in a page",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -323,7 +330,6 @@
           {
             "title": "Run it",
             "command": "cd company-answers && npm run dev",
-            "description": "Keep Vite running, report its exact Local URL, and wait for the user to open it in their normal signed-in browser. Never open or automate the URL yourself.",
             "kind": "run"
           },
           {
@@ -338,6 +344,7 @@
         "language": "typescript",
         "description": "Chat API variant — one chat.create call, citations rendered",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -396,7 +403,6 @@
           {
             "title": "Run it",
             "command": "cd company-answers && npm start",
-            "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
             "kind": "run"
           }
         ]
@@ -462,6 +468,7 @@
     "authMethod": ["custom"],
     "buildMethod": "scaffold",
     "execution": {
+      "type": "host-configuration",
       "questions": [
         {
           "id": "email",
@@ -597,6 +604,7 @@
         "language": "typescript",
         "description": "Path A — parallel Platform Search tiles + Client Chat synthesis",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -652,7 +660,6 @@
           {
             "title": "Run it",
             "command": "cd customer-360 && npm start",
-            "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
             "kind": "run"
           }
         ]
@@ -662,6 +669,7 @@
         "language": "typescript",
         "description": "Path B — Platform Agents createRun for prescriptive account briefs",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -721,7 +729,6 @@
           {
             "title": "Run it",
             "command": "cd customer-360 && npm start",
-            "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
             "kind": "run"
           }
         ]
@@ -807,6 +814,7 @@
     "authMethod": ["web-sdk-cookie"],
     "buildMethod": "integrate",
     "execution": {
+      "type": "existing-app",
       "questions": [
         {
           "id": "email",
@@ -902,6 +910,7 @@
     "authMethod": ["client-api-oauth-or-token"],
     "buildMethod": "scaffold",
     "execution": {
+      "type": "hybrid-service",
       "questions": [
         {
           "id": "email",
@@ -1055,6 +1064,7 @@
     "authMethod": ["custom"],
     "buildMethod": "third-party-build",
     "execution": {
+      "type": "external-builder",
       "questions": [
         {
           "id": "email",
@@ -1131,6 +1141,7 @@
     "authMethod": ["custom"],
     "buildMethod": "third-party-build",
     "execution": {
+      "type": "external-builder",
       "questions": [
         {
           "id": "email",
@@ -1292,6 +1303,7 @@
         "language": "typescript",
         "description": "Web SDK variant — checklist + renderChat",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -1342,7 +1354,6 @@
           {
             "title": "Run it",
             "command": "cd onboarding-hub && npm run dev",
-            "description": "Start Vite and leave it running. Report the exact Local URL printed by Vite. Never open the URL yourself and never use browser automation. Wait for the user to open it in their normal browser where they are already signed in to Glean and tell you it is ready.",
             "kind": "run"
           },
           {
@@ -1357,6 +1368,7 @@
         "language": "typescript",
         "description": "Client Chat variant — server-side API call, custom UI",
         "execution": {
+          "type": "local-web",
           "questions": [
             {
               "id": "email",
@@ -1415,7 +1427,6 @@
           {
             "title": "Run it",
             "command": "cd onboarding-hub && npm start",
-            "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
             "kind": "run"
           }
         ]
@@ -1451,20 +1462,17 @@
     "authMethod": ["client-api-oauth-or-token"],
     "buildMethod": "scaffold",
     "execution": {
+      "type": "local-web",
       "questions": [
         {
-          "id": "mode",
-          "prompt": "Do you want the instant fixture demo or a live tenant run?"
-        },
-        {
           "id": "service",
-          "prompt": "For a live run, which service has a catalog entry, runbook, and past incident in Glean?"
+          "prompt": "Which service has a catalog entry, runbook, and past incident in Glean?"
         },
         {
           "id": "orchestrator",
-          "prompt": "For a live run, use direct Search + Chat or an existing Glean agent?"
+          "prompt": "Use direct Search + Chat or an existing Glean agent?"
         },
-        { "id": "email", "prompt": "For a live run, what is your work email?" }
+        { "id": "email", "prompt": "What is your work email?" }
       ],
       "auth": [
         {
@@ -1489,9 +1497,9 @@
     },
     "languages": ["typescript"],
     "prerequisites": [
-      "A Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
-      "A work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
-      "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+      "For configured runs: a Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
+      "For configured runs: a work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
+      "For configured runs: X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
       "Node 20+"
     ],
     "demoQueries": [
@@ -1680,6 +1688,7 @@
         "language": "python",
         "description": "Platform API search.query → snippets → LLM with citations",
         "execution": {
+          "type": "cli",
           "questions": [
             {
               "id": "email",
@@ -1714,6 +1723,10 @@
             "kind": "manual",
             "expectedDuration": "about 1 minute after sign-in",
             "startsOwnServer": false
+          },
+          "run": {
+            "command": "cd permissions-aware-retrieval && uv run main.py \"<allowed-topic>\"",
+            "userBrowser": false
           }
         },
         "steps": [
@@ -1746,6 +1759,7 @@
         "language": "typescript",
         "description": "Same flow in TypeScript",
         "execution": {
+          "type": "cli",
           "questions": [
             {
               "id": "email",
@@ -1780,6 +1794,10 @@
             "kind": "manual",
             "expectedDuration": "about 1 minute after sign-in",
             "startsOwnServer": false
+          },
+          "run": {
+            "command": "cd permissions-aware-retrieval && npm start -- \"<allowed-topic>\"",
+            "userBrowser": false
           }
         },
         "steps": [
@@ -1873,16 +1891,13 @@
     "authMethod": ["client-api-oauth-or-token"],
     "buildMethod": "scaffold",
     "execution": {
+      "type": "local-web",
       "questions": [
         {
-          "id": "mode",
-          "prompt": "Do you want the instant fixture demo or a live tenant run?"
-        },
-        {
           "id": "approved-sources",
-          "prompt": "For a live run, which Glean URL prefixes are approved sources for external answers?"
+          "prompt": "Which Glean URL prefixes are approved sources for external answers?"
         },
-        { "id": "email", "prompt": "For a live run, what is your work email?" }
+        { "id": "email", "prompt": "What is your work email?" }
       ],
       "auth": [
         {
@@ -1907,8 +1922,8 @@
     },
     "languages": ["typescript"],
     "prerequisites": [
-      "A Glean instance with your company content indexed",
-      "A work email for tenant discovery and OAuth sign-in; a CHAT-scoped API token is the fallback",
+      "For configured runs: a Glean instance with your company content indexed",
+      "For configured runs: a work email for tenant discovery and OAuth sign-in; a CHAT-scoped API token is the fallback",
       "Node 20+"
     ],
     "demoQueries": [

--- a/schemas/recipe.schema.json
+++ b/schemas/recipe.schema.json
@@ -176,6 +176,17 @@
           "execution": {
             "type": "object",
             "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "local-web",
+                  "existing-app",
+                  "cli",
+                  "host-configuration",
+                  "external-builder",
+                  "hybrid-service"
+                ]
+              },
               "questions": {
                 "default": [],
                 "type": "array",
@@ -424,7 +435,7 @@
                 ]
               }
             },
-            "required": ["auth", "verification"],
+            "required": ["type", "auth", "verification"],
             "additionalProperties": false
           },
           "steps": {
@@ -524,6 +535,17 @@
     "execution": {
       "type": "object",
       "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "local-web",
+            "existing-app",
+            "cli",
+            "host-configuration",
+            "external-builder",
+            "hybrid-service"
+          ]
+        },
         "questions": {
           "default": [],
           "type": "array",
@@ -772,7 +794,7 @@
           ]
         }
       },
-      "required": ["auth", "verification"],
+      "required": ["type", "auth", "verification"],
       "additionalProperties": false
     },
     "combines": {

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -451,7 +451,7 @@
             },
             "run": {
               "command": "cd company-answers && npm start",
-              "url": "http://localhost:3000",
+              "url": "the Local URL printed by the server",
               "userBrowser": true
             }
           },
@@ -753,7 +753,7 @@
             },
             "run": {
               "command": "cd customer-360 && npm start",
-              "url": "http://localhost:3000",
+              "url": "the Local URL printed by the server",
               "userBrowser": true
             }
           },
@@ -831,7 +831,7 @@
             },
             "run": {
               "command": "cd customer-360 && npm start",
-              "url": "http://localhost:3000",
+              "url": "the Local URL printed by the server",
               "userBrowser": true
             }
           },
@@ -1596,7 +1596,7 @@
             },
             "run": {
               "command": "cd onboarding-hub && npm start",
-              "url": "http://localhost:3000",
+              "url": "the Local URL printed by the server",
               "userBrowser": true
             }
           },
@@ -1844,7 +1844,7 @@
         },
         "run": {
           "command": "cd oncall-copilot && npm start",
-          "url": "http://localhost:3000",
+          "url": "the Local URL printed by the server",
           "userBrowser": true
         }
       },
@@ -2319,7 +2319,7 @@
         },
         "run": {
           "command": "cd rfp-responder && npm start",
-          "url": "http://localhost:3000",
+          "url": "the Local URL printed by the server",
           "userBrowser": true
         }
       },

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -74,6 +74,7 @@
         }
       ],
       "execution": {
+        "type": "cli",
         "questions": [
           {
             "id": "email",
@@ -108,6 +109,10 @@
           "command": "cd a2a-client && uv run main.py",
           "expectedDuration": "about 1 minute after sign-in",
           "startsOwnServer": false
+        },
+        "run": {
+          "command": "cd a2a-client && uv run main.py",
+          "userBrowser": false
         }
       },
       "architecture": [],
@@ -184,6 +189,7 @@
         "scaffold-web-sdk-embed"
       ],
       "execution": {
+        "type": "existing-app",
         "questions": [
           {
             "id": "email",
@@ -345,6 +351,7 @@
           "language": "typescript",
           "description": "Web SDK variant — renderChat in a page",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -397,7 +404,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Keep Vite running, report its exact Local URL, and wait for the user to open it in their normal signed-in browser. Never open or automate the URL yourself.",
               "command": "cd company-answers && npm run dev"
             },
             {
@@ -412,6 +418,7 @@
           "language": "typescript",
           "description": "Chat API variant — one chat.create call, citations rendered",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -474,7 +481,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
               "command": "cd company-answers && npm start"
             }
           ]
@@ -601,6 +607,7 @@
         }
       ],
       "execution": {
+        "type": "host-configuration",
         "questions": [
           {
             "id": "email",
@@ -712,6 +719,7 @@
           "language": "typescript",
           "description": "Path A — parallel Platform Search tiles + Client Chat synthesis",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -775,7 +783,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
               "command": "cd customer-360 && npm start"
             }
           ]
@@ -785,6 +792,7 @@
           "language": "typescript",
           "description": "Path B — Platform Agents createRun for prescriptive account briefs",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -853,7 +861,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
               "command": "cd customer-360 && npm start"
             }
           ]
@@ -984,6 +991,7 @@
         "scaffold-web-sdk-embed"
       ],
       "execution": {
+        "type": "existing-app",
         "questions": [
           {
             "id": "email",
@@ -1167,6 +1175,7 @@
         }
       ],
       "execution": {
+        "type": "hybrid-service",
         "questions": [
           {
             "id": "email",
@@ -1283,6 +1292,7 @@
       ],
       "scaffoldActions": [],
       "execution": {
+        "type": "external-builder",
         "questions": [
           {
             "id": "email",
@@ -1376,6 +1386,7 @@
       ],
       "scaffoldActions": [],
       "execution": {
+        "type": "external-builder",
         "questions": [
           {
             "id": "email",
@@ -1485,6 +1496,7 @@
           "language": "typescript",
           "description": "Web SDK variant — checklist + renderChat",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -1537,7 +1549,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Start Vite and leave it running. Report the exact Local URL printed by Vite. Never open the URL yourself and never use browser automation. Wait for the user to open it in their normal browser where they are already signed in to Glean and tell you it is ready.",
               "command": "cd onboarding-hub && npm run dev"
             },
             {
@@ -1552,6 +1563,7 @@
           "language": "typescript",
           "description": "Client Chat variant — server-side API call, custom UI",
           "execution": {
+            "type": "local-web",
             "questions": [
               {
                 "id": "email",
@@ -1614,7 +1626,6 @@
             {
               "kind": "run",
               "title": "Run it",
-              "description": "Leave the verified app running at http://localhost:3000 and give that URL to the user.",
               "command": "cd onboarding-hub && npm start"
             }
           ]
@@ -1724,9 +1735,9 @@
         "typescript"
       ],
       "prerequisites": [
-        "A Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
-        "A work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
-        "X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
+        "For configured runs: a Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
+        "For configured runs: a work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
+        "For configured runs: X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
         "Node 20+"
       ],
       "demoQueries": [
@@ -1795,25 +1806,21 @@
         }
       ],
       "execution": {
+        "type": "local-web",
         "questions": [
           {
-            "id": "mode",
-            "prompt": "Do you want the instant fixture demo or a live tenant run?",
-            "required": true
-          },
-          {
             "id": "service",
-            "prompt": "For a live run, which service has a catalog entry, runbook, and past incident in Glean?",
+            "prompt": "Which service has a catalog entry, runbook, and past incident in Glean?",
             "required": true
           },
           {
             "id": "orchestrator",
-            "prompt": "For a live run, use direct Search + Chat or an existing Glean agent?",
+            "prompt": "Use direct Search + Chat or an existing Glean agent?",
             "required": true
           },
           {
             "id": "email",
-            "prompt": "For a live run, what is your work email?",
+            "prompt": "What is your work email?",
             "required": true
           }
         ],
@@ -1982,6 +1989,7 @@
           "language": "python",
           "description": "Platform API search.query → snippets → LLM with citations",
           "execution": {
+            "type": "cli",
             "questions": [
               {
                 "id": "email",
@@ -2021,6 +2029,10 @@
               "kind": "manual",
               "expectedDuration": "about 1 minute after sign-in",
               "startsOwnServer": false
+            },
+            "run": {
+              "command": "cd permissions-aware-retrieval && uv run main.py \"<allowed-topic>\"",
+              "userBrowser": false
             }
           },
           "steps": [
@@ -2053,6 +2065,7 @@
           "language": "typescript",
           "description": "Same flow in TypeScript",
           "execution": {
+            "type": "cli",
             "questions": [
               {
                 "id": "email",
@@ -2092,6 +2105,10 @@
               "kind": "manual",
               "expectedDuration": "about 1 minute after sign-in",
               "startsOwnServer": false
+            },
+            "run": {
+              "command": "cd permissions-aware-retrieval && npm start -- \"<allowed-topic>\"",
+              "userBrowser": false
             }
           },
           "steps": [
@@ -2204,8 +2221,8 @@
         "typescript"
       ],
       "prerequisites": [
-        "A Glean instance with your company content indexed",
-        "A work email for tenant discovery and OAuth sign-in; a CHAT-scoped API token is the fallback",
+        "For configured runs: a Glean instance with your company content indexed",
+        "For configured runs: a work email for tenant discovery and OAuth sign-in; a CHAT-scoped API token is the fallback",
         "Node 20+"
       ],
       "demoQueries": [
@@ -2270,20 +2287,16 @@
         }
       ],
       "execution": {
+        "type": "local-web",
         "questions": [
           {
-            "id": "mode",
-            "prompt": "Do you want the instant fixture demo or a live tenant run?",
-            "required": true
-          },
-          {
             "id": "approved-sources",
-            "prompt": "For a live run, which Glean URL prefixes are approved sources for external answers?",
+            "prompt": "Which Glean URL prefixes are approved sources for external answers?",
             "required": true
           },
           {
             "id": "email",
-            "prompt": "For a live run, what is your work email?",
+            "prompt": "What is your work email?",
             "required": true
           }
         ],

--- a/src/types/recipe.test.ts
+++ b/src/types/recipe.test.ts
@@ -76,6 +76,7 @@ describe('parseRecipeEntry', () => {
     const entry = {
       ...validEntry(),
       execution: {
+        type: 'local-web',
         questions: [
           {
             id: 'email',
@@ -117,6 +118,7 @@ describe('parseRecipeEntry', () => {
     const entry = {
       ...validEntry(),
       execution: {
+        type: 'cli',
         auth: [{ kind: 'none' }],
         verification: {
           kind: 'automated',
@@ -131,6 +133,7 @@ describe('parseRecipeEntry', () => {
     const entry = {
       ...validEntry(),
       execution: {
+        type: 'cli',
         auth: [{ kind: 'none' }],
         verification: {
           kind: 'manual',
@@ -146,6 +149,7 @@ describe('parseRecipeEntry', () => {
       const entry = {
         ...validEntry(),
         execution: {
+          type: 'local-web',
           auth: [{ kind: 'none' }],
           verification: {
             kind: 'manual',
@@ -162,6 +166,7 @@ describe('parseRecipeEntry', () => {
     const entry = {
       ...validEntry(),
       execution: {
+        type: 'existing-app',
         auth: [{ kind: 'browser-cookie' }],
         verification: {
           kind: 'user-browser',
@@ -174,6 +179,20 @@ describe('parseRecipeEntry', () => {
       },
     };
     expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(true);
+  });
+
+  it('requires an execution type when an execution contract is present', () => {
+    const entry = {
+      ...validEntry(),
+      execution: {
+        auth: [{ kind: 'none' }],
+        verification: {
+          kind: 'manual',
+          expectedDuration: 'about 1 minute',
+        },
+      },
+    };
+    expect(parseRecipeEntry(entry, 'embed-search-chat').success).toBe(false);
   });
 
   it('rejects unknown top-level keys', () => {

--- a/src/types/recipe.ts
+++ b/src/types/recipe.ts
@@ -121,6 +121,20 @@ export const RECIPE_BUILD_METHODS = [
   'third-party-build',
 ] as const;
 
+/**
+ * How a coding agent runs and hands off a recipe or variant. This is distinct
+ * from `category` (what problem it solves) and `buildMethod` (how the
+ * implementation is produced).
+ */
+export const RECIPE_EXECUTION_TYPES = [
+  'local-web',
+  'existing-app',
+  'cli',
+  'host-configuration',
+  'external-builder',
+  'hybrid-service',
+] as const;
+
 /** Visual category — drives the pastel tile color and icon (design handoff). */
 export const RECIPE_CATEGORIES = [
   'search',
@@ -191,6 +205,7 @@ export const recipeRunSchema = z.union([
 ]);
 
 export const recipeExecutionSchema = z.strictObject({
+  type: z.enum(RECIPE_EXECUTION_TYPES),
   questions: z.array(recipeQuestionSchema).default([]),
   auth: z
     .array(


### PR DESCRIPTION
## Summary
- add the execution type enum to recipe execution contracts
- require a type for root and variant-level execution metadata
- regenerate the JSON schema and cover the required field in schema tests
- atomically sync the registry and compiled recipe data from the cookbook implementation branch

Cookbook implementation: https://github.com/gleanwork/glean-cookbook/pull/31

## Validation
- pnpm test: 207 passed, 2 skipped
- FF_COOKBOOKS=true pnpm build
- all 13 cookbook entries pass the updated source schema
- generated schema and recipe snapshots are current