### PR TITLE
docs: clarify DCR policy and MCP server URL reuse

### DIFF
--- a/docs/api-info/client/authentication/oauth.mdx
+++ b/docs/api-info/client/authentication/oauth.mdx
@@ -18,7 +18,7 @@ There are two sources for that token, and they behave slightly differently on th
     **Glean issues the tokens (OAuth 2.1)**
 
     - Authorization Code flow with PKCE
-    - Two registration modes: Dynamic Client Registration (DCR) for approved MCP hosts, and static clients for governed applications
+    - Two registration modes: Dynamic Client Registration (DCR), and static clients for governed applications when DCR is disabled or restricted, or when the app needs scopes DCR does not grant
     - Glean-defined, fine-grained scopes
     - Recognized by issuer — **no extra header**
     - Powers the [remote MCP server](/guides/mcp)
@@ -74,9 +74,9 @@ The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oau
   </Step>
 
   <Step title="Choose a client-registration mode">
-    **Dynamic Client Registration (DCR)** lets the client register itself. Use DCR for approved MCP hosts. The default policy is the Glean-managed list of approved applications. Administrators can add redirect URIs, restrict the list, or disable DCR. DCR clients receive only the restricted scope set configured for DCR. See [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
+    **Dynamic Client Registration (DCR)** lets the client register itself. By default a tenant allows any application that supports DCR. Administrators can instead restrict registration to approved applications, using the Glean-managed list, their own redirect URI patterns, or both, or disable DCR entirely. DCR clients receive only the restricted scope set configured for DCR. See [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
 
-    A **static OAuth client** is an application an administrator registers and governs. Use a static client when DCR is disabled, the application is not on the approved list, or the application needs scopes DCR does not grant. DCR also issues a `client_id`. Do not choose a static client only to get a stable identifier. See [static OAuth clients](https://docs.glean.com/administration/oauth/static-client-registration).
+    A **static OAuth client** is an application an administrator registers and governs. Use a static client when DCR is disabled, when the tenant restricts DCR to approved applications and this application is not allowed, or when the application needs scopes DCR does not grant. DCR also issues a `client_id`. Do not choose a static client only to get a stable identifier. See [static OAuth clients](https://docs.glean.com/administration/oauth/static-client-registration).
   </Step>
 
   <Step title="Obtain a token">

--- a/docs/api-info/client/authentication/oauth.mdx
+++ b/docs/api-info/client/authentication/oauth.mdx
@@ -70,7 +70,7 @@ The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oau
 
 <Steps>
   <Step title="Confirm the authorization server if sign-in fails">
-    Start with OAuth. If sign-in fails, ask a Glean administrator to confirm that the Glean OAuth Authorization Server is still enabled and that your client is allowed.
+    Start with OAuth. If sign-in fails, ask a Glean administrator to confirm that the Glean OAuth Authorization Server is enabled and that your client is allowed.
   </Step>
 
   <Step title="Choose a client-registration mode">

--- a/docs/api-info/client/authentication/oauth.mdx
+++ b/docs/api-info/client/authentication/oauth.mdx
@@ -18,7 +18,7 @@ There are two sources for that token, and they behave slightly differently on th
     **Glean issues the tokens (OAuth 2.1)**
 
     - Authorization Code flow with PKCE
-    - Two registration modes: Dynamic Client Registration (DCR), and static clients for governed applications when DCR is disabled or restricted, or when the app needs scopes DCR does not grant
+    - Two registration modes: Dynamic Client Registration (DCR), subject to tenant policy, and admin-created static clients
     - Glean-defined, fine-grained scopes
     - Recognized by issuer — **no extra header**
     - Powers the [remote MCP server](/guides/mcp)
@@ -74,9 +74,9 @@ The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oau
   </Step>
 
   <Step title="Choose a client-registration mode">
-    **Dynamic Client Registration (DCR)** lets the client register itself. By default a tenant allows any application that supports DCR. Administrators can instead restrict registration to approved applications, using the Glean-managed list, their own redirect URI patterns, or both, or disable DCR entirely. DCR clients receive only the restricted scope set configured for DCR. See [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
+    **Dynamic Client Registration (DCR)** lets the client register itself. A tenant can allow any application that supports DCR, restrict registration to approved applications using the Glean-managed list, custom redirect URI patterns, or both, or disable DCR entirely. DCR clients receive only the restricted scope set configured for DCR. See [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
 
-    A **static OAuth client** is an application an administrator registers and governs. Use a static client when DCR is disabled, when the tenant restricts DCR to approved applications and this application is not allowed, or when the application needs scopes DCR does not grant. DCR also issues a `client_id`. Do not choose a static client only to get a stable identifier. See [static OAuth clients](https://docs.glean.com/administration/oauth/static-client-registration).
+    A **static OAuth client** is an application an administrator registers and governs. Use a static client when DCR is disabled, when the tenant restricts DCR to approved applications and this application is not allowed, or when the application needs scopes DCR does not grant. See [static OAuth clients](https://docs.glean.com/administration/oauth/static-client-registration).
   </Step>
 
   <Step title="Obtain a token">

--- a/docs/api-info/client/authentication/oauth.mdx
+++ b/docs/api-info/client/authentication/oauth.mdx
@@ -66,7 +66,7 @@ The official API clients accept an OAuth access token in their existing token fi
 <Tabs>
 <TabItem value="gas" label="Glean Authorization Server">
 
-The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oauth/authorization-server) is an OAuth 2.1 authorization server that issues access tokens for the Client API. It reuses your existing SSO. It does not replace your IdP. The server is off by default. Glean turns it on for eligible tenants during default-on MCP provisioning.
+The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oauth/authorization-server) is an OAuth 2.1 authorization server that issues access tokens for the Client API. It reuses your existing SSO. It does not replace your IdP. It is on by default. Tenants that already used IdP OAuth may have it off.
 
 <Steps>
   <Step title="Confirm the authorization server if sign-in fails">

--- a/docs/api-info/client/authentication/oauth.mdx
+++ b/docs/api-info/client/authentication/oauth.mdx
@@ -66,7 +66,7 @@ The official API clients accept an OAuth access token in their existing token fi
 <Tabs>
 <TabItem value="gas" label="Glean Authorization Server">
 
-The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oauth/authorization-server) is an OAuth 2.1 authorization server that issues access tokens for the Client API. It is enabled by default and reuses your existing SSO. It does not replace your IdP.
+The [Glean OAuth Authorization Server](https://docs.glean.com/administration/oauth/authorization-server) is an OAuth 2.1 authorization server that issues access tokens for the Client API. It reuses your existing SSO. It does not replace your IdP. The server is off by default. Glean turns it on for eligible tenants during default-on MCP provisioning.
 
 <Steps>
   <Step title="Confirm the authorization server if sign-in fails">

--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -44,7 +44,7 @@ Choose your authentication method based on your needs:
 ### Choose OAuth if you:
 - Are building a per-user Client API integration
 - Want users to authorize access without distributing Glean-issued API tokens
-- Can use the Glean OAuth Authorization Server (enabled by default) or already use supported OAuth tokens from your enterprise identity provider
+- Can use the Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or already use supported OAuth tokens from your enterprise identity provider
 - Want the token issuer to manage expiration and refresh
 
 ### Choose Glean-issued tokens if you:

--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -18,7 +18,7 @@ This guide helps you choose and implement the right authentication method for Gl
     - Tokens from the Glean OAuth Authorization Server or an external IdP
     - Works with Google, Azure, Okta, OneLogin
     - Glean-defined scopes (Authorization Server) or Client API access via your IdP
-    - DCR for approved MCP hosts; static clients for governed applications
+    - Use DCR for Dynamic Client Registration (default allows any DCR-capable application), and static clients for governed applications when DCR is disabled or restricted, or when the app needs scopes DCR does not grant
 
     [Setup OAuth →](./oauth)
   </Card>

--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -18,7 +18,7 @@ This guide helps you choose and implement the right authentication method for Gl
     - Tokens from the Glean OAuth Authorization Server or an external IdP
     - Works with Google, Azure, Okta, OneLogin
     - Glean-defined scopes (Authorization Server) or Client API access via your IdP
-    - Use DCR for Dynamic Client Registration (default allows any DCR-capable application), and static clients for governed applications when DCR is disabled or restricted, or when the app needs scopes DCR does not grant
+    - DCR subject to tenant policy, or admin-created static clients when DCR is unavailable or does not grant the required scopes
 
     [Setup OAuth →](./oauth)
   </Card>

--- a/docs/api-info/client/authentication/overview.mdx
+++ b/docs/api-info/client/authentication/overview.mdx
@@ -44,7 +44,7 @@ Choose your authentication method based on your needs:
 ### Choose OAuth if you:
 - Are building a per-user Client API integration
 - Want users to authorize access without distributing Glean-issued API tokens
-- Can use the Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or already use supported OAuth tokens from your enterprise identity provider
+- Can use the Glean OAuth Authorization Server (on by default; tenants that already used IdP OAuth may have it off) or already use supported OAuth tokens from your enterprise identity provider
 - Want the token issuer to manage expiration and refresh
 
 ### Choose Glean-issued tokens if you:

--- a/docs/api-info/platform/authentication/overview.mdx
+++ b/docs/api-info/platform/authentication/overview.mdx
@@ -19,7 +19,7 @@ Authorization: Bearer <platform_token>
 
 <CardGroup cols={3}>
   <Card title="Glean OAuth Authorization Server" icon="Shield" iconSet="feather">
-    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is enabled by default. DCR is subject to tenant policy; use a static client when DCR is disabled, when the tenant policy does not allow the application, or when the application needs scopes DCR does not grant.
+    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is off by default except on eligible tenants with default-on MCP. DCR is subject to tenant policy; use a static client when DCR is disabled, when the tenant policy does not allow the application, or when the application needs scopes DCR does not grant.
   </Card>
 
   <Card title="External IdP OAuth" icon="Globe" iconSet="feather">

--- a/docs/api-info/platform/authentication/overview.mdx
+++ b/docs/api-info/platform/authentication/overview.mdx
@@ -19,7 +19,7 @@ Authorization: Bearer <platform_token>
 
 <CardGroup cols={3}>
   <Card title="Glean OAuth Authorization Server" icon="Shield" iconSet="feather">
-    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is off by default except on eligible tenants with default-on MCP. DCR is subject to tenant policy; use a static client when DCR is disabled, when the tenant policy does not allow the application, or when the application needs scopes DCR does not grant.
+    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is on by default. Tenants that already used IdP OAuth may have it off. DCR is subject to tenant policy; use a static client when DCR is disabled, when the tenant policy does not allow the application, or when the application needs scopes DCR does not grant.
   </Card>
 
   <Card title="External IdP OAuth" icon="Globe" iconSet="feather">

--- a/docs/api-info/platform/authentication/overview.mdx
+++ b/docs/api-info/platform/authentication/overview.mdx
@@ -19,7 +19,7 @@ Authorization: Bearer <platform_token>
 
 <CardGroup cols={3}>
   <Card title="Glean OAuth Authorization Server" icon="Shield" iconSet="feather">
-    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is enabled by default. By default a tenant allows any application that supports DCR; use a static client when DCR is disabled or the tenant restricts DCR and this application is not allowed, or when the application needs scopes DCR does not grant.
+    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is enabled by default. DCR is subject to tenant policy; use a static client when DCR is disabled, when the tenant policy does not allow the application, or when the application needs scopes DCR does not grant.
   </Card>
 
   <Card title="External IdP OAuth" icon="Globe" iconSet="feather">

--- a/docs/api-info/platform/authentication/overview.mdx
+++ b/docs/api-info/platform/authentication/overview.mdx
@@ -19,7 +19,7 @@ Authorization: Bearer <platform_token>
 
 <CardGroup cols={3}>
   <Card title="Glean OAuth Authorization Server" icon="Shield" iconSet="feather">
-    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is enabled by default. Use DCR for approved MCP hosts. Use a static client when DCR is disabled, the application is not approved, or the application needs scopes DCR does not grant.
+    Use Glean's OAuth Authorization Server for OAuth access tokens and fine-grained Glean scopes. It is enabled by default. By default a tenant allows any application that supports DCR; use a static client when DCR is disabled or the tenant restricts DCR and this application is not allowed, or when the application needs scopes DCR does not grant.
   </Card>
 
   <Card title="External IdP OAuth" icon="Globe" iconSet="feather">

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -29,7 +29,7 @@ Your server URL is used in API requests and API client configuration:
     **Recommended for new integrations**
 
     - OAuth is preferred for per-user integrations
-    - Glean OAuth Authorization Server (on by default) or external IdP OAuth
+    - Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or external IdP OAuth
     - Glean-issued tokens for Indexing, global `X-Glean-ActAs`, or when no OAuth path exists
     - [Platform authentication guide](/api/platform-api/authentication)
   </Card>
@@ -40,7 +40,7 @@ Your server URL is used in API requests and API client configuration:
     **For existing and specialized user-facing integrations**
 
     - OAuth is preferred for per-user integrations
-    - Glean OAuth Authorization Server (on by default) or external IdP OAuth
+    - Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or external IdP OAuth
     - Glean-issued tokens for global `X-Glean-ActAs`, or when no OAuth path exists
     - [Client authentication guide](/api-info/client/authentication/overview)
   </Card>
@@ -60,11 +60,11 @@ Your server URL is used in API requests and API client configuration:
 
 ### Platform API: per-user or admin-managed access
 
-For per-user Platform API integrations, prefer OAuth. The Glean OAuth Authorization Server is enabled by default. Use an external-IdP OAuth token when your organization already issues those tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Platform API authentication guide](/api/platform-api/authentication).
+For per-user Platform API integrations, prefer OAuth. The Glean OAuth Authorization Server is off by default except on eligible tenants with default-on MCP. Use an external-IdP OAuth token when your organization already issues those tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Platform API authentication guide](/api/platform-api/authentication).
 
 ### Client API: per-user or admin-managed access
 
-For per-user Client API integrations, prefer OAuth. The Glean OAuth Authorization Server is enabled by default. Use external-IdP OAuth when your organization already issues the access tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Client API authentication guide](/api-info/client/authentication/overview).
+For per-user Client API integrations, prefer OAuth. The Glean OAuth Authorization Server is off by default except on eligible tenants with default-on MCP. Use external-IdP OAuth when your organization already issues the access tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Client API authentication guide](/api-info/client/authentication/overview).
 
 ### Indexing API
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -29,7 +29,7 @@ Your server URL is used in API requests and API client configuration:
     **Recommended for new integrations**
 
     - OAuth is preferred for per-user integrations
-    - Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or external IdP OAuth
+    - Glean OAuth Authorization Server (on by default; some IdP OAuth tenants keep it off) or external IdP OAuth
     - Glean-issued tokens for Indexing, global `X-Glean-ActAs`, or when no OAuth path exists
     - [Platform authentication guide](/api/platform-api/authentication)
   </Card>
@@ -40,7 +40,7 @@ Your server URL is used in API requests and API client configuration:
     **For existing and specialized user-facing integrations**
 
     - OAuth is preferred for per-user integrations
-    - Glean OAuth Authorization Server (off by default except on eligible tenants with default-on MCP) or external IdP OAuth
+    - Glean OAuth Authorization Server (on by default; some IdP OAuth tenants keep it off) or external IdP OAuth
     - Glean-issued tokens for global `X-Glean-ActAs`, or when no OAuth path exists
     - [Client authentication guide](/api-info/client/authentication/overview)
   </Card>
@@ -60,11 +60,11 @@ Your server URL is used in API requests and API client configuration:
 
 ### Platform API: per-user or admin-managed access
 
-For per-user Platform API integrations, prefer OAuth. The Glean OAuth Authorization Server is off by default except on eligible tenants with default-on MCP. Use an external-IdP OAuth token when your organization already issues those tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Platform API authentication guide](/api/platform-api/authentication).
+For per-user Platform API integrations, prefer OAuth. The Glean OAuth Authorization Server is on by default. Tenants that already used IdP OAuth may have it off. Use an external-IdP OAuth token when your organization already issues those tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Platform API authentication guide](/api/platform-api/authentication).
 
 ### Client API: per-user or admin-managed access
 
