### PR TITLE
Show cookbook auth per build path, not as a union

### DIFF
--- a/src/components/Cookbook/Cookbook.test.tsx
+++ b/src/components/Cookbook/Cookbook.test.tsx
@@ -44,7 +44,6 @@ function makeRecipe(overrides: Partial<RecipeRecord>): RecipeRecord {
   };
 }
 
-/** One build path of a recipe whose auth contract varies by path. */
 function dualPathAsset(
   slug: string,
   scopes: string[],
@@ -543,8 +542,6 @@ describe('RecipeLayout', () => {
     expect(auth).toHaveTextContent('Platform Agents');
     expect(auth).toHaveTextContent('(SEARCH, AGENTS)');
 
-    // Chips are grouped per path, so SEARCH is chipped twice. The union would
-    // have told the Search + Chat reader to mint an AGENTS scope it never calls.
     expect(screen.getAllByText('SEARCH')).toHaveLength(2);
     expect(screen.getAllByText('CHAT')).toHaveLength(1);
     expect(screen.getAllByText('AGENTS')).toHaveLength(1);

--- a/src/components/Cookbook/Cookbook.test.tsx
+++ b/src/components/Cookbook/Cookbook.test.tsx
@@ -7,6 +7,7 @@ import RecipeIndex from './RecipeIndex';
 import RecipeLayout, { RecipeArchitecture } from './RecipeLayout';
 import FlagshipCard from './FlagshipCard';
 import type { RecipeRecord } from '../../types/recipe';
+import type { AuthKind } from './authContexts';
 import catStyles from './categories.module.css';
 import layoutStyles from './RecipeLayout.module.css';
 
@@ -47,6 +48,7 @@ function makeRecipe(overrides: Partial<RecipeRecord>): RecipeRecord {
 function dualPathAsset(
   slug: string,
   scopes: string[],
+  kind: AuthKind = 'oauth-with-token-fallback',
 ): NonNullable<RecipeRecord['codeAssets']>[number] {
   return {
     repoPath: `recipes/customer-360/${slug}`,
@@ -57,7 +59,7 @@ function dualPathAsset(
       questions: [],
       auth: [
         {
-          kind: 'oauth-with-token-fallback',
+          kind,
           scopes,
           setupCommand: 'cd customer-360 && npm run login',
         },
@@ -569,6 +571,35 @@ describe('RecipeLayout', () => {
     expect(auth).not.toHaveTextContent('TypeScript');
     expect(auth).not.toHaveTextContent('Python');
     expect(screen.getAllByText('SEARCH')).toHaveLength(1);
+  });
+
+  it('does not put token scopes on a cookie path that declares none', () => {
+    render(
+      <RecipeLayout
+        plugin={plugin}
+        recipe={makeRecipe({
+          authMethod: ['web-sdk-cookie', 'client-api-oauth-or-token'],
+          buildMethod: 'scaffold',
+          requiredScopes: ['CHAT'],
+          codeAssets: [
+            dualPathAsset('web-sdk', [], 'browser-cookie'),
+            dualPathAsset('chat-api', ['CHAT']),
+          ],
+        })}
+      >
+        <p>Body</p>
+      </RecipeLayout>,
+    );
+
+    const auth = screen.getByText('Auth').parentElement!;
+    expect(auth).toHaveTextContent('Web SDK');
+    expect(auth).toHaveTextContent('existing Glean browser session');
+    expect(auth).toHaveTextContent('Chat API');
+
+    const scopes = screen.getByText('Required scopes').parentElement!;
+    expect(scopes).toHaveTextContent('Chat API');
+    expect(scopes).toHaveTextContent('CHAT');
+    expect(scopes).not.toHaveTextContent('Web SDK');
   });
 
   it('does not tell cookie-SSO recipes to mint a token', () => {

--- a/src/components/Cookbook/Cookbook.test.tsx
+++ b/src/components/Cookbook/Cookbook.test.tsx
@@ -44,6 +44,35 @@ function makeRecipe(overrides: Partial<RecipeRecord>): RecipeRecord {
   };
 }
 
+/** One build path of a recipe whose auth contract varies by path. */
+function dualPathAsset(
+  slug: string,
+  scopes: string[],
+): NonNullable<RecipeRecord['codeAssets']>[number] {
+  return {
+    repoPath: `recipes/customer-360/${slug}`,
+    language: 'typescript',
+    description: `The ${slug} path`,
+    execution: {
+      type: 'local-web',
+      questions: [],
+      auth: [
+        {
+          kind: 'oauth-with-token-fallback',
+          scopes,
+          setupCommand: 'cd customer-360 && npm run login',
+        },
+      ],
+      verification: {
+        kind: 'automated',
+        command: 'cd customer-360 && npm run verify',
+        expectedDuration: '1–3 minutes',
+        startsOwnServer: true,
+      },
+    },
+  };
+}
+
 const flagship = makeRecipe({
   id: 'build-engineering-portal',
   title: 'Build an engineering portal',
@@ -488,6 +517,61 @@ describe('RecipeLayout', () => {
     expect(
       screen.getByRole('link', { name: 'Glean-issued tokens' }),
     ).toHaveAttribute('href', '/api-info/client/authentication/glean-issued');
+  });
+
+  it('gives each build path its own scopes rather than the union', () => {
+    render(
+      <RecipeLayout
+        plugin={plugin}
+        recipe={makeRecipe({
+          authMethod: ['client-api-oauth-or-token'],
+          buildMethod: 'scaffold',
+          requiredScopes: ['SEARCH', 'CHAT', 'AGENTS'],
+          codeAssets: [
+            dualPathAsset('platform-search-chat', ['SEARCH', 'CHAT']),
+            dualPathAsset('platform-agents', ['SEARCH', 'AGENTS']),
+          ],
+        })}
+      >
+        <p>Body</p>
+      </RecipeLayout>,
+    );
+
+    const auth = screen.getByText('Auth').parentElement!;
+    expect(auth).toHaveTextContent('Platform Search Chat');
+    expect(auth).toHaveTextContent('(SEARCH, CHAT)');
+    expect(auth).toHaveTextContent('Platform Agents');
+    expect(auth).toHaveTextContent('(SEARCH, AGENTS)');
+
+    // Chips are grouped per path, so SEARCH is chipped twice. The union would
+    // have told the Search + Chat reader to mint an AGENTS scope it never calls.
+    expect(screen.getAllByText('SEARCH')).toHaveLength(2);
+    expect(screen.getAllByText('CHAT')).toHaveLength(1);
+    expect(screen.getAllByText('AGENTS')).toHaveLength(1);
+  });
+
+  it('does not split the rail when both paths need the same scopes', () => {
+    render(
+      <RecipeLayout
+        plugin={plugin}
+        recipe={makeRecipe({
+          authMethod: ['client-api-oauth-or-token'],
+          buildMethod: 'scaffold',
+          requiredScopes: ['SEARCH'],
+          codeAssets: [
+            dualPathAsset('typescript', ['SEARCH']),
+            dualPathAsset('python', ['SEARCH']),
+          ],
+        })}
+      >
+        <p>Body</p>
+      </RecipeLayout>,
+    );
+
+    const auth = screen.getByText('Auth').parentElement!;
+    expect(auth).not.toHaveTextContent('TypeScript');
+    expect(auth).not.toHaveTextContent('Python');
+    expect(screen.getAllByText('SEARCH')).toHaveLength(1);
   });
 
   it('does not tell cookie-SSO recipes to mint a token', () => {

--- a/src/components/Cookbook/RecipeAuth.tsx
+++ b/src/components/Cookbook/RecipeAuth.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import Link from '@docusaurus/Link';
 import type { RecipeRecord } from '../../types/recipe';
+import { authContexts, type AuthKind } from './authContexts';
 import styles from './RecipeLayout.module.css';
 
 const FIND_SERVER = '/get-started/authentication#finding-your-server-url';
@@ -12,40 +13,16 @@ const TOKEN_MGMT_CLIENT =
 const TOKEN_MGMT_INDEXING =
   'https://app.glean.com/admin/platform/tokenManagement?tab=indexing';
 
-type AuthKind = NonNullable<RecipeRecord['execution']>['auth'][number]['kind'];
-
-function kindsFromRecipe(recipe: RecipeRecord): AuthKind[] {
-  const declared = recipe.execution?.auth.map((entry) => entry.kind) ?? [];
-  if (declared.length > 0) {
-    return [...new Set(declared)];
-  }
-  const mapped: AuthKind[] = [];
-  for (const method of recipe.authMethod) {
-    if (method === 'web-sdk-cookie') {
-      mapped.push('browser-cookie');
-    } else if (method === 'client-api-oauth-or-token') {
-      mapped.push('oauth-with-token-fallback');
-    } else if (method === 'indexing-token') {
-      mapped.push('indexing-token');
-    }
-  }
-  return [...new Set(mapped)];
-}
-
-function setupCommand(recipe: RecipeRecord): string | undefined {
-  return recipe.execution?.auth.find((entry) => entry.setupCommand)
-    ?.setupCommand;
-}
-
 function AuthBlock({
   kind,
-  recipe,
+  scopeList,
+  login,
 }: {
   kind: AuthKind;
-  recipe: RecipeRecord;
+  scopeList: string[];
+  login?: string;
 }): React.ReactElement | null {
-  const login = setupCommand(recipe);
-  const scopes = recipe.requiredScopes.join(', ');
+  const scopes = scopeList.join(', ');
 
   switch (kind) {
     case 'none':
@@ -110,14 +87,20 @@ function AuthBlock({
   }
 }
 
-/** Sticky-rail auth guidance keyed off recipe auth data. */
+/** Sticky-rail auth guidance keyed off recipe auth data, per build path. */
 export function RecipeAuthCard({
   recipe,
 }: {
   recipe: RecipeRecord;
 }): React.ReactElement | null {
-  const kinds = kindsFromRecipe(recipe).filter((kind) => kind !== 'none');
-  if (kinds.length === 0) {
+  const contexts = authContexts(recipe)
+    .map((context) => ({
+      ...context,
+      entries: context.entries.filter((entry) => entry.kind !== 'none'),
+    }))
+    .filter((context) => context.entries.length > 0);
+
+  if (contexts.length === 0) {
     return null;
   }
 
@@ -125,8 +108,25 @@ export function RecipeAuthCard({
     <div className={styles.railCard}>
       <div className={styles.railLabel}>Auth</div>
       <div className={styles.authBody}>
-        {kinds.map((kind) => (
-          <AuthBlock key={kind} kind={kind} recipe={recipe} />
+        {contexts.map((context, contextIndex) => (
+          <div
+            className={styles.authBody}
+            key={context.label ?? `auth-${contextIndex}`}
+          >
+            {context.label && (
+              <p>
+                <strong>{context.label}</strong>
+              </p>
+            )}
+            {context.entries.map((entry, entryIndex) => (
+              <AuthBlock
+                key={`${entry.kind}-${entryIndex}`}
+                kind={entry.kind}
+                scopeList={entry.scopes}
+                login={entry.setupCommand}
+              />
+            ))}
+          </div>
         ))}
       </div>
     </div>

--- a/src/components/Cookbook/RecipeAuth.tsx
+++ b/src/components/Cookbook/RecipeAuth.tsx
@@ -87,7 +87,6 @@ function AuthBlock({
   }
 }
 
-/** Sticky-rail auth guidance keyed off recipe auth data, per build path. */
 export function RecipeAuthCard({
   recipe,
 }: {

--- a/src/components/Cookbook/RecipeLayout.tsx
+++ b/src/components/Cookbook/RecipeLayout.tsx
@@ -651,20 +651,22 @@ function RequiredScopesCard({
       <div className={styles.railCard}>
         <div className={styles.railLabel}>Required scopes</div>
         <div className={styles.authBody}>
-          {groups.map((group) => (
-            <div key={group.label}>
-              <p>
-                <strong>{group.label}</strong>
-              </p>
-              <div className={styles.scopes}>
-                {group.scopes.map((scope) => (
-                  <span className={styles.scopeChip} key={scope}>
-                    {scope}
-                  </span>
-                ))}
+          {groups
+            .filter((group) => group.scopes.length > 0)
+            .map((group) => (
+              <div key={group.label}>
+                <p>
+                  <strong>{group.label}</strong>
+                </p>
+                <div className={styles.scopes}>
+                  {group.scopes.map((scope) => (
+                    <span className={styles.scopeChip} key={scope}>
+                      {scope}
+                    </span>
+                  ))}
+                </div>
               </div>
-            </div>
-          ))}
+            ))}
         </div>
       </div>
     );

--- a/src/components/Cookbook/RecipeLayout.tsx
+++ b/src/components/Cookbook/RecipeLayout.tsx
@@ -639,11 +639,6 @@ export default function RecipeLayout({
   );
 }
 
-/**
- * Scope chips, split per build path when the paths differ. The flat
- * `requiredScopes` union is what the whole recipe can need, so on a recipe
- * with a path split it overstates what either path actually asks for.
- */
 function RequiredScopesCard({
   recipe,
 }: {

--- a/src/components/Cookbook/RecipeLayout.tsx
+++ b/src/components/Cookbook/RecipeLayout.tsx
@@ -14,6 +14,7 @@ import PluginRunButton from './PluginRunButton';
 import { AdaptiveBrandIcon, CATEGORY_ICONS } from './categories';
 import { BRAND_ICON_SRC } from './brandIcons';
 import { RecipeAuthCard } from './RecipeAuth';
+import { humanizeVariantLabel, variantScopeGroups } from './authContexts';
 import styles from './RecipeLayout.module.css';
 import catStyles from './categories.module.css';
 
@@ -253,27 +254,6 @@ export function RecipeDemoQueries(): React.ReactElement | null {
       )}
     </RecipeSection>
   );
-}
-
-const VARIANT_LABEL_WORDS: Record<string, string> = {
-  sdk: 'SDK',
-  api: 'API',
-  typescript: 'TypeScript',
-  javascript: 'JavaScript',
-};
-
-/** Last path segment of a codeAsset's repoPath, title-cased ("web-sdk" -> "Web SDK"). */
-function humanizeVariantLabel(repoPath: string): string {
-  return repoPath
-    .split('/')
-    .pop()!
-    .split('-')
-    .map(
-      (word) =>
-        VARIANT_LABEL_WORDS[word] ??
-        word.charAt(0).toUpperCase() + word.slice(1),
-    )
-    .join(' ');
 }
 
 /** One numbered row in a steps timeline. */
@@ -651,21 +631,64 @@ export default function RecipeLayout({
               </div>
             </div>
 
-            {recipe.requiredScopes.length > 0 ? (
-              <div className={styles.railCard}>
-                <div className={styles.railLabel}>Required scopes</div>
-                <div className={styles.scopes}>
-                  {recipe.requiredScopes.map((scope) => (
-                    <span className={styles.scopeChip} key={scope}>
-                      {scope}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ) : null}
+            <RequiredScopesCard recipe={recipe} />
           </div>
         </div>
       </div>
     </RecipeContext.Provider>
+  );
+}
+
+/**
+ * Scope chips, split per build path when the paths differ. The flat
+ * `requiredScopes` union is what the whole recipe can need, so on a recipe
+ * with a path split it overstates what either path actually asks for.
+ */
+function RequiredScopesCard({
+  recipe,
+}: {
+  recipe: RecipeRecord;
+}): React.ReactElement | null {
+  const groups = variantScopeGroups(recipe);
+
+  if (groups) {
+    return (
+      <div className={styles.railCard}>
+        <div className={styles.railLabel}>Required scopes</div>
+        <div className={styles.authBody}>
+          {groups.map((group) => (
+            <div key={group.label}>
+              <p>
+                <strong>{group.label}</strong>
+              </p>
+              <div className={styles.scopes}>
+                {group.scopes.map((scope) => (
+                  <span className={styles.scopeChip} key={scope}>
+                    {scope}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (recipe.requiredScopes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={styles.railCard}>
+      <div className={styles.railLabel}>Required scopes</div>
+      <div className={styles.scopes}>
+        {recipe.requiredScopes.map((scope) => (
+          <span className={styles.scopeChip} key={scope}>
+            {scope}
+          </span>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/src/components/Cookbook/authContexts.ts
+++ b/src/components/Cookbook/authContexts.ts
@@ -91,9 +91,6 @@ export function variantScopeGroups(
     label: context.label ?? '',
     scopes: [...new Set(context.entries.flatMap((entry) => entry.scopes))],
   }));
-  if (groups.some((group) => group.scopes.length === 0)) {
-    return undefined;
-  }
   const distinct = new Set(groups.map((group) => group.scopes.join(',')));
   return distinct.size === 1 ? undefined : groups;
 }

--- a/src/components/Cookbook/authContexts.ts
+++ b/src/components/Cookbook/authContexts.ts
@@ -4,7 +4,6 @@ type Execution = NonNullable<RecipeRecord['execution']>;
 export type AuthEntry = Execution['auth'][number];
 export type AuthKind = AuthEntry['kind'];
 
-/** One auth contract, labelled when a recipe splits auth across build paths. */
 export type AuthContext = {
   label?: string;
   entries: AuthEntry[];
@@ -17,7 +16,6 @@ const VARIANT_LABEL_WORDS: Record<string, string> = {
   javascript: 'JavaScript',
 };
 
-/** Last path segment of a codeAsset's repoPath, title-cased ("web-sdk" -> "Web SDK"). */
 export function humanizeVariantLabel(repoPath: string): string {
   return repoPath
     .split('/')
@@ -31,7 +29,6 @@ export function humanizeVariantLabel(repoPath: string): string {
     .join(' ');
 }
 
-/** Recipes predating execution data still declare auth as a bare method. */
 function fallbackEntries(recipe: RecipeRecord): AuthEntry[] {
   const kinds: AuthKind[] = [];
   for (const method of recipe.authMethod) {
@@ -62,7 +59,6 @@ function variantContexts(recipe: RecipeRecord): AuthContext[] {
   );
 }
 
-/** What two contracts have to share to render as one paragraph. */
 function renderKey(context: AuthContext): string {
   return context.entries
     .map(
@@ -72,14 +68,6 @@ function renderKey(context: AuthContext): string {
     .join('|');
 }
 
-/**
- * The auth contracts to render, one per build path when they differ.
- *
- * A recipe whose paths need different scopes carries no top-level `execution`,
- * so reading `requiredScopes` showed every reader the union of all paths —
- * telling a Customer 360 Path A reader to mint an AGENTS scope that path never
- * calls.
- */
 export function authContexts(recipe: RecipeRecord): AuthContext[] {
   if (recipe.execution) {
     return [{ entries: recipe.execution.auth }];
@@ -92,7 +80,6 @@ export function authContexts(recipe: RecipeRecord): AuthContext[] {
   return distinct.size === 1 ? [{ entries: variants[0].entries }] : variants;
 }
 
-/** Per-path scope chips, only when the paths genuinely require different scopes. */
 export function variantScopeGroups(
   recipe: RecipeRecord,
 ): { label: string; scopes: string[] }[] | undefined {
@@ -104,8 +91,6 @@ export function variantScopeGroups(
     label: context.label ?? '',
     scopes: [...new Set(context.entries.flatMap((entry) => entry.scopes))],
   }));
-  // A path declaring no scopes would render an empty group, which reads as
-  // "this path needs nothing" rather than "this path did not say".
   if (groups.some((group) => group.scopes.length === 0)) {
     return undefined;
   }

--- a/src/components/Cookbook/authContexts.ts
+++ b/src/components/Cookbook/authContexts.ts
@@ -1,0 +1,114 @@
+import type { RecipeRecord } from '../../types/recipe';
+
+type Execution = NonNullable<RecipeRecord['execution']>;
+export type AuthEntry = Execution['auth'][number];
+export type AuthKind = AuthEntry['kind'];
+
+/** One auth contract, labelled when a recipe splits auth across build paths. */
+export type AuthContext = {
+  label?: string;
+  entries: AuthEntry[];
+};
+
+const VARIANT_LABEL_WORDS: Record<string, string> = {
+  sdk: 'SDK',
+  api: 'API',
+  typescript: 'TypeScript',
+  javascript: 'JavaScript',
+};
+
+/** Last path segment of a codeAsset's repoPath, title-cased ("web-sdk" -> "Web SDK"). */
+export function humanizeVariantLabel(repoPath: string): string {
+  return repoPath
+    .split('/')
+    .pop()!
+    .split('-')
+    .map(
+      (word) =>
+        VARIANT_LABEL_WORDS[word] ??
+        word.charAt(0).toUpperCase() + word.slice(1),
+    )
+    .join(' ');
+}
+
+/** Recipes predating execution data still declare auth as a bare method. */
+function fallbackEntries(recipe: RecipeRecord): AuthEntry[] {
+  const kinds: AuthKind[] = [];
+  for (const method of recipe.authMethod) {
+    if (method === 'web-sdk-cookie') {
+      kinds.push('browser-cookie');
+    } else if (method === 'client-api-oauth-or-token') {
+      kinds.push('oauth-with-token-fallback');
+    } else if (method === 'indexing-token') {
+      kinds.push('indexing-token');
+    }
+  }
+  return [...new Set(kinds)].map((kind) => ({
+    kind,
+    scopes: recipe.requiredScopes,
+  }));
+}
+
+function variantContexts(recipe: RecipeRecord): AuthContext[] {
+  return (recipe.codeAssets ?? []).flatMap((asset) =>
+    asset.execution
+      ? [
+          {
+            label: humanizeVariantLabel(asset.repoPath),
+            entries: asset.execution.auth,
+          },
+        ]
+      : [],
+  );
+}
+
+/** What two contracts have to share to render as one paragraph. */
+function renderKey(context: AuthContext): string {
+  return context.entries
+    .map(
+      (entry) =>
+        `${entry.kind}:${entry.scopes.join(',')}:${entry.setupCommand ?? ''}`,
+    )
+    .join('|');
+}
+
+/**
+ * The auth contracts to render, one per build path when they differ.
+ *
+ * A recipe whose paths need different scopes carries no top-level `execution`,
+ * so reading `requiredScopes` showed every reader the union of all paths —
+ * telling a Customer 360 Path A reader to mint an AGENTS scope that path never
+ * calls.
+ */
+export function authContexts(recipe: RecipeRecord): AuthContext[] {
+  if (recipe.execution) {
+    return [{ entries: recipe.execution.auth }];
+  }
+  const variants = variantContexts(recipe);
+  if (variants.length === 0) {
+    return [{ entries: fallbackEntries(recipe) }];
+  }
+  const distinct = new Set(variants.map(renderKey));
+  return distinct.size === 1 ? [{ entries: variants[0].entries }] : variants;
+}
+
+/** Per-path scope chips, only when the paths genuinely require different scopes. */
+export function variantScopeGroups(
+  recipe: RecipeRecord,
+): { label: string; scopes: string[] }[] | undefined {
+  const variants = variantContexts(recipe);
+  if (variants.length < 2) {
+    return undefined;
+  }
+  const groups = variants.map((context) => ({
+    label: context.label ?? '',
+    scopes: [...new Set(context.entries.flatMap((entry) => entry.scopes))],
+  }));
+  // A path declaring no scopes would render an empty group, which reads as
+  // "this path needs nothing" rather than "this path did not say".
+  if (groups.some((group) => group.scopes.length === 0)) {
+    return undefined;
+  }
+  const distinct = new Set(groups.map((group) => group.scopes.join(',')));
+  return distinct.size === 1 ? undefined : groups;
+}


### PR DESCRIPTION
The cookbook Auth rail and scope chips read `recipe.requiredScopes`, which is the union of every path in the recipe. On Customer 360 that told a Path A reader to mint an `AGENTS` scope that path never calls.

## What changed

Auth now comes from `codeAssets[].execution.auth`. When paths disagree, the rail shows one block per path. When they agree, it stays a single block, so one-path recipes look the same.

Scope chips only split when every path declares scopes and those scopes actually differ. A path that declares none would otherwise render an empty group, which reads as "needs nothing" rather than "did not say".

Reading the per-path contract also recovers `setupCommand`, which the rail previously dropped for these recipes.

## Follow-up

The Customer 360 copy rewrite lives in glean-cookbook. This PR does not sync generated `docs/cookbook/*.mdx` or `recipes.json`. After that cookbook PR merges, a normal `pnpm registry:sync` picks the new copy up.
