### PR TITLE
[Docs] Widen page content inset from 14px to 24px

### DIFF
--- a/src/components/home/HomeRedesign.module.css
+++ b/src/components/home/HomeRedesign.module.css
@@ -4,8 +4,8 @@
 .page {
   font-family: var(--gdt-font-text);
   /* 56px total gutter each side per handoff 1a (main column padding);
-   * the doc container contributes 14px, we add the rest */
-  padding: 0 42px 24px;
+   * the doc container contributes 24px, we add the rest */
+  padding: 0 32px 24px;
 }
 
 @media (max-width: 996px) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -928,10 +928,10 @@ article:has(.indexing-sdk-root) > header {
 }
 
 /* Breadcrumbs render outside the redesign root — align them with the
- * page's 56px gutter (42px + the container's 14px) */
+ * page's 56px gutter (32px + the container's 24px) */
 .container:has(.home-redesign-root) .theme-doc-breadcrumbs {
-  margin-left: 42px;
-  margin-right: 42px;
+  margin-left: 32px;
+  margin-right: 32px;
 }
 
 .container:has(.home-redesign-root) [class*='docItemCol'] {
@@ -965,6 +965,15 @@ html[data-theme='dark'] .theme-code-block {
 html[data-theme='dark'] [class*='codeBlockTitle'] {
   background: #0c0d10;
   border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+/* Infima's .container uses padding: 0 var(--ifm-spacing-horizontal).
+ * --ifm-font-size-base is 87.5%, so that 1rem inset is 14px — too tight
+ * against the sidebar. Leave --ifm-spacing-horizontal alone (grid gutters,
+ * API method badges) and only widen the page content inset. */
+.container {
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
 /* ==== Docs design pass: extend the homepage design language sitewide ==== */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -969,9 +969,10 @@ html[data-theme='dark'] [class*='codeBlockTitle'] {
 
 /* Infima's .container uses padding: 0 var(--ifm-spacing-horizontal).
  * --ifm-font-size-base is 87.5%, so that 1rem inset is 14px — too tight
- * against the sidebar. Leave --ifm-spacing-horizontal alone (grid gutters,
- * API method badges) and only widen the page content inset. */
-.container {
+ * against the sidebar. Scope to the docs main column so navbar/footer
+ * Infima containers keep the default. Leave --ifm-spacing-horizontal
+ * alone (grid gutters, API method badges). */
+main[class*='docMainContainer'] > .container {
   padding-left: 24px;
   padding-right: 24px;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Design review of the developer site: the left padding on the page content area is too small. It is 14px today (Infima `.container` padding of `1rem`, and `--ifm-font-size-base: 87.5%` makes that 14px). It should be 24px. This is general developer-site styling, not cookbook-specific.

Frank He flagged this while reviewing cookbook pages: the inset is site-wide chrome, not a cookbook layout issue.

## Solution

Set `.container` padding to 24px in `src/css/custom.css`. Leave `--ifm-spacing-horizontal` alone so grid gutters and API method badges stay put.

The homepage 1a gutter is still 56px: its extra padding drops from 42px to 32px (`32 + 24`). Breadcrumb margins match.

## Test plan

- [x] Playwright against production (before) and the local `pnpm build` (after): sidebar-to-content gap is 14px → 24px on `/guides/mcp` and `/cookbook`. Container `padding-left` is `24px`. Homepage breadcrumbs stay 56px from the sidebar.
- [x] `pnpm test` (227 passed)
- [x] `pnpm build` with `FF_COOKBOOKS=true`
- Preview: https://glean-developer-site-git-cfreeman-docs-f810d1-glean-developers.vercel.app/guides/mcp

## Before / after

Measured gap between the sidebar edge and the page title, same 1440×900 viewport.

### Regular docs (`/guides/mcp`)

Before (14px):

![Before: MCP guide with 14px content inset](https://cursor.com/artifacts/c/art-8a945723-66fa-4a02-89e0-3896e49c0880)

After (24px):

![After: MCP guide with 24px content inset](https://cursor.com/artifacts/c/art-d15b38db-03c2-4aa7-93d5-9c3edc9e381e)

### Cookbooks index (`/cookbook`)

Before (14px):

![Before: Cookbooks index with 14px content inset](https://cursor.com/artifacts/c/art-efe92a74-52b9-4994-985b-7a8132c49bdf)

After (24px):

![After: Cookbooks index with 24px content inset](https://cursor.com/artifacts/c/art-b8df8125-b27d-411c-8b64-6982e272ccbe)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00267-6cf0-78f5-8f0e-ee0a5181d6c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00267-6cf0-78f5-8f0e-ee0a5181d6c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

