### PR TITLE
[Docs] Stop the Triggers changelog entry rendering as Deprecated

### DIFF
--- a/changelog/entries/2026-08-20-platform-triggers-api.md
+++ b/changelog/entries/2026-08-20-platform-triggers-api.md
@@ -19,7 +19,7 @@ The Platform Triggers API is now documented as an experimental release — subsc
 
 ## Experimental
 
-These endpoints are experimental. Send `X-Glean-Include-Experimental: true` or they are not exposed. They may change or be removed without notice and are not covered by the [deprecation policy](/deprecations/overview). See [Experimental APIs](/experimental/overview).
+These endpoints are experimental. Send `X-Glean-Include-Experimental: true` or they are not exposed. They may change or be removed without notice, and the standard API lifecycle guarantees do not apply. See [Experimental APIs](/experimental/overview).
 
 ## Documentation
 


### PR DESCRIPTION
Before:
<img width="784" height="606" alt="image" src="https://github.com/user-attachments/assets/d52b9ba2-0bd7-4241-85fe-2987c767ce82" />

After:
<img width="784" height="437" alt="image" src="https://github.com/user-attachments/assets/a6467eeb-095e-4992-9113-e66e6ca15fb7" />


## Problem

The [Platform Triggers API (Experimental)](https://developers.glean.com/changelog) entry is badged **Deprecated** on the live changelog. It is a brand-new experimental API — nothing about it is deprecated.

`classifyChangelogImpact` scans the entry body:

```js
// packages/changelog-generator/src/shared/impact.ts:14
const DEPRECATED_PATTERNS = [/\bdeprecated\b/i, /\bdeprecation\b/i];
```

The entry linked the deprecation policy in order to say the API is **not** covered by it:

> …may change or be removed without notice and are not covered by the [deprecation policy](/deprecations/overview).

That one word matches. No higher level (breaking / action_required) fires, so `deprecated` becomes the entry's impact.

## Fix

Reworded to keep the meaning without the token:

> …may change or be removed without notice, and the standard API lifecycle guarantees do not apply. See [Experimental APIs](/experimental/overview).

Verified by running the real classifier over both versions:

```
BEFORE (live)  impact=deprecated   attention=[Deprecated]
AFTER  (fix)   impact=routine      attention=[none]
```

## Also: dated 2026-08-20

The entry read 08-19, which predated publication — the docs merged in #692 at 09:53 UTC on 08-20. The slug is the filename minus the date prefix, so the URL is unchanged and no redirect is needed.

## Follow-up worth considering

The classifier arguably over-matches: a *reference* to the deprecation policy is not a deprecation, and any future entry that links that policy will hit the same trap. Narrowing the pattern (or scanning only headings) belongs in the generator and is out of scope here — this is the safe fix for what is currently wrong in production.