-For per-user Client API integrations, prefer OAuth. The Glean OAuth Authorization Server is off by default except on eligible tenants with default-on MCP. Use external-IdP OAuth when your organization already issues the access tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Client API authentication guide](/api-info/client/authentication/overview).
+For per-user Client API integrations, prefer OAuth. The Glean OAuth Authorization Server is on by default. Tenants that already used IdP OAuth may have it off. Use external-IdP OAuth when your organization already issues the access tokens. Use a Glean-issued token for global permissions with `X-Glean-ActAs`, or when no OAuth path exists. See the [Client API authentication guide](/api-info/client/authentication/overview).
 
 ### Indexing API
 

--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -8,7 +8,7 @@ This is different from the public [Docs MCP Server](/docs-mcp), which gives a co
 
 ## Check that you can connect
 
-Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP. Open the Configurator first. If it is unavailable, ask an administrator to confirm that at least one MCP server is enabled.
+Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. Open the Configurator first. If it is unavailable, ask an administrator to confirm that at least one MCP server is enabled and that the Configurator is visible.
 
 <Steps>
   <Step title="Open the MCP Configurator">
@@ -16,7 +16,7 @@ Glean enables the OAuth Authorization Server and Remote MCP Server by default fo
   </Step>
 
   <Step title="If the Configurator is missing">
