### PR TITLE
fix(sidebar): create a Platform category for any new tag, not just Chat

### DIFF
--- a/scripts/sync-api-sidebar.mjs
+++ b/scripts/sync-api-sidebar.mjs
@@ -393,9 +393,6 @@ function resolvePlatformTarget(root, tag, plannedCategories) {
   if (matches.length === 1) {
     return { items: getItemsProperty(matches[0]) };
   }
-  if (tag !== 'Chat') {
-    return { error: `no Platform API Reference category labelled '${tag}'` };
-  }
   const openApiSpecIndexes = platform.items.elements
     .map((element, index) => ({ element, index }))
     .filter(

--- a/scripts/sync-api-sidebar.test.ts
+++ b/scripts/sync-api-sidebar.test.ts
@@ -9,6 +9,7 @@ const testDirs: string[] = [];
 function createFixture(options?: {
   ambiguous?: boolean;
   camelCaseOpId?: boolean;
+  newTag?: boolean;
   preseed?: boolean;
   unresolved?: boolean;
 }) {
@@ -224,6 +225,18 @@ sidebar_class_name: "get api-method"
 `,
     );
   }
+  if (options?.newTag) {
+    fs.writeFileSync(
+      path.join(root, 'docs/api/platform-api/platform-triggers-list.api.mdx'),
+      `---
+id: platform-triggers-list
+title: "List triggers"
+sidebar_label: "List triggers"
+sidebar_class_name: "get api-method"
+---
+`,
+    );
+  }
 
   const paths = new Map<
     string,
@@ -246,6 +259,16 @@ sidebar_class_name: "get api-method"
         tag: 'Search',
         summary: 'Retrieve the thing',
         operationId: 'getPlatformThing',
+      },
+    ]);
+  }
+  if (options?.newTag) {
+    paths.set('/triggers', [
+      {
+        method: 'get',
+        tag: 'Triggers',
+        summary: 'List triggers',
+        operationId: 'platform-triggers-list',
       },
     ]);
   }
@@ -354,6 +377,21 @@ describe('sync-api-sidebar', () => {
       /label: 'Chat',[\s\S]*?id: 'api\/platform-api\/platform-chat-create',[\s\S]*?\n {10}\},\n {8}\],\n {6}\},\n {6}\{\n {8}type: 'link',\n {8}href: 'https:\/\/developers\.glean\.com\/oas\/platform',\n {8}label: 'OpenAPI Spec',/,
     );
     expect(sidebar.match(/id: 'guides\/chat\/overview'/g)).toHaveLength(1);
+    expect(run(root, '--check').status).toBe(0);
+  });
+
+  it('creates a Platform category for a tag it has never seen', () => {
+    const root = createFixture({ newTag: true });
+
+    expect(run(root, '--fix').status).toBe(0);
+    const sidebar = fs.readFileSync(path.join(root, 'sidebars.ts'), 'utf8');
+
+    expect(sidebar).toContain("label: 'Triggers'");
+    expect(sidebar).toContain("id: 'api/platform-api/platform-triggers-list'");
+    // New categories land before the OpenAPI Spec link, like Chat does.
+    expect(sidebar.indexOf("label: 'Triggers'")).toBeLessThan(
+      sidebar.indexOf("label: 'OpenAPI Spec'"),
+    );
     expect(run(root, '--check').status).toBe(0);
   });
 


### PR DESCRIPTION
## Problem

`resolvePlatformTarget` in `scripts/sync-api-sidebar.mjs` can bootstrap exactly one Platform API family:

```js
if (tag !== 'Chat') {
  return { error: `no Platform API Reference category labelled '${tag}'` };
}
```

For any other new tag it errors, `sidebar:fix` exits 1, and `openapi:regenerate:all` dies with it — the two are chained with `&&`.

That makes a new API family unlaunchable without hand-editing `sidebars.ts`, and creates a merge deadlock:

- generation needs the category to already exist on `main`
- the PR that adds the category can't build, because it references operation pages generation hasn't created yet (`onBrokenLinks: 'throw'`)

The Triggers launch hit exactly this. [Run 32223407996](https://github.com/gleanwork/glean-developer-site/actions/runs/32223407996) failed on all ten operations with `no Platform API Reference category labelled 'Triggers'`, produced no PR, and the daily cron re-failed the same way.

## Fix

Drop the guard. The creation path below it was never Chat-specific — it inserts a new category before the `OpenAPI Spec` link and returns its `items` array. It works for any tag; it was just unreachable.

Net effect: a new API family now needs **no** hand-written sidebar. Regeneration creates the category and inserts its operations. A human still adds the category's `link:` to the overview page and any preferred ordering, which is the right split.

## Verification

New test asserts a previously unseen tag (`Triggers`) gets its category created, populated, and placed before the `OpenAPI Spec` link, and that `--check` is clean afterwards.

- with the guard in place: `1 failed | 9 passed`
- with this change: `10 passed`

Also reproduced the original failure end-to-end locally: removing the Triggers category and running `sidebar:fix` against a triggers-bearing spec fails on `main` and inserts all ten entries with this change.