### PR TITLE
docs(codex): add install-first plugin guide

### DIFF
--- a/docs/guides/mcp/codex.mdx
+++ b/docs/guides/mcp/codex.mdx
@@ -4,38 +4,116 @@ description: Install the official Glean plugin for Codex — enterprise knowledg
 ---
 
 import PluginPage from '@site/src/components/PluginPage';
+import FeatureFlag from '@site/src/components/FeatureFlag';
 
 {/* Install commands synced from https://github.com/gleanwork/codex-plugins/blob/main/README.md */}
 
-<PluginPage
-  name="Codex"
-  tagline="You use Codex. Glean brings the enterprise context."
-  clientId="codex"
-  mono
-  steps={[
-    {
-      type: 'cta',
-      label: 'Get your Glean MCP server details',
-      description: 'The plugin requires a Glean MCP connection. Open the Glean MCP configurator to find your organization\'s server URL and server name — you\'ll use both in the last step.',
-      ctaText: 'Open MCP Configurator',
-      ctaHref: 'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=codex',
-    },
-    {
-      type: 'command',
-      label: 'Add the Glean marketplace and install the plugin',
-      description: 'Run these commands in your terminal to install the Glean enterprise-knowledge plugin.',
-      commands: [
-        { title: 'Add the Glean marketplace', code: 'codex plugin marketplace add gleanwork/codex-plugins' },
-        { title: 'Install the plugin', code: 'codex plugin add glean@glean-codex-plugins' },
-      ],
-    },
-    {
-      type: 'command',
-      label: 'Connect the Glean MCP server',
-      description: 'Before starting Codex, connect the MCP server — substitute the server URL and name from step 1. Then start a new Codex task so the bundled skills and MCP tools are available.',
-      commands: [
-        { title: 'Connect and sign in', code: 'codex mcp add glean --url <server-url>/mcp/<server-name>\ncodex mcp login glean' },
-      ],
-    },
-  ]}
-/>
+{/* New page is gated behind `codex-plugin-v2`. The current page is preserved as
+    the fallback and renders whenever the flag is turned off. */}
+
+<FeatureFlag
+  flag="codex-plugin-v2"
+  fallback={
+    <PluginPage
+      name="Codex"
+      tagline="You use Codex. Glean brings the enterprise context."
+      clientId="codex"
+      mono
+      steps={[
+        {
+          type: 'cta',
+          label: 'Get your Glean MCP server details',
+          description:
+            "The plugin requires a Glean MCP connection. Open the Glean MCP configurator to find your organization's server URL and server name — you'll use both in the last step.",
+          ctaText: 'Open MCP Configurator',
+          ctaHref:
+            'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=codex',
+        },
+        {
+          type: 'command',
+          label: 'Add the Glean marketplace and install the plugin',
+          description:
+            'Run these commands in your terminal to install the Glean enterprise-knowledge plugin.',
+          commands: [
+            {
+              title: 'Add the Glean marketplace',
+              code: 'codex plugin marketplace add gleanwork/codex-plugins',
+            },
+            {
+              title: 'Install the plugin',
+              code: 'codex plugin add glean@glean-codex-plugins',
+            },
+          ],
+        },
+        {
+          type: 'command',
+          label: 'Connect the Glean MCP server',
+          description:
+            'Before starting Codex, connect the MCP server — substitute the server URL and name from step 1. Then start a new Codex task so the bundled skills and MCP tools are available.',
+          commands: [
+            {
+              title: 'Connect and sign in',
+              code: 'codex mcp add glean --url <server-url>/mcp/<server-name>\ncodex mcp login glean',
+            },
+          ],
+        },
+      ]}
+    />
+  }
+>
+  <PluginPage
+    name="Codex"
+    tagline="You use Codex. Glean brings the enterprise context."
+    clientId="codex"
+    mono
+    whatsIncluded={
+      <>
+        The Glean plugin turns Codex into a front door to your company:
+        Glean&rsquo;s expert skills — search, code exploration, people, meetings,
+        onboarding, productivity — the custom skills your team authors in Glean,
+        and every tool configured centrally in Glean, each paired with skills
+        tuned to use it well. Those tools are surfaced with Glean&rsquo;s security
+        and permission guardrails fully enforced, all running through a Glean
+        MCP server so it works right in your terminal.{' '}
+        <a
+          href="https://github.com/gleanwork/codex-plugins/blob/main/README.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          See everything included in the plugin →
+        </a>
+      </>
+    }
+    steps={[
+      {
+        type: 'command',
+        label: 'Add the Glean marketplace and install the plugin',
+        description: 'Run these commands in your terminal to install the plugin.',
+        commands: [
+          {
+            title: 'Add the Glean marketplace',
+            code: 'codex plugin marketplace add gleanwork/codex-plugins',
+          },
+          {
+            title: 'Install the plugin',
+            code: 'codex plugin add glean@glean-codex-plugins',
+          },
+        ],
+      },
+      {
+        type: 'list',
+        label: 'Setup the Glean MCP connection',
+        description:
+          "Connect the plugin to your Glean instance through Glean's OAuth sign-in. You only need to do this once per machine.",
+        items: [
+          <>
+            In Codex, run: <code>$glean_run setup my Glean</code>
+          </>,
+          'Enter your work email when prompted.',
+          'Complete Glean OAuth in the browser window that opens and approve access.',
+          'Back in Codex, confirm it reports connected — you now have every skill and tool provisioned for you in Glean, right in your terminal. Search company knowledge, take action across your connected apps, and move through real work faster without leaving the command line.',
+        ],
+      },
+    ]}
+  />
+</FeatureFlag>


