### PR TITLE
docs(platform): add the Triggers category to the sidebar

### DIFF
--- a/docs/api/platform-api/triggers-overview.mdx
+++ b/docs/api/platform-api/triggers-overview.mdx
@@ -1,0 +1,11 @@
+---
+title: Triggers API Overview
+---
+
+# Triggers API
+
+The Platform Triggers API lets an application subscribe to content events in Glean and receive them at its own endpoint as signed webhooks. A trigger is created from a **preset** — a curated event definition such as "a review is requested from me" or "30 minutes before an event starts" — so you describe what you care about rather than assembling a query.
+
+Events are delivered as [Standard Webhooks](https://www.standardwebhooks.com), signed with HMAC-SHA256, and are scoped to what the subscribing user is permitted to see.
+
+These endpoints are [experimental](/experimental/overview) — send `X-Glean-Include-Experimental: true` on each request, or they are not exposed.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -935,6 +935,15 @@ const baseSidebars: SidebarsConfig = {
               ],
             },
             {
+              type: 'category',
+              label: 'Triggers',
+              link: {
+                type: 'doc',
+                id: 'api/platform-api/triggers-overview',
+              },
+              items: [],
+            },
+            {
               type: 'link',
               href: 'https://developers.glean.com/oas/platform',
               label: 'OpenAPI Spec',


### PR DESCRIPTION
## Why

Regeneration can't add a new Platform API family by itself. Need to add the `Triggers` category to sidebar for docs regeneration to run.

## Sequence after this merges

1. Run **Trigger Redeploy** — opens the "Regenerate OpenAPI Documentation" PR with the ten pages and ten sidebar entries.
2. Push the cards, changelog and ordering.