### PR TITLE
[Docs] Refresh API Explorer OAuth clients when scopes change

### DIFF
--- a/src/components/ApiOAuth/oauth.test.ts
+++ b/src/components/ApiOAuth/oauth.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { isOAuthEligiblePath, scopeForPath } from './oauth';
+import {
+  clientRegistrationCacheKey,
+  isOAuthEligiblePath,
+  scopeForPath,
+} from './oauth';
 
 describe('API Explorer OAuth helpers', () => {
   it('offers OAuth on Client and Platform API pages, not Indexing', () => {
@@ -33,5 +37,23 @@ describe('API Explorer OAuth helpers', () => {
   it('returns undefined for unmapped groups so no scope is requested', () => {
     expect(scopeForPath('/api/client-api/messages/list')).toBeUndefined();
     expect(scopeForPath('/api/indexing-api/index-document')).toBeUndefined();
+  });
+
+  it('refreshes a registered client when the server scope set changes', () => {
+    const original = clientRegistrationCacheKey({
+      issuer: 'https://example-be.glean.com',
+      scopes_supported: ['search', 'chat'],
+    });
+    const reordered = clientRegistrationCacheKey({
+      issuer: 'https://example-be.glean.com',
+      scopes_supported: ['chat', 'search'],
+    });
+    const withSkills = clientRegistrationCacheKey({
+      issuer: 'https://example-be.glean.com',
+      scopes_supported: ['chat', 'search', 'skills'],
+    });
+
+    expect(reordered).toBe(original);
+    expect(withSkills).not.toBe(original);
   });
 });

--- a/src/components/ApiOAuth/oauth.ts
+++ b/src/components/ApiOAuth/oauth.ts
@@ -88,6 +88,16 @@ async function discover(serverUrl: string): Promise<ServerMetadata> {
   return res.json();
 }
 
+export function clientRegistrationCacheKey(metadata: {
+  issuer: string;
+  scopes_supported?: string[];
+}): string {
+  const supportedScopes = [...new Set(metadata.scopes_supported ?? [])]
+    .sort()
+    .join(' ');
+  return `${metadata.issuer}|${supportedScopes}`;
+}
+
 /** Register (or reuse) a public client for this issuer via DCR. */
 async function getClientId(metadata: ServerMetadata): Promise<string> {
   let cache: Record<string, string> = {};
@@ -96,8 +106,11 @@ async function getClientId(metadata: ServerMetadata): Promise<string> {
   } catch {
     // Corrupt cache; re-register.
   }
-  if (cache[metadata.issuer]) {
-    return cache[metadata.issuer];
+  // Dynamic clients receive their allowed scopes at registration time. Include
+  // the server's advertised scope set so newly added scopes trigger a refresh.
+  const cacheKey = clientRegistrationCacheKey(metadata);
+  if (cache[cacheKey]) {
+    return cache[cacheKey];
   }
   if (!metadata.registration_endpoint) {
     throw new Error(
@@ -119,7 +132,7 @@ async function getClientId(metadata: ServerMetadata): Promise<string> {
     throw new Error(`Client registration failed (HTTP ${res.status}).`);
   }
   const { client_id: clientId } = await res.json();
-  cache[metadata.issuer] = clientId;
+  cache[cacheKey] = clientId;
   localStorage.setItem(CLIENT_ID_STORE, JSON.stringify(cache));
   return clientId;
 }


### PR DESCRIPTION
## Summary

- key cached dynamically registered OAuth clients by the server's advertised scope set
- automatically register a fresh client when an instance adds or removes OAuth scopes
- fix the empty Skills consent screen caused by clients cached before the `skills` scope was available

## Before

The API Explorer reused a client whose allowed scopes were snapshotted at registration. Requesting a newly introduced scope produced a consent screen with no permissions and failed with `Please select at least one permission to grant`.

## After

A change to `scopes_supported` invalidates the cached client and triggers dynamic registration with the current allowed scopes. Scope ordering does not invalidate the cache.

## Test plan

- `pnpm exec vitest run src/components/ApiOAuth/oauth.test.ts`
- `pnpm exec prettier --check src/components/ApiOAuth/oauth.ts src/components/ApiOAuth/oauth.test.ts`
- `git diff --check`