-    If the Configurator is unavailable, ask a Glean administrator to confirm that at least one MCP server is enabled. That check lives in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers).
+    If the Configurator is unavailable, ask a Glean administrator to confirm that at least one MCP server is enabled and that the end-user Configurator is visible. That check lives in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers).
   </Step>
 
   <Step title="Match the host to its setup path">

--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -12,15 +12,19 @@ Glean enables the OAuth Authorization Server and Remote MCP Server by default fo
 
 <Steps>
   <Step title="Open the MCP Configurator">
-    Open the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) and select your host. Copy the current server URL, server name, and host-specific instructions. See the [MCP Configurator user guide](https://docs.glean.com/user-guide/mcp/usage) if the navigation in Glean differs.
+    Open the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true). Copy the current server URL and server name. (Optional) Select your host to copy host-specific instructions. See the [MCP Configurator user guide](https://docs.glean.com/user-guide/mcp/usage) if the navigation in Glean differs.
   </Step>
 
   <Step title="If the Configurator or host is missing">
-    Ask an administrator to confirm that MCP servers are enabled, that the end-user Configurator is visible, and to check the DCR allowlist and any prior custom OAuth configuration. Those checks live in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers) and [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
+    If the Configurator is unavailable, ask a Glean administrator to confirm that MCP servers are enabled and that the end-user Configurator is visible. Those checks live in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers).
+
+    If the Configurator is available but a listed host does not appear, ask the administrator to check the tenant's DCR policy and any prior custom OAuth configuration. Those checks live in [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
+
+    If your host is an MCP application that is not listed, that is expected. Use [Supported MCP Hosts](/guides/mcp/supported-hosts) guidance, choose **Custom**, and paste the server URL and server name instead.
   </Step>
 
   <Step title="Match the host to its setup path">