### PR DESCRIPTION
## Summary

Updates `/guides/mcp/codex` with an install-first experience for the Glean Codex plugin, gated behind the existing `codex-plugin-v2` feature flag.

The current Codex page is preserved as the fallback and remains visible while the flag is off. The new page can be enabled through the existing runtime feature-flag configuration when the plugin is ready to launch.

### New page

- **What's included** — explains that the plugin brings Glean's expert skills, custom skills authored by teams in Glean, and centrally configured Glean tools with security and permission guardrails enforced.
- Links to the [`codex-plugins` README](https://github.com/gleanwork/codex-plugins/blob/main/README.md) for more detail about the plugin contents.
- **Installation** — add the Glean marketplace and install the plugin.
- **Setup the Glean MCP connection** — run `$glean_run setup my Glean` from Codex, complete authentication, and confirm the connection.
- Removes the new-page dependency on manually copying a remote MCP server URL/name; the existing remote-MCP instructions remain available in the fallback page.

### Implementation

- Adds optional `whatsIncluded` support to `PluginPage`; existing plugin pages are unaffected.
- Keeps `codex-plugin-v2` off when absent; no new default-flag mechanism is introduced.
- Preserves the current Codex page in the `FeatureFlag` fallback.
- Does not modify generated API Reference content.

## Rollout

After this PR is deployed, enable the page for everyone by adding this entry to the existing `feature-flags` item in the `glean-developer-feature-flags` Edge Config:

```json
{
  "codex-plugin-v2": {
    "enabled": true
  }
}
```

For local or preview testing, use:

```text
/guides/mcp/codex?ff_codex-plugin-v2=true
```

To force the fallback page:

```text
/guides/mcp/codex?ff_codex-plugin-v2=false
```

## Validation

- `pnpm prettier --check .` ✅
- `pnpm test` ✅ — 169 passed, 2 skipped
- `pnpm build` ✅ — fallback page renders when the flag is absent
- `FF_CODEX_PLUGIN_V2=true pnpm build` ✅ — new page renders with the install flow and README link

## Manual Codex verification

With a locally built Codex marketplace available from `agent-plugins/dist/codex`:

```bash
cd /path/to/agent-plugins
codex plugin remove glean@glean-codex-plugins
codex plugin marketplace remove glean-codex-plugins
codex plugin marketplace add "$PWD/dist/codex"
codex plugin add glean@glean-codex-plugins
codex plugin list --json
```

Start a new `codex` session and verify the plugin setup and connected-account flows:

```text
$glean_run setup my Glean
$glean_run Search Glean for a recent document I accessed and summarize it.
$glean_run Find my upcoming meetings and summarize what I need to prepare.
```

