### PR TITLE
[Docs] Hide experimental opt-in control in the API Explorer

### DIFF
--- a/scripts/openapi-capitalize-language.mjs
+++ b/scripts/openapi-capitalize-language.mjs
@@ -50,6 +50,31 @@ const HTTP_METHODS = [
 ];
 
 const EXPERIMENTAL_HEADER_NAME = 'X-Glean-Include-Experimental';
+const EXPERIMENTAL_HEADER_DESCRIPTION =
+  'This endpoint is experimental, so requests must include this header set to `true`. See [How experimental APIs work](https://developers.glean.com/experimental/overview) for details.';
+
+function isExperimentalHeaderParam(param) {
+  return (
+    typeof param?.name === 'string' &&
+    param.name.toLowerCase() === EXPERIMENTAL_HEADER_NAME.toLowerCase()
+  );
+}
+
+function normalizeExperimentalHeader(param) {
+  param.in = 'header';
+  param.required = true;
+  const schema =
+    param.schema && typeof param.schema === 'object' && !param.schema.$ref
+      ? param.schema
+      : {};
+  param.schema = { ...schema, type: 'boolean', default: true };
+  param.example = true;
+  param.value = 'true';
+  if (typeof param.description !== 'string' || param.description.length === 0) {
+    param.description = EXPERIMENTAL_HEADER_DESCRIPTION;
+  }
+}
+
 const SKILLS_MULTIPART_OPERATION_IDS = new Set([
   'platform-skills-create',
   'platform-skills-validate',
@@ -71,6 +96,9 @@ const SKILLS_MULTIPART_OPERATION_IDS = new Set([
  * generator (ApiExplorer/buildPostmanRequest `setHeaders`) only emits a
  * header parameter when the parameter object carries a truthy `value`, so
  * pre-setting it makes the header appear in the generated cURL example.
+ * Existing declarations are normalized to that same contract instead of
+ * being skipped, so a header without `value` cannot hide from the
+ * explorer while also being omitted from Send.
  */
 export function injectExperimentalHeaders(apiSpec) {
   const paths = apiSpec?.paths;
@@ -90,19 +118,18 @@ export function injectExperimentalHeaders(apiSpec) {
       }
 
       operation.parameters ??= [];
-      const alreadyDeclared = operation.parameters.some(
-        (param) =>
-          param?.in === 'header' &&
-          typeof param?.name === 'string' &&
-          param.name.toLowerCase() === EXPERIMENTAL_HEADER_NAME.toLowerCase(),
+      const existingHeader = operation.parameters.find((param) =>
+        isExperimentalHeaderParam(param),
       );
-      if (alreadyDeclared) continue;
+      if (existingHeader) {
+        normalizeExperimentalHeader(existingHeader);
+        continue;
+      }
 
       operation.parameters.unshift({
         in: 'header',
         name: EXPERIMENTAL_HEADER_NAME,
-        description:
-          'This endpoint is experimental, so requests must include this header set to `true`. See [How experimental APIs work](https://developers.glean.com/experimental/overview) for details.',
+        description: EXPERIMENTAL_HEADER_DESCRIPTION,
         required: true,
         schema: {
           type: 'boolean',

--- a/scripts/openapi-capitalize-language.test.ts
+++ b/scripts/openapi-capitalize-language.test.ts
@@ -49,6 +49,7 @@ paths:
     expect(header.name).toBe(HEADER_NAME);
     expect(header.required).toBe(true);
     expect(header.schema).toEqual({ type: 'boolean', default: true });
+    expect(header.example).toBe(true);
     // Non-standard `value` pre-fills the generated cURL snippet in
     // docusaurus-theme-openapi-docs (see buildPostmanRequest setHeaders).
     expect(header.value).toBe('true');
@@ -120,6 +121,108 @@ paths:
 
     const params = spec.paths['/rest/api/v1/search'].post.parameters;
     expect(params.filter((p: any) => p.name === HEADER_NAME)).toHaveLength(1);
+    expect(params[0].value).toBe('true');
+    expect(params[0].required).toBe(true);
+  });
+
+  it('normalizes an already declared header that is missing a value', () => {
+    const spec = loadSpec(`
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /rest/api/v1/search:
+    post:
+      operationId: search
+      x-glean-experimental:
+        id: abc
+      parameters:
+        - in: header
+          name: ${HEADER_NAME}
+          description: Keep this description.
+          x-custom: leftover
+      responses:
+        200:
+          description: Success
+`);
+
+    injectExperimentalHeaders(spec);
+
+    const header = spec.paths['/rest/api/v1/search'].post.parameters[0];
+    expect(header.in).toBe('header');
+    expect(header.required).toBe(true);
+    expect(header.schema).toEqual({ type: 'boolean', default: true });
+    expect(header.example).toBe(true);
+    expect(header.value).toBe('true');
+    expect(header.description).toBe('Keep this description.');
+    expect(header['x-custom']).toBe('leftover');
+    expect(
+      spec.paths['/rest/api/v1/search'].post.parameters.filter(
+        (p: any) => p.name === HEADER_NAME,
+      ),
+    ).toHaveLength(1);
+  });
+
+  it('matches an already declared header case-insensitively', () => {
+    const spec = loadSpec(`
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /rest/api/v1/search:
+    post:
+      operationId: search
+      x-glean-experimental:
+        id: abc
+      parameters:
+        - in: header
+          name: x-glean-include-experimental
+          required: true
+      responses:
+        200:
+          description: Success
+`);
+
+    injectExperimentalHeaders(spec);
+
+    const params = spec.paths['/rest/api/v1/search'].post.parameters;
+    expect(params).toHaveLength(1);
+    expect(params[0].name).toBe('x-glean-include-experimental');
+    expect(params[0].value).toBe('true');
+    expect(params[0].schema).toEqual({ type: 'boolean', default: true });
+  });
+
+  it('moves a same-name parameter into the header location', () => {
+    const spec = loadSpec(`
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0.0"
+paths:
+  /rest/api/v1/search:
+    post:
+      operationId: search
+      x-glean-experimental:
+        id: abc
+      parameters:
+        - in: query
+          name: ${HEADER_NAME}
+          description: Keep this description.
+      responses:
+        200:
+          description: Success
+`);
+
+    injectExperimentalHeaders(spec);
+
+    const params = spec.paths['/rest/api/v1/search'].post.parameters;
+    expect(params).toHaveLength(1);
+    expect(params[0].in).toBe('header');
+    expect(params[0].name).toBe(HEADER_NAME);
+    expect(params[0].value).toBe('true');
+    expect(params[0].description).toBe('Keep this description.');
   });
 
   it('handles specs without paths', () => {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -584,6 +584,11 @@ span.openapi-schema__container {
   margin-top: 12px;
 }
 
+.openapi-explorer__request-form
+  .openapi-explorer__details-container:has(> summary:only-child) {
+  display: none;
+}
+
 .openapi-explorer__response-container {
   border-radius: 16px;
   border: 1px solid var(--gdt-border-light);

--- a/src/theme/ApiExplorer/ParamOptions/index.test.tsx
+++ b/src/theme/ApiExplorer/ParamOptions/index.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const explorerState = {
+  params: {
+    path: [] as Array<Record<string, unknown>>,
+    query: [] as Array<Record<string, unknown>>,
+    cookie: [] as Array<Record<string, unknown>>,
+    header: [] as Array<Record<string, unknown>>,
+  },
+};
+
+vi.mock('@theme/ApiItem/hooks', () => ({
+  useTypedSelector: (selector: (state: typeof explorerState) => unknown) =>
+    selector(explorerState),
+}));
+
+vi.mock('@docusaurus/Translate', () => ({
+  translate: ({ message }: { message: string }) => message,
+}));
+
+vi.mock('@theme/translationIds', () => ({
+  OPENAPI_PARAM_OPTIONS: {
+    HIDE_OPTIONAL: 'hide-optional',
+    SHOW_OPTIONAL: 'show-optional',
+  },
+}));
+
+vi.mock('@theme/ApiExplorer/FormItem', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const booleanSpy = vi.fn(({ param }: { param: { name: string } }) => (
+  <select aria-label={param.name} data-testid={`ctrl-${param.name}`} />
+));
+
+vi.mock(
+  '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem',
+  () => ({
+    default: (props: { param: { name: string } }) => booleanSpy(props),
+  }),
+);
+
+vi.mock(
+  '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem',
+  () => ({
+    default: ({ param }: { param: { name: string } }) => (
+      <input aria-label={param.name} data-testid={`ctrl-${param.name}`} />
+    ),
+  }),
+);
+
+vi.mock(
+  '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem',
+  () => ({
+    default: ({ param }: { param: { name: string } }) => (
+      <input aria-label={param.name} data-testid={`ctrl-${param.name}`} />
+    ),
+  }),
+);
+
+vi.mock(
+  '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem',
+  () => ({
+    default: ({ param }: { param: { name: string } }) => (
+      <select aria-label={param.name} data-testid={`ctrl-${param.name}`} />
+    ),
+  }),
+);
+
+vi.mock(
+  '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem',
+  () => ({
+    default: ({ param }: { param: { name: string } }) => (
+      <select aria-label={param.name} data-testid={`ctrl-${param.name}`} />
+    ),
+  }),
+);
+
+describe('ParamOptions explorer visibility', () => {
+  beforeEach(() => {
+    booleanSpy.mockClear();
+    explorerState.params = {
+      path: [],
+      query: [],
+      cookie: [],
+      header: [],
+    };
+  });
+
+  it('does not mount a form controller for the experimental header', async () => {
+    explorerState.params.header = [
+      {
+        in: 'header',
+        name: 'X-Glean-Include-Experimental',
+        required: true,
+        schema: { type: 'boolean', default: true },
+        value: 'true',
+      },
+    ];
+
+    const { default: ParamOptions } = await import('./index');
+    const { container } = render(<ParamOptions />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(booleanSpy).not.toHaveBeenCalled();
+    expect(
+      screen.queryByLabelText('X-Glean-Include-Experimental'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('still renders unrelated parameter controls', async () => {
+    explorerState.params.query = [
+      {
+        in: 'query',
+        name: 'q',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ];
+    explorerState.params.header = [
+      {
+        in: 'header',
+        name: 'X-Glean-Include-Experimental',
+        required: true,
+        schema: { type: 'boolean', default: true },
+        value: 'true',
+      },
+      {
+        in: 'header',
+        name: 'Accept',
+        required: true,
+        schema: { type: 'string' },
+      },
+    ];
+
+    const { default: ParamOptions } = await import('./index');
+    render(<ParamOptions />);
+
+    expect(screen.getByTestId('ctrl-q')).toBeInTheDocument();
+    expect(screen.getByTestId('ctrl-Accept')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('ctrl-X-Glean-Include-Experimental'),
+    ).not.toBeInTheDocument();
+    expect(booleanSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/theme/ApiExplorer/ParamOptions/index.tsx
+++ b/src/theme/ApiExplorer/ParamOptions/index.tsx
@@ -1,0 +1,246 @@
+/* ============================================================================
+ * Copyright (c) Palo Alto Networks
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * ========================================================================== */
+
+/**
+ * Ejected from docusaurus-theme-openapi-docs@5.0.2 ParamOptions.
+ * Filters X-Glean-Include-Experimental out of the visible form before any
+ * React Hook Form controller mounts. Redux still holds the full parameter
+ * so generated cURL and Send keep the header.
+ */
+import React, { useState, useId } from 'react';
+
+import { translate } from '@docusaurus/Translate';
+import FormItem from '@theme/ApiExplorer/FormItem';
+import ParamArrayFormItem from '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamArrayFormItem';
+import ParamBooleanFormItem from '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamBooleanFormItem';
+import ParamMultiSelectFormItem from '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamMultiSelectFormItem';
+import ParamSelectFormItem from '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamSelectFormItem';
+import ParamTextFormItem from '@theme/ApiExplorer/ParamOptions/ParamFormItems/ParamTextFormItem';
+import { useTypedSelector } from '@theme/ApiItem/hooks';
+import { OPENAPI_PARAM_OPTIONS } from '@theme/translationIds';
+
+import { isVisibleInExplorer } from './isVisibleInExplorer';
+
+type Param = {
+  in?: string;
+  name?: string;
+  required?: boolean;
+  schema?: any;
+};
+
+export interface LabelProps {
+  label?: string;
+  type?: string;
+  required?: boolean;
+}
+
+export interface ParamProps {
+  param: Param;
+}
+
+export function getSchemaEnum(schema: any): any[] | undefined {
+  if (schema?.enum) {
+    return schema.enum;
+  }
+
+  if (schema?.allOf && Array.isArray(schema.allOf)) {
+    for (const item of schema.allOf) {
+      if (item.enum) {
+        return item.enum;
+      }
+    }
+  }
+
+  if (schema?.const !== undefined) {
+    return [schema.const];
+  }
+
+  return undefined;
+}
+
+function ParamOption({
+  param,
+  label,
+  type,
+  required,
+}: ParamProps & LabelProps) {
+  const schemaEnum = getSchemaEnum(param.schema);
+  const itemsEnum = getSchemaEnum(param.schema?.items);
+
+  if (param.schema?.type === 'array' && itemsEnum) {
+    return (
+      <ParamMultiSelectFormItem
+        param={param}
+        label={label}
+        type={type}
+        required={required}
+      />
+    );
+  }
+
+  if (param.schema?.type === 'array') {
+    return (
+      <ParamArrayFormItem
+        param={param}
+        label={label}
+        type={type}
+        required={required}
+      />
+    );
+  }
+
+  if (schemaEnum) {
+    return (
+      <ParamSelectFormItem
+        param={param}
+        label={label}
+        type={type}
+        required={required}
+      />
+    );
+  }
+
+  if (param.schema?.type === 'boolean') {
+    return (
+      <ParamBooleanFormItem
+        param={param}
+        label={label}
+        type={type}
+        required={required}
+      />
+    );
+  }
+
+  return (
+    <ParamTextFormItem
+      param={param}
+      label={label}
+      type={type}
+      required={required}
+    />
+  );
+}
+
+function ParamOptionWrapper({ param }: ParamProps) {
+  return (
+    <FormItem>
+      <ParamOption
+        param={param}
+        label={param.name}
+        type={param.in}
+        required={param.required}
+      />
+    </FormItem>
+  );
+}
+
+function ParamOptions() {
+  const [showOptional, setShowOptional] = useState(false);
+
+  const optionalId = useId();
+
+  const pathParams = useTypedSelector((state: any) => state.params.path);
+  const queryParams = useTypedSelector((state: any) => state.params.query);
+  const cookieParams = useTypedSelector((state: any) => state.params.cookie);
+  const headerParams = useTypedSelector((state: any) => state.params.header);
+
+  const allParams = [
+    ...pathParams,
+    ...queryParams,
+    ...cookieParams,
+    ...headerParams,
+  ].filter(isVisibleInExplorer);
+
+  if (allParams.length === 0) {
+    return null;
+  }
+
+  const requiredParams = allParams.filter((p) => p.required);
+  const optionalParams = allParams.filter((p) => !p.required);
+
+  return (
+    <>
+      {requiredParams.map((param) => (
+        <ParamOptionWrapper key={`${param.in}-${param.name}`} param={param} />
+      ))}
+
+      {optionalParams.length > 0 && (
+        <>
+          <button
+            type="button"
+            className="openapi-explorer__show-more-btn"
+            aria-expanded={showOptional}
+            aria-controls={optionalId}
+            onClick={() => setShowOptional((prev) => !prev)}
+          >
+            <span
+              style={{
+                width: '1.5em',
+                display: 'inline-block',
+                textAlign: 'center',
+              }}
+            >
+              <span
+                className={
+                  showOptional
+                    ? 'openapi-explorer__plus-btn--expanded'
+                    : 'openapi-explorer__plus-btn'
+                }
+              >
+                <div>
+                  <svg
+                    style={{
+                      fill: 'currentColor',
+                      width: '10px',
+                      height: '10px',
+                    }}
+                    height="16"
+                    viewBox="0 0 16 16"
+                    width="16"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9 7h6a1 1 0 0 1 0 2H9v6a1 1 0 0 1-2 0V9H1a1 1 0 1 1 0-2h6V1a1 1 0 1 1 2 0z"
+                      fillRule="evenodd"
+                    ></path>
+                  </svg>
+                </div>
+              </span>
+            </span>
+            {showOptional
+              ? translate({
+                  id: OPENAPI_PARAM_OPTIONS.HIDE_OPTIONAL,
+                  message: 'Hide optional parameters',
+                })
+              : translate({
+                  id: OPENAPI_PARAM_OPTIONS.SHOW_OPTIONAL,
+                  message: 'Show optional parameters',
+                })}
+          </button>
+
+          <div
+            className={
+              showOptional
+                ? 'openapi-explorer__show-options'
+                : 'openapi-explorer__hide-options'
+            }
+            id={optionalId}
+          >
+            {optionalParams.map((param) => (
+              <ParamOptionWrapper
+                key={`${param.in}-${param.name}`}
+                param={param}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}
+
+export default ParamOptions;

--- a/src/theme/ApiExplorer/ParamOptions/isVisibleInExplorer.test.ts
+++ b/src/theme/ApiExplorer/ParamOptions/isVisibleInExplorer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { isVisibleInExplorer } from './isVisibleInExplorer';
+
+describe('isVisibleInExplorer', () => {
+  it('hides the experimental header regardless of casing', () => {
+    expect(
+      isVisibleInExplorer({
+        in: 'header',
+        name: 'X-Glean-Include-Experimental',
+      }),
+    ).toBe(false);
+    expect(
+      isVisibleInExplorer({
+        in: 'header',
+        name: 'x-glean-include-experimental',
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps unrelated headers and non-header parameters', () => {
+    expect(isVisibleInExplorer({ in: 'header', name: 'Authorization' })).toBe(
+      true,
+    );
+    expect(
+      isVisibleInExplorer({
+        in: 'query',
+        name: 'X-Glean-Include-Experimental',
+      }),
+    ).toBe(true);
+    expect(isVisibleInExplorer({ in: 'path', name: 'id' })).toBe(true);
+  });
+
+  it('filters mixed lists while leaving only-hidden lists empty', () => {
+    const mixed = [
+      { in: 'query', name: 'q' },
+      { in: 'header', name: 'X-Glean-Include-Experimental' },
+      { in: 'header', name: 'Accept' },
+    ].filter(isVisibleInExplorer);
+    expect(mixed.map((p) => p.name)).toEqual(['q', 'Accept']);
+
+    const onlyHidden = [
+      { in: 'header', name: 'x-glean-include-experimental' },
+    ].filter(isVisibleInExplorer);
+    expect(onlyHidden).toEqual([]);
+  });
+});

--- a/src/theme/ApiExplorer/ParamOptions/isVisibleInExplorer.ts
+++ b/src/theme/ApiExplorer/ParamOptions/isVisibleInExplorer.ts
@@ -1,0 +1,16 @@
+export const EXPERIMENTAL_HEADER_NAME = 'X-Glean-Include-Experimental';
+
+export function isVisibleInExplorer(parameter: {
+  in?: string;
+  name?: string;
+}): boolean {
+  if (parameter.in !== 'header') {
+    return true;
+  }
+  if (typeof parameter.name !== 'string') {
+    return true;
+  }
+  return (
+    parameter.name.toLowerCase() !== EXPERIMENTAL_HEADER_NAME.toLowerCase()
+  );
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,18 @@ export default defineConfig({
   resolve: {
     alias: {
       '@site': path.resolve(__dirname, './'),
+      '@theme/ApiExplorer': path.resolve(
+        __dirname,
+        './node_modules/docusaurus-theme-openapi-docs/lib/theme/ApiExplorer',
+      ),
+      '@theme/ApiItem': path.resolve(
+        __dirname,
+        './node_modules/docusaurus-theme-openapi-docs/lib/theme/ApiItem',
+      ),
+      '@theme/translationIds': path.resolve(
+        __dirname,
+        './node_modules/docusaurus-theme-openapi-docs/lib/theme/translationIds.js',
+      ),
       '@theme': path.resolve(
         __dirname,
         './node_modules/@docusaurus/theme-classic/lib/theme',


### PR DESCRIPTION
Experimental endpoints already send `X-Glean-Include-Experimental: true` in generated cURL and live Send, but the visible try-it panel still showed a required true/false control. Leaving it at `---` blocked Send even though the request was already correct.

This rebuilds the branch on current `main` (visible Request/Response from #638) and hides that header only in the explorer form. Redux still holds the parameter, so docs, cURL, and Send keep `X-Glean-Include-Experimental: true`. Header-only pages no longer show an empty Parameters accordion.

Existing spec declarations are normalized to header location, required boolean, `default: true`, `example: true`, and `value: 'true'` without regenerating OpenAPI artifacts.

## Test plan
- [x] Focused vitest: transform, visibility predicate, and ParamOptions controller-mount tests
- [x] `pnpm build`
- [x] Production serve `/api/platform-api/platform-search`: no experimental control, no empty Parameters accordion, left docs still required, cURL and intercepted Send include `true`
- [x] `/api/platform-api/platform-search-filters`: other controls remain, header hidden, cURL and Send retain `true`
- [x] `/api/platform-api/platform-agents-create-run`: unrelated controls still visible