-    Check [Supported MCP Hosts](/guides/mcp/supported-hosts) to see whether your host is user-configurable or organization-managed. Use that host's URL, server name, and configuration snippet. Do not copy another host's values.
+    Check [Supported MCP Hosts](/guides/mcp/supported-hosts) to see whether your host is user-configurable or organization-managed. Selecting a host is optional: one server URL connects any MCP host, including hosts the Configurator does not list. Select your host to get the setup method, configuration shape, and commands that fit it.
   </Step>
 </Steps>
 
@@ -28,7 +32,7 @@ Glean enables the OAuth Authorization Server and Remote MCP Server by default fo
 
 Complete the host's OAuth sign-in flow with your organization's SSO when prompted.
 
-Dynamic Client Registration (DCR) is the usual path for approved MCP hosts. The default policy is the Glean-managed list of approved applications. If DCR is disabled, the host is not approved, or the host needs scopes DCR does not grant, an administrator can register a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
+Dynamic Client Registration (DCR) is the usual path for MCP hosts. By default a tenant allows any application that supports DCR. Administrators can restrict registration to approved applications or turn DCR off. If DCR is disabled, your tenant does not allow the host to register, or the host needs scopes DCR does not grant, an administrator can register a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
 
 Use a Glean-issued API token only when the host cannot complete OAuth. Do not assign API Token Creator in bulk as an MCP rollout.
 

