### PR TITLE
[Docs] Neutral cookbook flagship chrome and scrollable architecture

### DIFF
--- a/src/components/Cookbook/Cookbook.test.tsx
+++ b/src/components/Cookbook/Cookbook.test.tsx
@@ -1,10 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RecipeIndex from './RecipeIndex';
-import RecipeLayout from './RecipeLayout';
+import RecipeLayout, { RecipeArchitecture } from './RecipeLayout';
 import FlagshipCard from './FlagshipCard';
 import type { RecipeRecord } from '../../types/recipe';
+import catStyles from './categories.module.css';
+import layoutStyles from './RecipeLayout.module.css';
+
+function readCss(fileName: string): string {
+  return fs.readFileSync(path.resolve(__dirname, fileName), 'utf8');
+}
 
 function makeRecipe(overrides: Partial<RecipeRecord>): RecipeRecord {
   return {
@@ -121,6 +129,20 @@ describe('FlagshipCard', () => {
     expect(screen.getByText('Combines three recipes')).toBeInTheDocument();
     expect(screen.getByText('Index a developer catalog')).toBeInTheDocument();
     expect(screen.getByText('Ground chat in the catalog')).toBeInTheDocument();
+  });
+
+  it('uses the regular light border and a neutral pill', () => {
+    const css = readCss('FlagshipCard.module.css');
+    expect(css).toMatch(
+      /\.card\s*\{[^}]*border:\s*1px solid var\(--gdt-border-light\)/s,
+    );
+    expect(css).not.toMatch(
+      /\.card\s*\{[^}]*border:\s*1\.5px solid var\(--gdt-primary\)/s,
+    );
+    expect(css).toMatch(/\.pill\s*\{[^}]*background:\s*var\(--gdt-bg-mid\)/s);
+    expect(css).not.toMatch(
+      /\.pill\s*\{[^}]*background:\s*var\(--gdt-primary\)/s,
+    );
   });
 });
 
