### PR TITLE
[NI][docs] Correct PushUploader delete argument

### DIFF
--- a/docs/libraries/indexing-sdk/push/uploader.mdx
+++ b/docs/libraries/indexing-sdk/push/uploader.mdx
@@ -78,7 +78,7 @@ This is the right call for event-driven connectors reacting to a webhook.
 ### Deleting
 
 ```python
-uploader.delete_document(object_type="article", doc_id="page_123")
+uploader.delete_document(object_type="article", document_id="page_123")
 ```
 
 ### Pre-supplied batches

--- a/docs/libraries/indexing-sdk/testing/end-to-end.mdx
+++ b/docs/libraries/indexing-sdk/testing/end-to-end.mdx
@@ -106,7 +106,7 @@ from glean.indexing.push import PushUploader
 
 uploader = PushUploader(datasource="company_wiki")
 for doc_id in created_ids:
-    uploader.delete_document(object_type="article", doc_id=doc_id)
+    uploader.delete_document(object_type="article", document_id=doc_id)
 ```
 
 Identity records need explicit deletion too: `delete_user()`, `delete_group()`,


### PR DESCRIPTION
The Indexing SDK guides pass an unsupported `doc_id` keyword to `PushUploader.delete_document`, so users copying either example get a `TypeError`.

## Summary
- Use the API's `document_id` keyword in both affected examples.

## Test plan
- `git diff --check`
- Verified both examples against the published `PushUploader.delete_document` signature
- Local pnpm build/tests were blocked before execution because Socket policy rejects the repository-pinned pnpm 10.13.1; CI will run repository validation

Made with [Cursor](https://cursor.com)