--- a/docs/guides/mcp/RemoteMCPContent.mdx
+++ b/docs/guides/mcp/RemoteMCPContent.mdx
@@ -8,23 +8,19 @@ This is different from the public [Docs MCP Server](/docs-mcp), which gives a co
 
 ## Check that you can connect
 
-Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. Open the Configurator first. If it is unavailable, ask an administrator to check your tenant's MCP and OAuth configuration.
+Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP. Open the Configurator first. If it is unavailable, ask an administrator to confirm that at least one MCP server is enabled.
 
 <Steps>
   <Step title="Open the MCP Configurator">
-    Open the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true). Copy the current server URL and server name. (Optional) Select your host to copy host-specific instructions. See the [MCP Configurator user guide](https://docs.glean.com/user-guide/mcp/usage) if the navigation in Glean differs.
+    Open the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true), choose the server you want to connect, and copy its URL. Selecting a host is optional; do it when you want setup instructions tailored to that application. See the [MCP Configurator user guide](https://docs.glean.com/user-guide/mcp/usage) if the navigation in Glean differs.
   </Step>
 
-  <Step title="If the Configurator or host is missing">
-    If the Configurator is unavailable, ask a Glean administrator to confirm that MCP servers are enabled and that the end-user Configurator is visible. Those checks live in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers).
-
-    If the Configurator is available but a listed host does not appear, ask the administrator to check the tenant's DCR policy and any prior custom OAuth configuration. Those checks live in [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration).
-
-    If your host is an MCP application that is not listed, that is expected. Use [Supported MCP Hosts](/guides/mcp/supported-hosts) guidance, choose **Custom**, and paste the server URL and server name instead.
+  <Step title="If the Configurator is missing">
+    If the Configurator is unavailable, ask a Glean administrator to confirm that at least one MCP server is enabled. That check lives in [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers).
   </Step>
 
   <Step title="Match the host to its setup path">
-    Check [Supported MCP Hosts](/guides/mcp/supported-hosts) to see whether your host is user-configurable or organization-managed. Selecting a host is optional: one server URL connects any MCP host, including hosts the Configurator does not list. Select your host to get the setup method, configuration shape, and commands that fit it.
+    Check [Supported MCP Hosts](/guides/mcp/supported-hosts) to see whether your host is user-configurable or organization-managed. One server URL connects any MCP host, including hosts the Configurator does not list. For an unlisted host, use that URL with the host's own MCP setup instructions.
   </Step>
 </Steps>
 
@@ -32,7 +28,7 @@ Glean enables the OAuth Authorization Server and Remote MCP Server by default fo
 
 Complete the host's OAuth sign-in flow with your organization's SSO when prompted.
 
-Dynamic Client Registration (DCR) is the usual path for MCP hosts. By default a tenant allows any application that supports DCR. Administrators can restrict registration to approved applications or turn DCR off. If DCR is disabled, your tenant does not allow the host to register, or the host needs scopes DCR does not grant, an administrator can register a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
+Dynamic Client Registration (DCR) is the usual path for MCP hosts. A tenant can allow any DCR-capable application, restrict registration to approved applications, or turn DCR off. Glean provisions new and previously unconfigured default-on MCP tenants with the Glean-managed list of approved applications; tenants with existing MCP or OAuth configuration keep their settings. If DCR is disabled, your tenant does not allow the host to register, or the host needs scopes DCR does not grant, an administrator can register a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
 
 Use a Glean-issued API token only when the host cannot complete OAuth. Do not assign API Token Creator in bulk as an MCP rollout.
 

--- a/docs/guides/mcp/troubleshooting.mdx
+++ b/docs/guides/mcp/troubleshooting.mdx
@@ -9,7 +9,7 @@ Use this guide for a tenant's Glean Remote MCP Server. If you only need Glean de
 
 ## The Configurator or host is missing
 
-Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, ask a Glean administrator to confirm that at least one MCP server is enabled.
+Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, ask a Glean administrator to confirm that at least one MCP server is enabled and that the Configurator is visible.
 
 If your host is not listed in the Configurator, use the server URL with the host's own MCP setup instructions. One server URL works across MCP hosts.
 
@@ -25,7 +25,7 @@ Ask the administrator to check the [DCR policy](https://docs.glean.com/administr
 
 ## Authentication fails or sign-in loops
 
-Revoke the grant on the Glean side, then clear it on the host side. In Glean, open **Your settings**, go to **Third party apps and MCP**, select the host, and choose **Revoke**. Then remove the host's stored Glean MCP credentials, reconnect the server, and complete your SSO sign-in again. An expired session, rejected consent, or a stale credential on either side can cause a loop.
+Revoke the grant on the Glean side, then clear it on the host side. In Glean, open **Your settings**, go to **Third party apps and MCP**, select the host, and choose **Revoke**. Then remove the host's stored Glean MCP credentials, reconnect the server, and complete your SSO sign-in again.
 
 Prefer OAuth. Use a Glean-issued API token only when the host cannot complete OAuth. Do not assign API Token Creator in bulk to work around OAuth. See the [Glean OAuth Authorization Server guide](https://docs.glean.com/administration/oauth/authorization-server) and the [authentication overview](/get-started/authentication).
 

--- a/docs/guides/mcp/troubleshooting.mdx
+++ b/docs/guides/mcp/troubleshooting.mdx
@@ -9,25 +9,31 @@ Use this guide for a tenant's Glean Remote MCP Server. If you only need Glean de
 
 ## The Configurator or host is missing
 
-Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, or it does not show your host, ask a Glean administrator to confirm that MCP servers are enabled and that the Configurator is visible, then to check the DCR allowlist and any prior custom OAuth configuration.
+Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, ask a Glean administrator to confirm that MCP servers are enabled and that the Configurator is visible.
+
+If the Configurator is present but a listed host does not appear, ask a Glean administrator to check the tenant's DCR policy and any prior custom OAuth configuration.
+
+If your host is an MCP application that is not listed in the Configurator, that is expected. Use the [Supported MCP Hosts](/guides/mcp/supported-hosts) guidance, choose **Custom**, and paste the server URL and server name instead.
 
 Administrators should start with [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers). After the check, reopen the Configurator and select the host again.
 
 ## DCR or redirect URI is rejected
 
-Dynamic Client Registration (DCR) works when the host is on the tenant's approved list and the redirect URI matches policy. Copy the host's configuration from the MCP Configurator. Do not substitute a redirect URI from a different host.
+A tenant sets one of three Dynamic Client Registration (DCR) policies: allow any application, allow only approved applications, or do not allow dynamic registration. Registration fails when the policy restricts it to approved applications and the host's redirect URI matches no allowed pattern, or when DCR is off. Copy the host's configuration from the MCP Configurator. Do not substitute a redirect URI from a different host.
 
 Ask the administrator to check the [DCR policy](https://docs.glean.com/administration/oauth/dynamic-client-registration). When DCR is unavailable or its scopes do not fit a governed application, use a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
 
 ## Authentication fails or sign-in loops
 
-Remove the host's stored Glean MCP credentials. Reconnect the server. Complete the host's SSO sign-in flow again. An expired session, rejected consent, or stale credential can cause a loop.
+Revoke the grant on the Glean side, then clear it on the host side. In Glean, open **Your settings**, go to **Third party apps and MCP**, select the host, and choose **Revoke**. Then remove the host's stored Glean MCP credentials, reconnect the server, and complete your SSO sign-in again. An expired session, rejected consent, or a stale credential on either side can cause a loop.
 
 Prefer OAuth. Use a Glean-issued API token only when the host cannot complete OAuth. Do not assign API Token Creator in bulk to work around OAuth. See the [Glean OAuth Authorization Server guide](https://docs.glean.com/administration/oauth/authorization-server) and the [authentication overview](/get-started/authentication).
 
 ## The URL or server name is wrong
 
-Return to the MCP Configurator, select the exact host, and copy both the server URL and server name again. A value from another host, tenant, or environment can appear valid but connect to the wrong server. Restart the host after you replace the configuration.
+A server URL identifies a Glean MCP server, not a host, so the same URL works across hosts. It fails when it points at the wrong server, tenant, or environment. Return to the MCP Configurator, confirm the server you intended, and copy the server URL again. Restart the host after you replace the configuration.
+
+Host-specific values are the configuration shape, transport, redirect URI, and setup command. Copy those from the Configurator entry for your host.
 
 For organization-managed hosts, use the host's managed-configuration guidance from [About Glean MCP Servers](https://docs.glean.com/administration/platform/mcp/about). For device-managed deployment, use the [MDM deployment guide](https://docs.glean.com/administration/platform/mcp/mdm-mcp).
 

--- a/docs/guides/mcp/troubleshooting.mdx
+++ b/docs/guides/mcp/troubleshooting.mdx
@@ -9,19 +9,19 @@ Use this guide for a tenant's Glean Remote MCP Server. If you only need Glean de
 
 ## The Configurator or host is missing
 
-Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP or hide the end-user Configurator. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, ask a Glean administrator to confirm that MCP servers are enabled and that the Configurator is visible.
+Glean enables the OAuth Authorization Server and Remote MCP Server by default for eligible tenants. Administrators can disable MCP. If the [MCP Configurator](https://app.glean.com/settings/install?mcpConfigure=true) is missing, ask a Glean administrator to confirm that at least one MCP server is enabled.
 
-If the Configurator is present but a listed host does not appear, ask a Glean administrator to check the tenant's DCR policy and any prior custom OAuth configuration.
+If your host is not listed in the Configurator, use the server URL with the host's own MCP setup instructions. One server URL works across MCP hosts.
 
-If your host is an MCP application that is not listed in the Configurator, that is expected. Use the [Supported MCP Hosts](/guides/mcp/supported-hosts) guidance, choose **Custom**, and paste the server URL and server name instead.
-
-Administrators should start with [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers). After the check, reopen the Configurator and select the host again.
+Administrators should start with [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers). After the check, reopen the Configurator and copy the server URL. Select a host only when it is listed and you want tailored setup instructions.
 
 ## DCR or redirect URI is rejected
 
-A tenant sets one of three Dynamic Client Registration (DCR) policies: allow any application, allow only approved applications, or do not allow dynamic registration. Registration fails when the policy restricts it to approved applications and the host's redirect URI matches no allowed pattern, or when DCR is off. Copy the host's configuration from the MCP Configurator. Do not substitute a redirect URI from a different host.
+A tenant sets one of three Dynamic Client Registration (DCR) policies: allow any application, allow only approved applications, or do not allow dynamic registration. Registration fails when the policy restricts it to approved applications and the host's redirect URI matches no allowed pattern, or when DCR is off. For a listed host, copy its configuration from the MCP Configurator. For an unlisted host, follow that host's own MCP and OAuth setup instructions. Do not substitute a redirect URI from a different host.
 
-Ask the administrator to check the [DCR policy](https://docs.glean.com/administration/oauth/dynamic-client-registration). When DCR is unavailable or its scopes do not fit a governed application, use a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
+New and previously unconfigured default-on MCP tenants use the Glean-managed list of approved applications. Tenants with existing MCP or OAuth configuration keep their settings.
+
+Ask the administrator to check the [DCR policy](https://docs.glean.com/administration/oauth/dynamic-client-registration) after a registration or redirect URI failure. When DCR is unavailable or its scopes do not fit a governed application, use a [static OAuth client](https://docs.glean.com/administration/oauth/static-client-registration). See [OAuth authentication](/api-info/client/authentication/oauth) for the DCR versus static model.
 
 ## Authentication fails or sign-in loops
 
@@ -29,11 +29,11 @@ Revoke the grant on the Glean side, then clear it on the host side. In Glean, op
 
 Prefer OAuth. Use a Glean-issued API token only when the host cannot complete OAuth. Do not assign API Token Creator in bulk to work around OAuth. See the [Glean OAuth Authorization Server guide](https://docs.glean.com/administration/oauth/authorization-server) and the [authentication overview](/get-started/authentication).
 
-## The URL or server name is wrong
+## The server URL points to the wrong server
 
-A server URL identifies a Glean MCP server, not a host, so the same URL works across hosts. It fails when it points at the wrong server, tenant, or environment. Return to the MCP Configurator, confirm the server you intended, and copy the server URL again. Restart the host after you replace the configuration.
+A server URL identifies a Glean MCP server, not a host, so the same URL works across hosts. If the host uses a URL for a different server, return to the MCP Configurator, choose the intended server, and copy its URL again. Restart the host after you replace the configuration.
 
-Host-specific values are the configuration shape, transport, redirect URI, and setup command. Copy those from the Configurator entry for your host.
+For a listed host, follow its tailored setup instructions in the Configurator.
 
 For organization-managed hosts, use the host's managed-configuration guidance from [About Glean MCP Servers](https://docs.glean.com/administration/platform/mcp/about). For device-managed deployment, use the [MDM deployment guide](https://docs.glean.com/administration/platform/mcp/mdm-mcp).
 

--- a/packages/docusaurus-theme-glean/package.json
+++ b/packages/docusaurus-theme-glean/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
-    "@gleanwork/mcp-config-schema": "^5.2.0",
+    "@gleanwork/mcp-config-schema": "^5.4.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.24.0",
     "react-feather": "^2.0.10"

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/mcp-config-schema-compat.test.ts
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/mcp-config-schema-compat.test.ts
@@ -1,0 +1,13 @@
+import { MCPConfigRegistry } from '@gleanwork/mcp-config-schema/browser';
+
+describe('mcp-config-schema theme dependency', () => {
+  it('exposes getManagedSetupUrl on the installed package', () => {
+    const chatgpt = 'https://chatgpt.com/admin/apps?tab=available&q=glean';
+    const registry = new MCPConfigRegistry({
+      managedSetupUrls: { chatgpt },
+    });
+
+    expect(registry.getManagedSetupUrl('chatgpt')).toBe(chatgpt);
+    expect(registry.getManagedSetupUrl('linear')).toBeUndefined();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
         specifier: ^3.0.0
         version: 3.10.1(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.46)(esbuild@0.28.1)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(esbuild@0.28.1)(postcss@8.5.25))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@18.3.1))(@rspack/core@1.7.12)(@swc/core@1.15.46)(esbuild@0.28.1)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@swc/core@1.15.46)(esbuild@0.28.1)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@gleanwork/mcp-config-schema':
-        specifier: ^5.2.0
-        version: 5.2.0(zod@4.4.3)
+        specifier: ^5.4.0
+        version: 5.4.0(zod@4.4.3)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -2124,12 +2124,6 @@ packages:
 
   '@gleanwork/mcp-config-schema@4.3.0':
     resolution: {integrity: sha512-qajPyFZoNYVhFJ0IBgSQDRaLFPL5ysgTjdzCJYx7SG1lygHHz220Fj5lC7wP2/ntJiCmiQv8jl7zAS5kOnDNgg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-
-  '@gleanwork/mcp-config-schema@5.2.0':
-    resolution: {integrity: sha512-2ldjVVC+ZcgSPXcwahqqZralI0JgMNeHas234psL/KytK74CLXX0OKuLEdI4SUdcHLnnQQSgShvQqy2UYb+lPA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -14510,14 +14504,6 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@gleanwork/mcp-config-schema@4.3.0(zod@4.4.3)':
-    dependencies:
-      glob: 13.0.6
-      js-yaml: 4.2.0
-      mkdirp: 3.0.1
-      smol-toml: 1.6.1
-      zod: 4.4.3
-
-  '@gleanwork/mcp-config-schema@5.2.0(zod@4.4.3)':
     dependencies:
       glob: 13.0.6
       js-yaml: 4.2.0


### PR DESCRIPTION
**Internal Description for reviewers**:

## DCR policy and MCP server identity

The MCP onboarding docs conflated the selectable DCR policy with the policy Glean applies when provisioning default-on MCP. They also treated a server URL as host-specific and omitted Glean-side revocation when troubleshooting sign-in loops.

Tenants can allow any DCR-capable application, restrict registration to approved applications, or disable DCR. New and previously unconfigured default-on MCP tenants receive the Glean-managed approved-application list; tenants with existing MCP or OAuth configuration retain their settings.

The Configurator flow now follows the published user guide: choose the intended server and copy its URL, optionally select a host for tailored instructions, and reuse the URL with unlisted hosts. DCR troubleshooting starts after registration or redirect failure. Sign-in-loop recovery revokes the Glean connected-app grant before clearing host credentials.

**Context/Jira (Mandatory if external)**:

Follow-up to #685–#687. Original thread: [Slack](https://askscio.slack.com/archives/C0A74DX9Q8N/p1786488385929539)

Authoritative references:
- [Dynamic Client Registration](https://docs.glean.com/administration/oauth/dynamic-client-registration)
- [Set up Glean MCP server](https://docs.glean.com/administration/platform/mcp/enable-mcp-servers)
- [Using the Glean MCP Server](https://docs.glean.com/user-guide/mcp/usage)

**Test plan**:
- [x] `pnpm format`
- [x] `NODE_OPTIONS='--no-experimental-webstorage' pnpm test` — 236 passed, 2 skipped
- [x] `pnpm build`
- [ ] _Need review from all reviewers (default: 1)_
---

_Release Notes ([go/relnotesfaq](https://go/relnotesfaq))_

**Change Categories (mandatory - check all that apply)**
* **Internal (This PR will not be included in the external release notes)**
  - [ ] Flag-gated development/Internal fix
* **External (Choose one if applicable. A detailed external description is mandatory)**
  - [x] Bug Fixes/Enhancements
  - [ ] Security or Permissions related change
  - [ ] Feature launch
  - [ ] UI change
  - [ ] 3rd party LLM integration change
  - [ ] External API breaking change
  - [ ] Scrubbed logs change
* **Platform (Choose one if applicable. Choose at least one other category from Internal or External)**
  - [ ] AWS only change
  - [ ] Azure only change
  - [ ] GCP only change

- [ ] Document Updates Needed

_(DO NOT include confidential details. Should be at least 40 characters long.)_
**External description for customers**:

Clarifies Dynamic Client Registration policy, default-on MCP provisioning, reusable MCP server URLs, and connected-app revocation steps.