@@ -332,6 +354,81 @@ describe('RecipeLayout', () => {
     expect(screen.queryByText(/cursor plugin/)).not.toBeInTheDocument();
     expect(screen.getByText(/Import from Repo/)).toBeInTheDocument();
     expect(screen.getByText('/embed-search-chat')).toBeInTheDocument();
+  });
+
+  it('does not render a category tile beside the title', () => {
+    render(
+      <RecipeLayout plugin={plugin} recipe={makeRecipe({})}>
+        <p>Body</p>
+      </RecipeLayout>,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Embed search & chat' }),
+    ).toBeInTheDocument();
+    expect(document.querySelector(`.${catStyles.tile}`)).toBeNull();
+  });
+
+  it('renders architecture in a horizontally scrollable canvas', () => {
+    render(
+      <RecipeLayout
+        plugin={plugin}
+        recipe={makeRecipe({
+          architecture: [
+            {
+              label: 'App',
+              caption: 'frontend',
+              emphasized: false,
+            },
+            {
+              label: 'Glean',
+              caption: 'index',
+              emphasized: true,
+            },
+            {
+              label: 'Auth',
+              caption: 'SSO',
+              emphasized: false,
+            },
+            {
+              label: 'Portal',
+              caption: 'UI',
+              emphasized: false,
+            },
+          ],
+        })}
+      >
+        <RecipeArchitecture />
+      </RecipeLayout>,
+    );
+
+    expect(screen.getByText('Architecture')).toBeInTheDocument();
+    expect(screen.getByText('App')).toBeInTheDocument();
+    expect(screen.getByText('Portal')).toBeInTheDocument();
+    expect(
+      document.querySelector(`.${layoutStyles.archCanvas}`),
+    ).not.toBeNull();
+  });
+
+  it('scrolls the flowchart horizontally instead of stacking it', () => {
+    const css = readCss('RecipeLayout.module.css');
+    expect(css).toMatch(/\.archCanvas\s*\{[^}]*overflow-x:\s*auto/s);
+    expect(css).toMatch(/\.archNode\s*\{[^}]*flex:\s*1 0 /s);
+    expect(css).not.toMatch(
+      /@media \(max-width: 700px\)[\s\S]*\.archFlow\s*\{[\s\S]*flex-direction:\s*column/,
+    );
+  });
+
+  it('every recipe page goes through RecipePage, so title layout applies to all of them', () => {
+    const dir = path.resolve(__dirname, '../../../docs/cookbook');
+    const files = fs
+      .readdirSync(dir)
+      .filter((file) => file.endsWith('.mdx') && file !== 'index.mdx');
+    expect(files.length).toBeGreaterThanOrEqual(12);
+    for (const file of files) {
+      const src = fs.readFileSync(path.join(dir, file), 'utf8');
+      expect(src).toContain('<RecipePage recipeId=');
+    }
   });
 
   it('keeps copy-prompt for recipes whose mechanism really is prose', () => {

--- a/src/components/Cookbook/FlagshipCard.module.css
+++ b/src/components/Cookbook/FlagshipCard.module.css
@@ -1,4 +1,4 @@
-/* Flagship hero card — design handoff 4a, exact values */
+/* Flagship hero card */
 
 .card {
   display: grid;
@@ -7,7 +7,7 @@
   align-items: center;
   padding: 36px;
   border-radius: 22px;
-  border: 1.5px solid var(--gdt-primary);
+  border: 1px solid var(--gdt-border-light);
   background: linear-gradient(150deg, #eef0ff 0%, #f7f8ff 45%, #ffffff 100%);
   text-decoration: none;
   color: var(--gdt-text-primary);
@@ -37,8 +37,8 @@ html[data-theme='dark'] .card {
   height: 26px;
   padding: 0 12px;
   border-radius: 9999px;
-  background: var(--gdt-primary);
-  color: #fff;
+  background: var(--gdt-bg-mid);
+  color: var(--gdt-text-secondary);
   font-family: var(--ifm-font-family-monospace);
   font-size: 11px;
   font-weight: 600;

--- a/src/components/Cookbook/FlagshipCard.tsx
+++ b/src/components/Cookbook/FlagshipCard.tsx
@@ -10,9 +10,9 @@ interface FlagshipCardProps {
 }
 
 /**
- * Flagship hero card per design handoff 4a: full-width, blue 1.5px border,
- * light gradient, "Combines N recipes" mini-list on the right built from the
- * recipe's `combines` frontmatter.
+ * Flagship hero card: full-width, regular light border, light gradient,
+ * "Combines N recipes" mini-list on the right built from the recipe's
+ * `combines` frontmatter.
  */
 export default function FlagshipCard({
   recipe,

--- a/src/components/Cookbook/RecipeLayout.module.css
+++ b/src/components/Cookbook/RecipeLayout.module.css
@@ -34,13 +34,10 @@ html[data-theme='dark'] .banner {
 }
 
 .bannerMain {
-  display: flex;
-  align-items: center;
-  gap: 14px;
   margin-bottom: 14px;
 }
 
-.banner h1.banner h1.bannerTitle {
+.banner h1.bannerTitle {
   font-family: var(--gdt-font-display);
   font-size: 32px;
   letter-spacing: 0;
@@ -284,6 +281,19 @@ html[data-theme='dark'] .banner {
   background-color: var(--gdt-bg-light);
   background-image: radial-gradient(#e0e2ea 1px, transparent 1px);
   background-size: 16px 16px;
+  overflow-x: auto;
+  max-width: 100%;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gdt-border-dark) transparent;
+}
+
+.archCanvas::-webkit-scrollbar {
+  height: 6px;
+}
+
+.archCanvas::-webkit-scrollbar-thumb {
+  background: var(--gdt-border-dark);
+  border-radius: 3px;
 }
 
 html[data-theme='dark'] .archCanvas {
@@ -297,17 +307,20 @@ html[data-theme='dark'] .archCanvas {
   display: flex;
   align-items: stretch;
   gap: 0;
+  min-width: 100%;
+  width: max-content;
 }
 
 .archArrow {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
   padding: 0 6px;
   color: var(--gdt-primary);
 }
 
 .archNode {
-  flex: 1;
+  flex: 1 0 140px;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -352,18 +365,6 @@ html[data-theme='dark'] .archCanvas {
 .archCaption {
   font-size: 11.5px;
   color: var(--gdt-text-secondary);
-}
-
-@media (max-width: 700px) {
-  .archFlow {
-    flex-direction: column;
-  }
-
-  .archArrow {
-    justify-content: center;
-    padding: 6px 0;
-    transform: rotate(90deg);
-  }
 }
 
 /* Prerequisites */

--- a/src/components/Cookbook/RecipeLayout.tsx
+++ b/src/components/Cookbook/RecipeLayout.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../types/recipe';
 import BrowserFrame from '../BrowserFrame';
 import PluginRunButton from './PluginRunButton';
-import { CategoryTile, CATEGORY_ICONS } from './categories';
+import { CATEGORY_ICONS } from './categories';
 import styles from './RecipeLayout.module.css';
 import catStyles from './categories.module.css';
 
@@ -532,10 +532,10 @@ function RecipePreview({
 
 /**
  * Recipe detail template per design handoff 4b: gradient header banner
- * (category tile, title, meta pills) and a main + sticky-rail grid. The
- * native theme breadcrumb (rendered above this component) handles
- * back-navigation to /cookbook. Body sections come from the recipe MDX via
- * the section components.
+ * (title, meta pills) and a main + sticky-rail grid. The native theme
+ * breadcrumb (rendered above this component) handles back-navigation to
+ * /cookbook. Body sections come from the recipe MDX via the section
+ * components.
  */
 export default function RecipeLayout({
   recipe,
@@ -558,16 +558,8 @@ export default function RecipeLayout({
           >
             <div>
               <div className={styles.bannerMain}>
-                <CategoryTile
-                  category={recipe.category}
-                  iconOverride={recipe.icon}
-                  iconSize={26}
-                  size={52}
-                />
-                <div>
-                  <h1 className={styles.bannerTitle}>{recipe.title}</h1>
-                  <p className={styles.bannerDesc}>{recipe.description}</p>
-                </div>
+                <h1 className={styles.bannerTitle}>{recipe.title}</h1>
+                <p className={styles.bannerDesc}>{recipe.description}</p>
               </div>
               <div className={styles.metaRow}>
                 {metaPill(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Design review of the developer-site Cookbooks pages:

1. The flagship card on `/cookbook` used a blue `--gdt-primary` border. The "End-to-end build" pill was also solid blue.
2. Every recipe page put a category tile to the left of the title, which threw the title out of alignment with the content below.
3. Architecture flowcharts (especially 6-node ones like On-call Copilot and RFP Responder) overflowed their box on narrower viewports instead of scrolling.

## Solution

All presentation changes live in `src/components/Cookbook/`. Generated recipe MDX is untouched; every recipe page already goes through `RecipePage` → `RecipeLayout`.

- Flagship card border is `1px solid var(--gdt-border-light)`. The pill uses `--gdt-bg-mid` / `--gdt-text-secondary`.
- Recipe banners no longer render `CategoryTile`. Index grid cards still do.
- Architecture canvas uses `overflow-x: auto`. Nodes keep a 140px basis and do not shrink, so a too-wide flowchart scrolls inside the box instead of stacking or clipping.

## Test plan

- [x] `pnpm exec vitest run src/components/Cookbook/Cookbook.test.tsx`
- [x] `pnpm test` (227 passed)
- [x] `pnpm build` with `FF_COOKBOOK=true`
- [x] Playwright against the local build: all 13 recipe pages have no title-row tile (`h1` left edge is 314px on each). On-call architecture `scrollWidth` 1144 / `clientWidth` 730, `overflow-x: auto`. RFP architecture `scrollWidth` 1078 / `clientWidth` 730.
- Preview: https://glean-developer-site-git-cfreeman-cookb-704d63-glean-developers.vercel.app/cookbook

### Flagship card

Before (blue border, blue pill):

![Before: Cookbooks index flagship card with blue border and blue End-to-end build pill](https://cursor.com/artifacts/c/art-84c637c1-c51d-42a6-a4ec-d60ab6d259de)

After (light border, grey pill):

![After: Cookbooks index flagship card with light border and grey End-to-end build pill](https://cursor.com/artifacts/c/art-422c3b49-f477-4ca2-a596-1460f38633b5)

### Recipe title alignment

Before (category tile left of the title):

![Before: On-call Copilot title with category tile](https://cursor.com/artifacts/c/art-c9899a0b-0bb3-4d6a-b5a4-b707f2356893)

After (title aligned with the content below):

![After: On-call Copilot title without category tile](https://cursor.com/artifacts/c/art-897065d6-6cbb-4181-a1f0-cad68bfee3d3)

Same treatment on Embed search & chat:

![After: Embed search and chat title without category tile](https://cursor.com/artifacts/c/art-2bd67a5e-d2ee-43e8-ac5b-d2538a999f02)

### Architecture overflow

After, 760px viewport. Chart is wider than the box and scrolls inside it.

![After: On-call Copilot architecture at a narrow viewport, left side](https://cursor.com/artifacts/c/art-a3e3a100-72bf-44f2-a202-f07eb3abac0f)

![After: On-call Copilot architecture scrolled to the right](https://cursor.com/artifacts/c/art-714460b6-a8ba-4c3b-ad83-7f5c7cd13d5d)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-655d05ed-8e78-423b-8aac-f94baa2ba708?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-655d05ed-8e78-423b-8aac-f94baa2ba708&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

