### PR TITLE
[Docs] Add PATCH API method styling

### DIFF
--- a/src/components/ApiOAuth/oauth.test.ts
+++ b/src/components/ApiOAuth/oauth.test.ts
@@ -25,13 +25,13 @@ describe('API Explorer OAuth helpers', () => {
       'agents',
     );
     expect(scopeForPath('/api/platform-api/platform-search')).toBe('search');
+    expect(scopeForPath('/api/platform-api/platform-skills-list')).toBe(
+      'skills',
+    );
   });
 
   it('returns undefined for unmapped groups so no scope is requested', () => {
     expect(scopeForPath('/api/client-api/messages/list')).toBeUndefined();
-    expect(
-      scopeForPath('/api/platform-api/platform-skills-list'),
-    ).toBeUndefined();
     expect(scopeForPath('/api/indexing-api/index-document')).toBeUndefined();
   });
 });

--- a/src/components/ApiOAuth/oauth.ts
+++ b/src/components/ApiOAuth/oauth.ts
@@ -36,6 +36,7 @@ const PATH_SCOPES: Record<string, string> = {
   pins: 'pins',
   search: 'search',
   shortcuts: 'shortcuts',
+  skills: 'skills',
   summarize: 'summarize',
   tools: 'tools',
   verification: 'verification',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -338,6 +338,23 @@
   --ifm-badge-border-color: none;
 }
 
+.patch > .menu__link::before {
+  content: 'PATCH';
+  background-color: rgba(168, 85, 247, 0.2);
+  color: #7e22ce;
+}
+
+.patch > .menu__link--active::before {
+  background-color: #9333ea;
+  color: #ffffff;
+}
+
+.openapi__method-endpoint > .badge--warning {
+  background-color: #9333ea;
+  color: #ffffff;
+  --ifm-badge-border-color: none;
+}
+
 [data-theme='dark'] .post > .menu__link::before {
   color: #60a5fa;
 }
@@ -377,6 +394,20 @@
 
 [data-theme='dark'] .badge--info {
   background-color: #f59e0b;
+  color: #ffffff;
+}
+
+[data-theme='dark'] .patch > .menu__link::before {
+  color: #c084fc;
+}
+
+[data-theme='dark'] .patch > .menu__link--active::before {
+  background-color: #a855f7;
+  color: #ffffff;
+}
+
+[data-theme='dark'] .openapi__method-endpoint > .badge--warning {
+  background-color: #a855f7;
   color: #ffffff;
 }
 


### PR DESCRIPTION
## Summary

- add the missing PATCH method label to generated API sidebar entries
- give PATCH endpoint badges a distinct purple treatment instead of the generic warning yellow
- scope the header override to OpenAPI method badges so other warning badges are unchanged

<img width="1389" height="777" alt="Screenshot 2026-08-13 at 11 40 18 AM" src="https://github.com/user-attachments/assets/032048bb-2b90-4f7e-9a3e-e9c3bacf2b44" />
Before

<img width="1389" height="777" alt="Screenshot 2026-08-13 at 11 41 07 AM" src="https://github.com/user-attachments/assets/42edafdc-f77a-4912-9ba1-ec3314819d21" />
After

## Test plan

- `pnpm exec prettier --check src/css/custom.css`
- `pnpm build`
- visually verified `/api/platform-api/platform-skills-update` in dark mode
- `pnpm test` (208 tests pass; 6 existing Web SDK tests fail because `window.localStorage` is undefined in the local test environment)