### PR TITLE
Sync cookbook pages for the Customer 360-style setup copy

### DIFF
--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -160,7 +160,7 @@
     "languages": ["python", "typescript"],
     "prerequisites": [
       "A Glean instance where you can add a custom datasource",
-      "A Glean-issued Indexing API token, created in Admin Console Token Management (Indexing Tokens)",
+      "A Glean-issued Indexing API token, created in Admin Console → API access → Indexing API tokens",
       "Node.js 18+ to run the portal app locally"
     ],
     "demoQueries": [
@@ -578,11 +578,10 @@
     "buildMethod": "scaffold",
     "languages": ["typescript"],
     "prerequisites": [
-      "A work email for tenant discovery and OAuth sign-in; a scoped Glean API token is the fallback",
-      "X_GLEAN_INCLUDE_EXPERIMENTAL=true for Platform Search and Agents",
-      "Path B: an Account Brief agent in Agent Builder; set GLEAN_AGENT_ID server-side",
-      "Node 20+",
-      "An account name your own content covers — the page is built around whichever you pick (GLEAN_ACCOUNT_NAME)"
+      "Node 20 or newer",
+      "Your work email, so the sign-in command can find your Glean tenant. If your tenant cannot use OAuth, you need a Glean API token instead, scoped to the path you pick",
+      "The name of one of your own customers, spelled the way it appears in your Glean documents. You put that name in GLEAN_ACCOUNT_NAME, and the page is built around it. This is the customer you are reading about, not your own company or your Glean instance",
+      "Path B only: a conversational Account Brief agent in Agent Builder, whose ID you put in GLEAN_AGENT_ID. A form-triggered agent will not work"
     ],
     "demoQueries": [
       {
@@ -595,7 +594,7 @@
       },
       {
         "query": "What are the renewal risks?",
-        "expectedBehavior": "Either names risks grounded in cited content, or says it has none to report. It must not infer risk the sources don't support, and the account overview must show only the supplied account name and deterministic Search result counts."
+        "expectedBehavior": "Either names risks grounded in cited content, or says it has none to report. It must not infer risk the sources don't support, and the account overview must show only the account name you set plus counts taken straight from the Search results."
       }
     ],
     "codeAssets": [
@@ -610,7 +609,10 @@
               "id": "email",
               "prompt": "What is your work email? It is used once to discover your Glean tenant."
             },
-            { "id": "account", "prompt": "Which account should the page use?" }
+            {
+              "id": "account",
+              "prompt": "Which of your customers should this page be about? Use the name the way your Glean documents spell it, not your own company or Glean instance name."
+            }
           ],
           "auth": [
             {
@@ -636,37 +638,45 @@
         },
         "steps": [
           {
-            "title": "Scaffold the project",
+            "title": "Copy the project onto your machine",
             "command": "npx -y tiged@2.12.8 --mode=git gleanwork/glean-cookbook/recipes/customer-360/platform-search-chat customer-360",
-            "kind": "scaffold"
+            "kind": "scaffold",
+            "description": "Creates a customer-360 folder in whatever directory you run this from. Every command after this one runs inside that folder."
           },
           {
             "title": "Install dependencies",
             "command": "cd customer-360 && npm install",
-            "kind": "install"
+            "kind": "install",
+            "description": "Installs the Glean API client and the small local server that serves the page."
           },
           {
-            "title": "Try it with no credentials",
+            "title": "See it work before you connect anything",
             "command": "cd customer-360 && npm run verify:fixture",
-            "description": "Runs the Globex account tiles and Client Chat path against recorded Sample Corp responses. Overview counts must match the fixture result lengths, and the three demo queries must stay cited.",
+            "description": "Runs the whole page against recorded answers for a fictional account named Globex, so you can see what it produces before you connect anything. This needs no Glean credentials.",
             "kind": "verify-fixture"
           },
           {
-            "title": "Set credentials",
+            "title": "Sign in to Glean",
             "command": "cd customer-360 && npm run login -- --email \"<work-email>\"",
-            "description": "The shipped command discovers the tenant and completes OAuth, with a scoped API token fallback. Set GLEAN_ACCOUNT_NAME in the resulting ignored .env to the account the user supplied. Do not search for a different account.",
+            "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and CHAT scopes.",
             "kind": "authenticate"
           },
           {
-            "title": "Verify",
+            "title": "Choose which customer the page is about",
+            "description": "Signing in does not pick an account for you, so open .env and set GLEAN_ACCOUNT_NAME to one of your own customers, for example Acme Logistics. Spell it the way your Glean documents spell it, because the page searches your content for that exact name and builds the whole page from what it finds.",
+            "kind": "configure"
+          },
+          {
+            "title": "Check it against your own content",
             "command": "cd customer-360 && npm run verify",
-            "description": "Allow 1–3 minutes. It starts its own server, runs the demo queries against the supplied account, and asserts cited answers plus deterministic evidence coverage.",
+            "description": "Takes 1 to 3 minutes. It starts its own server, asks your Glean instance the three demo questions about the account you chose, and fails if any answer comes back without citing a real document.",
             "kind": "verify-live"
           },
           {
-            "title": "Run it",
+            "title": "Open the page",
             "command": "cd customer-360 && npm start",
-            "kind": "run"
+            "kind": "run",
+            "description": "Starts the server and prints a Local URL. Open that URL in your browser."
           }
         ]
       },
@@ -681,10 +691,13 @@
               "id": "email",
               "prompt": "What is your work email? It is used once to discover your Glean tenant."
             },
-            { "id": "account", "prompt": "Which account should the page use?" },
+            {
+              "id": "account",
+              "prompt": "Which of your customers should this page be about? Use the name the way your Glean documents spell it, not your own company or Glean instance name."
+            },
             {
               "id": "agent-id",
-              "prompt": "What is the ID of your Account Brief agent?"
+              "prompt": "What is the ID of your Account Brief agent? It must be a conversational agent, not a form-triggered one."
             }
           ],
           "auth": [
@@ -711,31 +724,44 @@
         },
         "steps": [
           {
-            "title": "Scaffold the project",
+            "title": "Build the Account Brief agent",
+            "description": "In Agent Builder, create a conversational agent that writes an account brief, and copy its ID from the browser URL. It must be conversational, because this page sends it a question and reads the reply. A form-triggered agent will not work here.",
+            "kind": "manual"
+          },
+          {
+            "title": "Copy the project onto your machine",
             "command": "npx -y tiged@2.12.8 --mode=git gleanwork/glean-cookbook/recipes/customer-360/platform-agents customer-360",
-            "kind": "scaffold"
+            "kind": "scaffold",
+            "description": "Creates a customer-360 folder in whatever directory you run this from. Every command after this one runs inside that folder."
           },
           {
             "title": "Install dependencies",
             "command": "cd customer-360 && npm install",
-            "kind": "install"
+            "kind": "install",
+            "description": "Installs the Glean API client and the small local server that serves the page."
           },
           {
-            "title": "Set credentials",
+            "title": "Sign in to Glean",
             "command": "cd customer-360 && npm run login -- --email \"<work-email>\"",
-            "description": "The shipped command discovers the tenant and completes OAuth, with a scoped API token fallback. Set GLEAN_ACCOUNT_NAME and GLEAN_AGENT_ID in the resulting ignored .env from the answers already supplied.",
+            "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and AGENTS scopes.",
             "kind": "authenticate"
           },
           {
-            "title": "Verify",
+            "title": "Choose the customer and point at your agent",
+            "description": "Signing in does not pick an account for you, so open .env and set two values. GLEAN_ACCOUNT_NAME is one of your own customers, for example Acme Logistics, spelled the way your Glean documents spell it. GLEAN_AGENT_ID is the ID of the Account Brief agent you created in Agent Builder.",
+            "kind": "configure"
+          },
+          {
+            "title": "Check it against your own content",
             "command": "cd customer-360 && npm run verify",
-            "description": "Allow 1–3 minutes. It starts its own server and verifies the supplied account and Account Brief agent before the app is left running.",
+            "description": "Takes 1 to 3 minutes. It starts its own server, confirms your agent answers for the account you chose, and fails if the brief comes back without citing a real document.",
             "kind": "verify-live"
           },
           {
-            "title": "Run it",
+            "title": "Open the page",
             "command": "cd customer-360 && npm start",
-            "kind": "run"
+            "kind": "run",
+            "description": "Starts the server and prints a Local URL. Open that URL in your browser."
           }
         ]
       }
@@ -743,7 +769,7 @@
     "steps": [
       {
         "title": "Pick a path",
-        "description": "Path A combines parallel Platform Search tiles with Client Chat synthesis. Path B keeps the same page UX but uses a template Account Brief agent.",
+        "description": "Both paths build the same page from the same content, and each has its own set of steps. Choose Platform Search Chat if you want the page to assemble the account itself, which is the better starting point. Choose Platform Agents if you already run an Account Brief agent and want the page to show what that agent says.",
         "kind": "choose"
       }
     ],
@@ -796,7 +822,7 @@
     "featured": false,
     "tags": ["dual-implementation", "sales", "platform-api"],
     "content": {
-      "problem": "Account executives jump between CRM notes, renewal docs, and security\npackets to prep a single customer conversation. This puts those sources in\none account workspace with evidence coverage, compact source sections, and\nan above-the-fold assistant thread — so the next call needs one tab, not nine.\n\nEverything displayed comes from what your instance already knows about that\naccount. The overview uses only the supplied account name and deterministic\nSearch result counts; assistant claims remain cited rather than turning loose\nsearch matches into unsupported CRM facts.\n\nThis recipe builds the page two ways: Platform Search plus Client Chat for an\nopen-ended dashboard, or Agents `createRun` for a prescriptive QBR-ready brief.",
+      "problem": "Account executives jump between CRM notes, renewal docs, and security\npackets to prep a single customer conversation. This puts those sources in\none account workspace with evidence coverage, compact source sections, and\nan above-the-fold assistant thread — so the next call needs one tab, not nine.\n\nEverything displayed comes from what your instance already knows about that\naccount. The overview shows only the account name you set and counts taken\nstraight from the Search results; assistant claims remain cited rather than\nturning loose search matches into unsupported CRM facts.\n\nThis recipe builds the page two ways: Platform Search plus Client Chat for an\nopen-ended dashboard, or Agents `createRun` for a prescriptive QBR-ready brief.",
       "takeItFurther": [
         "Add a portfolio dashboard across a rep's whole book of business, with health and renewal countdown tiles per account.",
         "Schedule a weekly headless job that re-runs the account's queries, diffs against the last run, and posts only what changed to Slack.",
@@ -1600,7 +1626,7 @@
     },
     "prerequisites": [
       "A Lovable account",
-      "A Glean API token with the CHAT scope. Create it in Admin Console Token Management, then keep it as a Lovable backend secret; every request uses this one token owner's access",
+      "A Glean Client API token with the CHAT scope. Create it in Admin Console → API access → Client API tokens, then keep it as a Lovable backend secret; every request uses this one token owner's access",
       "A private Lovable project — multi-user deployments require authenticated per-user Glean OAuth"
     ],
     "demoQueries": [
@@ -1677,7 +1703,7 @@
     },
     "prerequisites": [
       "A Replit account with Agent access",
-      "A Glean API token with the CHAT scope. Create it in Admin Console Token Management, then keep it in Replit Secrets; every request uses this one token owner's access",
+      "A Glean Client API token with the CHAT scope. Create it in Admin Console → API access → Client API tokens, then keep it in Replit Secrets; every request uses this one token owner's access",
       "A private Repl — multi-user deployments require authenticated per-user Glean OAuth"
     ],
     "demoQueries": [
@@ -1802,7 +1828,7 @@
       }
     ],
     "aiPrompt": "Build an Onboarding Hub following https://developers.glean.com/cookbook/onboarding-hub. Ask whether to use (A) Web SDK or (B) Client Chat, then collect the selected path's configuration before starting it. Path A requires VITE_GLEAN_BACKEND and public/steps.json, uses renderChat and re-mounts with initialMessage to seed a step question, and must be opened by the user in their normal signed-in browser—never by browser automation. Path B calls Client Chat server-side, parses CONTENT messages and citations, retries empty output once, and owns the escalation UI. Keep secrets server-side. Verify cited supported answers on both paths and unsupported-answer escalation only on Client Chat.",
-    "llmContext": "Path A requires an explicit VITE_GLEAN_BACKEND, validated public/steps.json, and the user's existing Glean SSO session. Start Vite, report its exact URL, and wait for the user to open it in their normal signed-in browser; never open or automate it. Seed a step question by re-mounting with initialMessage. Do not pass chatId to continue a thread: it makes the widget treat that chat as selected and look for a message in its own frame URL instead of using initialMessage, so nothing is sent. Each ask starts a fresh thread; renderChat exposes no imperative send. Path B uses server-side Client Chat with saveChat:false, CONTENT messages, fragment citations, one empty-output retry, and an application-owned escalation state.",
+    "llmContext": "Path A requires an explicit VITE_GLEAN_BACKEND, validated public/steps.json, and the user's existing Glean SSO session. Start Vite, report its exact URL, and wait for the user to open it in their normal signed-in browser; never open or automate it. Do not open or drive their browser. Seed a step question by re-mounting with initialMessage. Do not pass chatId to continue a thread: it makes the widget treat that chat as selected and look for a message in its own frame URL instead of using initialMessage, so nothing is sent. Each ask starts a fresh thread; renderChat exposes no imperative send. Path B uses server-side Client Chat with saveChat:false, CONTENT messages, fragment citations, one empty-output retry, and an application-owned escalation state. Signing in does not configure the checklist; Path A uses public/steps.json and Path B uses GLEAN_ONBOARDING_STEPS_FILE.",
     "lastVerified": "2026-08-07",
     "goDependency": false,
     "featured": false,
@@ -1856,19 +1882,26 @@
             "kind": "install"
           },
           {
-            "title": "Configure the backend and checklist",
-            "command": "cd onboarding-hub && npm run configure -- --email \"<work-email>\" && cp public/steps.example.json public/steps.json",
-            "description": "Enter the user's work email when prompted; tenant discovery writes VITE_GLEAN_BACKEND to .env.local. Replace public/steps.json with the onboarding steps the user supplied and keep every id unique.",
+            "title": "Point the app at your Glean instance",
+            "command": "cd onboarding-hub && npm run configure -- --email \"<work-email>\"",
+            "description": "Your email is used once to find which Glean tenant you belong to. The command creates .env.local and fills in VITE_GLEAN_BACKEND. If you would rather skip it, copy .env.example to .env.local and set VITE_GLEAN_BACKEND to the Glean web app URL from the About page, for example https://acme.glean.com.",
+            "kind": "authenticate"
+          },
+          {
+            "title": "Fill in your checklist",
+            "command": "cd onboarding-hub && cp public/steps.example.json public/steps.json",
+            "description": "Copying the example gives you a runnable file. Open public/steps.json and replace the sample steps with your own first-week tasks. Every id must be unique.",
             "kind": "configure"
           },
           {
-            "title": "Run it",
+            "title": "Open the page",
             "command": "cd onboarding-hub && npm run dev",
-            "kind": "run"
+            "kind": "run",
+            "description": "Starts Vite and prints a Local URL. Open that URL in the same browser where you are already signed in to Glean."
           },
           {
-            "title": "Verify",
-            "description": "After the user confirms the app is open in their normal signed-in browser, ask them to confirm the configured checklist renders. Have them click Ask about this and verify a cited first-day answer. Do not open or drive their browser.",
+            "title": "Check it against your own content",
+            "description": "Confirm your checklist renders. Click Ask about this on a first-week step and check that the answer cites one of your documents.",
             "kind": "verify-live"
           }
         ]
@@ -1929,21 +1962,27 @@
             "kind": "verify-fixture"
           },
           {
-            "title": "Set credentials",
+            "title": "Sign in to Glean",
             "command": "cd onboarding-hub && npm run login -- --email \"<work-email>\"",
-            "description": "The shipped command discovers the tenant and completes OAuth, with a CHAT-scoped API token fallback. Configure the supplied onboarding steps in ignored .env or a local steps file. The app runs as the signed-in user; there is no act-as.",
+            "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the CHAT scope.",
             "kind": "authenticate"
           },
           {
-            "title": "Verify",
+            "title": "Point the app at your onboarding steps",
+            "description": "Signing in does not pick a checklist for you. Open .env and keep GLEAN_ONBOARDING_STEPS_FILE pointed at a JSON file of your first-week tasks. The included ./steps.example.json is enough to run the app. Edit that file, or point the variable at one of your own.",
+            "kind": "configure"
+          },
+          {
+            "title": "Check it against your own content",
             "command": "cd onboarding-hub && npm run verify",
-            "description": "Allow 1–3 minutes. It starts its own server and checks the configured onboarding topics for cited answers plus unsupported-question escalation.",
+            "description": "Takes 1 to 3 minutes. It starts its own server, asks your Glean instance about the steps in that file, and fails if a supported question comes back without a citation or if an unsupported question does not escalate.",
             "kind": "verify-live"
           },
           {
-            "title": "Run it",
+            "title": "Open the page",
             "command": "cd onboarding-hub && npm start",
-            "kind": "run"
+            "kind": "run",
+            "description": "Starts the server and prints a Local URL. Open that URL in your browser."
           }
         ]
       }
@@ -2015,7 +2054,6 @@
     "prerequisites": [
       "For configured runs: a Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
       "For configured runs: a work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
-      "For configured runs: X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
       "Node 20+"
     ],
     "demoQueries": [
@@ -2059,19 +2097,31 @@
         "kind": "verify-fixture"
       },
       {
-        "title": "Set credentials",
+        "title": "Sign in to Glean",
         "command": "cd oncall-copilot && npm run login -- --email \"<work-email>\"",
-        "description": "Only for a live run. Use npm run login for direct Search + Chat, or npm run login:agent when the user selected an existing Glean agent. Set WATCHED_SERVICES to the service already supplied and GLEAN_AGENT_ID only for the agent path.",
+        "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and CHAT scopes.",
         "kind": "authenticate"
       },
       {
-        "title": "Run it",
-        "command": "cd oncall-copilot && npm start",
-        "kind": "run"
+        "title": "Name the service this copilot watches",
+        "description": "Signing in does not pick a service for you. Open .env and set WATCHED_SERVICES to the catalog name of the service you named up front. If you watch more than one, use a comma-separated list.",
+        "kind": "configure"
       },
       {
-        "title": "Verify",
-        "description": "Fire the sample alarm and check three things: the probable cause cites a past incident rather than a runbook, approving as someone who is not on call returns 403, and forcing expiry escalates without executing anything.",
+        "title": "Point at an existing Glean agent, if you chose that path",
+        "command": "cd oncall-copilot && npm run login:agent -- --email \"<work-email>\"",
+        "description": "Skip this step if you are using Search and Chat directly. If an existing Glean agent should own the plan, run login:agent so the token also has the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
+        "kind": "configure"
+      },
+      {
+        "title": "Open the page",
+        "command": "cd oncall-copilot && npm start",
+        "kind": "run",
+        "description": "Starts the server and prints a Local URL. Open that URL in your browser."
+      },
+      {
+        "title": "Check it against your own content",
+        "description": "Fire an alarm for the service you named. Check that a probable cause cites a past incident from your own corpus rather than a runbook, that approving as someone who is not on call returns 403, and that forcing expiry escalates without executing anything.",
         "kind": "verify-live"
       }
     ],
@@ -2673,19 +2723,25 @@
         "kind": "verify-fixture"
       },
       {
-        "title": "Set credentials",
+        "title": "Sign in to Glean",
         "command": "cd rfp-responder && npm run login -- --email \"<work-email>\"",
-        "description": "Only for a live run. Use the shipped login flow, then configure the approved source prefixes supplied up front. The app runs as the signed-in user; there is no act-as.",
+        "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the CHAT scope.",
         "kind": "authenticate"
       },
       {
-        "title": "Run it",
-        "command": "cd rfp-responder && npm start",
-        "kind": "run"
+        "title": "Name the sources that may be quoted to a customer",
+        "description": "Signing in does not pick approved evidence for you. Open .env and set RFP_APPROVED_SOURCE_PREFIXES to comma-separated Glean URL prefixes your security team has cleared for customer-facing answers.",
+        "kind": "configure"
       },
       {
-        "title": "Verify",
-        "description": "Load the questionnaire, confirm the column mapping, and draft. Check that a supported question (SOC 2, encryption at rest) returns a cited answer, and that an unsupported one (ISO 27001, RTO/RPO) is left blank and assigned to an SME rather than answered.",
+        "title": "Open the page",
+        "command": "cd rfp-responder && npm start",
+        "kind": "run",
+        "description": "Starts the server and prints a Local URL. Open that URL in your browser."
+      },
+      {
+        "title": "Check it against your own content",
+        "description": "Load a questionnaire your own documents can speak to, confirm the column mapping, and draft. A row your docs cover should come back cited. A row they do not cover should stay blank and route to an SME.",
         "kind": "verify-live"
       }
     ],

--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -2091,9 +2091,9 @@
         "kind": "install"
       },
       {
-        "title": "Watch the governance hold, with no credentials",
+        "title": "See it work before you connect anything",
         "command": "cd oncall-copilot && npm run verify:fixture",
-        "description": "Replays recorded responses and asserts the parts that matter: the gate refuses the wrong actor, expiry escalates without executing, an unregistered action is refused, a mutating action with no supported cause is downgraded, and every attempt is audited.",
+        "description": "Runs the whole flow against recorded responses. It checks that the approval gate refuses the wrong actor, expiry escalates without executing, unregistered actions are refused, and every attempt is audited. This needs no Glean credentials.",
         "kind": "verify-fixture"
       },
       {

--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -2121,7 +2121,8 @@
       },
       {
         "title": "Check it against your own content",
-        "description": "Fire an alarm for the service you named. Check that a probable cause cites a past incident from your own corpus rather than a runbook, that approving as someone who is not on call returns 403, and that forcing expiry escalates without executing anything.",
+        "command": "curl -X POST \"<local-url>/webhook/pagerduty\" -H \"Content-Type: application/json\" -d '{\"id\":\"TEST-1\",\"service\":\"<your-service>\",\"kind\":\"canary\",\"metric\":\"error rate\",\"summary\":\"Error rate rose sharply during rollout\",\"severity\":\"Sev2\",\"firedAt\":\"2026-01-01T00:00:00Z\"}'",
+        "description": "The two buttons on the page fire the bundled payments-service samples, so they get filtered out once WATCHED_SERVICES names your service. Send your own alarm instead. Use the URL the server printed, the same service name you set in .env, and Sev1 or Sev2, because the app ignores Sev3 by default. Then watch the page: the probable cause should cite a past incident from your own corpus rather than a runbook, approving as someone who is not on call should return 403, and forcing expiry should escalate without executing anything.",
         "kind": "verify-live"
       }
     ],

--- a/data/cookbook-registry.json
+++ b/data/cookbook-registry.json
@@ -2025,7 +2025,7 @@
         },
         {
           "id": "orchestrator",
-          "prompt": "Use direct Search + Chat or an existing Glean agent?"
+          "prompt": "Should the Glean-agent planner be enabled as well, or just direct Search + Chat? Both render into the same dashboard."
         },
         { "id": "email", "prompt": "What is your work email?" }
       ],
@@ -2108,9 +2108,9 @@
         "kind": "configure"
       },
       {
-        "title": "Point at an existing Glean agent, if you chose that path",
+        "title": "Optional: let a Glean agent do the planning",
         "command": "cd oncall-copilot && npm run login:agent -- --email \"<work-email>\"",
-        "description": "Skip this step if you are using Search and Chat directly. If an existing Glean agent should own the plan, run login:agent so the token also has the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
+        "description": "The app ships with two planners and a dropdown to switch between them. Search and Chat works with the token you already have. The Glean agent planner stays greyed out until you point the app at an agent. To turn it on, run this command so your token also carries the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
         "kind": "configure"
       },
       {
@@ -2174,7 +2174,7 @@
       }
     ],
     "aiPrompt": "Build the On-call Copilot following the oncall-copilot recipe. Resolve the alarming service from an indexed service catalog, retrieve relevant precedents and runbooks, and classify evidence by role. Only a matching past incident may support a cause; a runbook may support a procedure. Assert no cause when no precedent matches. Gate mutating actions behind authorized human approval, expiry, a closed action registry, evidence support, and a complete audit log. Exercise unauthorized approval, expiry, unregistered action, and no-precedent paths during verification.",
-    "llmContext": "Use Platform Search for retrieval, Client Chat POST /rest/api/v1/chat for synthesis, and Platform Agents for the optional agent path. The app runs as the caller; its approval check is application policy, not impersonation. Resolve owners, on-call engineers, and escalation targets from the reader's service catalog. Only a matching past incident may support a cause; runbooks support procedures, not causes. Mutating actions require a supported cause, an authorized approver, a registered action, an unexpired proposal, and a complete audit trail. Set saveChat:false for verification and treat empty chat output as a retryable failure.",
+    "llmContext": "Use Platform Search for retrieval, Client Chat POST /rest/api/v1/chat for synthesis, and Platform Agents for the optional agent planner. Both planners ship in the same app and render into one dashboard; a dropdown switches between them, and the agent option is disabled unless GLEAN_AGENT_ID is set. This is not a scaffold fork; there is one tiged command. The app runs as the caller; its approval check is application policy, not impersonation. Resolve owners, on-call engineers, and escalation targets from the reader's service catalog. Only a matching past incident may support a cause; runbooks support procedures, not causes. Mutating actions require a supported cause, an authorized approver, a registered action, an unexpired proposal, and a complete audit trail. Set saveChat:false for verification and treat empty chat output as a retryable failure.",
     "goDependency": false,
     "featured": true,
     "tags": [

--- a/docs/cookbook/customer-360.mdx
+++ b/docs/cookbook/customer-360.mdx
@@ -29,9 +29,9 @@ one account workspace with evidence coverage, compact source sections, and
 an above-the-fold assistant thread — so the next call needs one tab, not nine.
 
 Everything displayed comes from what your instance already knows about that
-account. The overview uses only the supplied account name and deterministic
-Search result counts; assistant claims remain cited rather than turning loose
-search matches into unsupported CRM facts.
+account. The overview shows only the account name you set and counts taken
+straight from the Search results; assistant claims remain cited rather than
+turning loose search matches into unsupported CRM facts.
 
 This recipe builds the page two ways: Platform Search plus Client Chat for an
 open-ended dashboard, or Agents `createRun` for a prescriptive QBR-ready brief.

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -2415,8 +2415,8 @@
         },
         {
           "kind": "verify-fixture",
-          "title": "Watch the governance hold, with no credentials",
-          "description": "Replays recorded responses and asserts the parts that matter: the gate refuses the wrong actor, expiry escalates without executing, an unregistered action is refused, a mutating action with no supported cause is downgraded, and every attempt is audited.",
+          "title": "See it work before you connect anything",
+          "description": "Runs the whole flow against recorded responses. It checks that the approval gate refuses the wrong actor, expiry escalates without executing, unregistered actions are refused, and every attempt is audited. This needs no Glean credentials.",
           "command": "cd oncall-copilot && npm run verify:fixture"
         },
         {

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -2432,8 +2432,8 @@
         },
         {
           "kind": "configure",
-          "title": "Point at an existing Glean agent, if you chose that path",
-          "description": "Skip this step if you are using Search and Chat directly. If an existing Glean agent should own the plan, run login:agent so the token also has the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
+          "title": "Optional: let a Glean agent do the planning",
+          "description": "The app ships with two planners and a dropdown to switch between them. Search and Chat works with the token you already have. The Glean agent planner stays greyed out until you point the app at an agent. To turn it on, run this command so your token also carries the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
           "command": "cd oncall-copilot && npm run login:agent -- --email \"<work-email>\""
         },
         {
@@ -2458,7 +2458,7 @@
           },
           {
             "id": "orchestrator",
-            "prompt": "Use direct Search + Chat or an existing Glean agent?",
+            "prompt": "Should the Glean-agent planner be enabled as well, or just direct Search + Chat? Both render into the same dashboard.",
             "required": true
           },
           {
@@ -2567,7 +2567,7 @@
         ]
       },
       "aiPrompt": "Build the On-call Copilot following the oncall-copilot recipe. Resolve the alarming service from an indexed service catalog, retrieve relevant precedents and runbooks, and classify evidence by role. Only a matching past incident may support a cause; a runbook may support a procedure. Assert no cause when no precedent matches. Gate mutating actions behind authorized human approval, expiry, a closed action registry, evidence support, and a complete audit log. Exercise unauthorized approval, expiry, unregistered action, and no-precedent paths during verification.",
-      "llmContext": "Use Platform Search for retrieval, Client Chat POST /rest/api/v1/chat for synthesis, and Platform Agents for the optional agent path. The app runs as the caller; its approval check is application policy, not impersonation. Resolve owners, on-call engineers, and escalation targets from the reader's service catalog. Only a matching past incident may support a cause; runbooks support procedures, not causes. Mutating actions require a supported cause, an authorized approver, a registered action, an unexpired proposal, and a complete audit trail. Set saveChat:false for verification and treat empty chat output as a retryable failure.",
+      "llmContext": "Use Platform Search for retrieval, Client Chat POST /rest/api/v1/chat for synthesis, and Platform Agents for the optional agent planner. Both planners ship in the same app and render into one dashboard; a dropdown switches between them, and the agent option is disabled unless GLEAN_AGENT_ID is set. This is not a scaffold fork; there is one tiged command. The app runs as the caller; its approval check is application policy, not impersonation. Resolve owners, on-call engineers, and escalation targets from the reader's service catalog. Only a matching past incident may support a cause; runbooks support procedures, not causes. Mutating actions require a supported cause, an authorized approver, a registered action, an unexpired proposal, and a complete audit trail. Set saveChat:false for verification and treat empty chat output as a retryable failure.",
       "goDependency": false,
       "featured": true,
       "tags": [

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -2445,7 +2445,8 @@
         {
           "kind": "verify-live",
           "title": "Check it against your own content",
-          "description": "Fire an alarm for the service you named. Check that a probable cause cites a past incident from your own corpus rather than a runbook, that approving as someone who is not on call returns 403, and that forcing expiry escalates without executing anything."
+          "description": "The two buttons on the page fire the bundled payments-service samples, so they get filtered out once WATCHED_SERVICES names your service. Send your own alarm instead. Use the URL the server printed, the same service name you set in .env, and Sev1 or Sev2, because the app ignores Sev3 by default. Then watch the page: the probable cause should cite a past incident from your own corpus rather than a runbook, approving as someone who is not on call should return 403, and forcing expiry should escalate without executing anything.",
+          "command": "curl -X POST \"<local-url>/webhook/pagerduty\" -H \"Content-Type: application/json\" -d '{\"id\":\"TEST-1\",\"service\":\"<your-service>\",\"kind\":\"canary\",\"metric\":\"error rate\",\"summary\":\"Error rate rose sharply during rollout\",\"severity\":\"Sev2\",\"firedAt\":\"2026-01-01T00:00:00Z\"}'"
         }
       ],
       "execution": {

--- a/src/data/recipes.json
+++ b/src/data/recipes.json
@@ -166,7 +166,7 @@
       ],
       "prerequisites": [
         "A Glean instance where you can add a custom datasource",
-        "A Glean-issued Indexing API token, created in Admin Console Token Management (Indexing Tokens)",
+        "A Glean-issued Indexing API token, created in Admin Console → API access → Indexing API tokens",
         "Node.js 18+ to run the portal app locally"
       ],
       "demoQueries": [
@@ -693,11 +693,10 @@
         "typescript"
       ],
       "prerequisites": [
-        "A work email for tenant discovery and OAuth sign-in; a scoped Glean API token is the fallback",
-        "X_GLEAN_INCLUDE_EXPERIMENTAL=true for Platform Search and Agents",
-        "Path B: an Account Brief agent in Agent Builder; set GLEAN_AGENT_ID server-side",
-        "Node 20+",
-        "An account name your own content covers — the page is built around whichever you pick (GLEAN_ACCOUNT_NAME)"
+        "Node 20 or newer",
+        "Your work email, so the sign-in command can find your Glean tenant. If your tenant cannot use OAuth, you need a Glean API token instead, scoped to the path you pick",
+        "The name of one of your own customers, spelled the way it appears in your Glean documents. You put that name in GLEAN_ACCOUNT_NAME, and the page is built around it. This is the customer you are reading about, not your own company or your Glean instance",
+        "Path B only: a conversational Account Brief agent in Agent Builder, whose ID you put in GLEAN_AGENT_ID. A form-triggered agent will not work"
       ],
       "demoQueries": [
         {
@@ -710,7 +709,7 @@
         },
         {
           "query": "What are the renewal risks?",
-          "expectedBehavior": "Either names risks grounded in cited content, or says it has none to report. It must not infer risk the sources don't support, and the account overview must show only the supplied account name and deterministic Search result counts."
+          "expectedBehavior": "Either names risks grounded in cited content, or says it has none to report. It must not infer risk the sources don't support, and the account overview must show only the account name you set plus counts taken straight from the Search results."
         }
       ],
       "codeAssets": [
@@ -728,7 +727,7 @@
               },
               {
                 "id": "account",
-                "prompt": "Which account should the page use?",
+                "prompt": "Which of your customers should this page be about? Use the name the way your Glean documents spell it, not your own company or Glean instance name.",
                 "required": true
               }
             ],
@@ -760,35 +759,43 @@
           "steps": [
             {
               "kind": "scaffold",
-              "title": "Scaffold the project",
+              "title": "Copy the project onto your machine",
+              "description": "Creates a customer-360 folder in whatever directory you run this from. Every command after this one runs inside that folder.",
               "command": "npx -y tiged@2.12.8 --mode=git gleanwork/glean-cookbook/recipes/customer-360/platform-search-chat customer-360"
             },
             {
               "kind": "install",
               "title": "Install dependencies",
+              "description": "Installs the Glean API client and the small local server that serves the page.",
               "command": "cd customer-360 && npm install"
             },
             {
               "kind": "verify-fixture",
-              "title": "Try it with no credentials",
-              "description": "Runs the Globex account tiles and Client Chat path against recorded Sample Corp responses. Overview counts must match the fixture result lengths, and the three demo queries must stay cited.",
+              "title": "See it work before you connect anything",
+              "description": "Runs the whole page against recorded answers for a fictional account named Globex, so you can see what it produces before you connect anything. This needs no Glean credentials.",
               "command": "cd customer-360 && npm run verify:fixture"
             },
             {
               "kind": "authenticate",
-              "title": "Set credentials",
-              "description": "The shipped command discovers the tenant and completes OAuth, with a scoped API token fallback. Set GLEAN_ACCOUNT_NAME in the resulting ignored .env to the account the user supplied. Do not search for a different account.",
+              "title": "Sign in to Glean",
+              "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and CHAT scopes.",
               "command": "cd customer-360 && npm run login -- --email \"<work-email>\""
             },
             {
+              "kind": "configure",
+              "title": "Choose which customer the page is about",
+              "description": "Signing in does not pick an account for you, so open .env and set GLEAN_ACCOUNT_NAME to one of your own customers, for example Acme Logistics. Spell it the way your Glean documents spell it, because the page searches your content for that exact name and builds the whole page from what it finds."
+            },
+            {
               "kind": "verify-live",
-              "title": "Verify",
-              "description": "Allow 1–3 minutes. It starts its own server, runs the demo queries against the supplied account, and asserts cited answers plus deterministic evidence coverage.",
+              "title": "Check it against your own content",
+              "description": "Takes 1 to 3 minutes. It starts its own server, asks your Glean instance the three demo questions about the account you chose, and fails if any answer comes back without citing a real document.",
               "command": "cd customer-360 && npm run verify"
             },
             {
               "kind": "run",
-              "title": "Run it",
+              "title": "Open the page",
+              "description": "Starts the server and prints a Local URL. Open that URL in your browser.",
               "command": "cd customer-360 && npm start"
             }
           ]
@@ -807,12 +814,12 @@
               },
               {
                 "id": "account",
-                "prompt": "Which account should the page use?",
+                "prompt": "Which of your customers should this page be about? Use the name the way your Glean documents spell it, not your own company or Glean instance name.",
                 "required": true
               },
               {
                 "id": "agent-id",
-                "prompt": "What is the ID of your Account Brief agent?",
+                "prompt": "What is the ID of your Account Brief agent? It must be a conversational agent, not a form-triggered one.",
                 "required": true
               }
             ],
@@ -843,30 +850,43 @@
           },
           "steps": [
             {
+              "kind": "manual",
+              "title": "Build the Account Brief agent",
+              "description": "In Agent Builder, create a conversational agent that writes an account brief, and copy its ID from the browser URL. It must be conversational, because this page sends it a question and reads the reply. A form-triggered agent will not work here."
+            },
+            {
               "kind": "scaffold",
-              "title": "Scaffold the project",
+              "title": "Copy the project onto your machine",
+              "description": "Creates a customer-360 folder in whatever directory you run this from. Every command after this one runs inside that folder.",
               "command": "npx -y tiged@2.12.8 --mode=git gleanwork/glean-cookbook/recipes/customer-360/platform-agents customer-360"
             },
             {
               "kind": "install",
               "title": "Install dependencies",
+              "description": "Installs the Glean API client and the small local server that serves the page.",
               "command": "cd customer-360 && npm install"
             },
             {
               "kind": "authenticate",
-              "title": "Set credentials",
-              "description": "The shipped command discovers the tenant and completes OAuth, with a scoped API token fallback. Set GLEAN_ACCOUNT_NAME and GLEAN_AGENT_ID in the resulting ignored .env from the answers already supplied.",
+              "title": "Sign in to Glean",
+              "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and AGENTS scopes.",
               "command": "cd customer-360 && npm run login -- --email \"<work-email>\""
             },
             {
+              "kind": "configure",
+              "title": "Choose the customer and point at your agent",
+              "description": "Signing in does not pick an account for you, so open .env and set two values. GLEAN_ACCOUNT_NAME is one of your own customers, for example Acme Logistics, spelled the way your Glean documents spell it. GLEAN_AGENT_ID is the ID of the Account Brief agent you created in Agent Builder."
+            },
+            {
               "kind": "verify-live",
-              "title": "Verify",
-              "description": "Allow 1–3 minutes. It starts its own server and verifies the supplied account and Account Brief agent before the app is left running.",
+              "title": "Check it against your own content",
+              "description": "Takes 1 to 3 minutes. It starts its own server, confirms your agent answers for the account you chose, and fails if the brief comes back without citing a real document.",
               "command": "cd customer-360 && npm run verify"
             },
             {
               "kind": "run",
-              "title": "Run it",
+              "title": "Open the page",
+              "description": "Starts the server and prints a Local URL. Open that URL in your browser.",
               "command": "cd customer-360 && npm start"
             }
           ]
@@ -877,7 +897,7 @@
         {
           "kind": "choose",
           "title": "Pick a path",
-          "description": "Path A combines parallel Platform Search tiles with Client Chat synthesis. Path B keeps the same page UX but uses a template Account Brief agent."
+          "description": "Both paths build the same page from the same content, and each has its own set of steps. Choose Platform Search Chat if you want the page to assemble the account itself, which is the better starting point. Choose Platform Agents if you already run an Account Brief agent and want the page to show what that agent says."
         }
       ],
       "combines": [
@@ -926,7 +946,7 @@
         }
       ],
       "content": {
-        "problem": "Account executives jump between CRM notes, renewal docs, and security\npackets to prep a single customer conversation. This puts those sources in\none account workspace with evidence coverage, compact source sections, and\nan above-the-fold assistant thread — so the next call needs one tab, not nine.\n\nEverything displayed comes from what your instance already knows about that\naccount. The overview uses only the supplied account name and deterministic\nSearch result counts; assistant claims remain cited rather than turning loose\nsearch matches into unsupported CRM facts.\n\nThis recipe builds the page two ways: Platform Search plus Client Chat for an\nopen-ended dashboard, or Agents `createRun` for a prescriptive QBR-ready brief.",
+        "problem": "Account executives jump between CRM notes, renewal docs, and security\npackets to prep a single customer conversation. This puts those sources in\none account workspace with evidence coverage, compact source sections, and\nan above-the-fold assistant thread — so the next call needs one tab, not nine.\n\nEverything displayed comes from what your instance already knows about that\naccount. The overview shows only the account name you set and counts taken\nstraight from the Search results; assistant claims remain cited rather than\nturning loose search matches into unsupported CRM facts.\n\nThis recipe builds the page two ways: Platform Search plus Client Chat for an\nopen-ended dashboard, or Agents `createRun` for a prescriptive QBR-ready brief.",
         "takeItFurther": [
           "Add a portfolio dashboard across a rep's whole book of business, with health and renewal countdown tiles per account.",
           "Schedule a weekly headless job that re-runs the account's queries, diffs against the last run, and posts only what changed to Slack.",
@@ -1863,7 +1883,7 @@
       "buildMethod": "third-party-build",
       "prerequisites": [
         "A Lovable account",
-        "A Glean API token with the CHAT scope. Create it in Admin Console Token Management, then keep it as a Lovable backend secret; every request uses this one token owner's access",
+        "A Glean Client API token with the CHAT scope. Create it in Admin Console → API access → Client API tokens, then keep it as a Lovable backend secret; every request uses this one token owner's access",
         "A private Lovable project — multi-user deployments require authenticated per-user Glean OAuth"
       ],
       "demoQueries": [
@@ -1957,7 +1977,7 @@
       "buildMethod": "third-party-build",
       "prerequisites": [
         "A Replit account with Agent access",
-        "A Glean API token with the CHAT scope. Create it in Admin Console Token Management, then keep it in Replit Secrets; every request uses this one token owner's access",
+        "A Glean Client API token with the CHAT scope. Create it in Admin Console → API access → Client API tokens, then keep it in Replit Secrets; every request uses this one token owner's access",
         "A private Repl — multi-user deployments require authenticated per-user Glean OAuth"
       ],
       "demoQueries": [
@@ -2134,20 +2154,27 @@
               "command": "cd onboarding-hub && npm install"
             },
             {
+              "kind": "authenticate",
+              "title": "Point the app at your Glean instance",
+              "description": "Your email is used once to find which Glean tenant you belong to. The command creates .env.local and fills in VITE_GLEAN_BACKEND. If you would rather skip it, copy .env.example to .env.local and set VITE_GLEAN_BACKEND to the Glean web app URL from the About page, for example https://acme.glean.com.",
+              "command": "cd onboarding-hub && npm run configure -- --email \"<work-email>\""
+            },
+            {
               "kind": "configure",
-              "title": "Configure the backend and checklist",
-              "description": "Enter the user's work email when prompted; tenant discovery writes VITE_GLEAN_BACKEND to .env.local. Replace public/steps.json with the onboarding steps the user supplied and keep every id unique.",
-              "command": "cd onboarding-hub && npm run configure -- --email \"<work-email>\" && cp public/steps.example.json public/steps.json"
+              "title": "Fill in your checklist",
+              "description": "Copying the example gives you a runnable file. Open public/steps.json and replace the sample steps with your own first-week tasks. Every id must be unique.",
+              "command": "cd onboarding-hub && cp public/steps.example.json public/steps.json"
             },
             {
               "kind": "run",
-              "title": "Run it",
+              "title": "Open the page",
+              "description": "Starts Vite and prints a Local URL. Open that URL in the same browser where you are already signed in to Glean.",
               "command": "cd onboarding-hub && npm run dev"
             },
             {
               "kind": "verify-live",
-              "title": "Verify",
-              "description": "After the user confirms the app is open in their normal signed-in browser, ask them to confirm the configured checklist renders. Have them click Ask about this and verify a cited first-day answer. Do not open or drive their browser."
+              "title": "Check it against your own content",
+              "description": "Confirm your checklist renders. Click Ask about this on a first-week step and check that the answer cites one of your documents."
             }
           ]
         },
@@ -2212,19 +2239,25 @@
             },
             {
               "kind": "authenticate",
-              "title": "Set credentials",
-              "description": "The shipped command discovers the tenant and completes OAuth, with a CHAT-scoped API token fallback. Configure the supplied onboarding steps in ignored .env or a local steps file. The app runs as the signed-in user; there is no act-as.",
+              "title": "Sign in to Glean",
+              "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the CHAT scope.",
               "command": "cd onboarding-hub && npm run login -- --email \"<work-email>\""
             },
             {
+              "kind": "configure",
+              "title": "Point the app at your onboarding steps",
+              "description": "Signing in does not pick a checklist for you. Open .env and keep GLEAN_ONBOARDING_STEPS_FILE pointed at a JSON file of your first-week tasks. The included ./steps.example.json is enough to run the app. Edit that file, or point the variable at one of your own."
+            },
+            {
               "kind": "verify-live",
-              "title": "Verify",
-              "description": "Allow 1–3 minutes. It starts its own server and checks the configured onboarding topics for cited answers plus unsupported-question escalation.",
+              "title": "Check it against your own content",
+              "description": "Takes 1 to 3 minutes. It starts its own server, asks your Glean instance about the steps in that file, and fails if a supported question comes back without a citation or if an unsupported question does not escalate.",
               "command": "cd onboarding-hub && npm run verify"
             },
             {
               "kind": "run",
-              "title": "Run it",
+              "title": "Open the page",
+              "description": "Starts the server and prints a Local URL. Open that URL in your browser.",
               "command": "cd onboarding-hub && npm start"
             }
           ]
@@ -2286,7 +2319,7 @@
         ]
       },
       "aiPrompt": "Build an Onboarding Hub following https://developers.glean.com/cookbook/onboarding-hub. Ask whether to use (A) Web SDK or (B) Client Chat, then collect the selected path's configuration before starting it. Path A requires VITE_GLEAN_BACKEND and public/steps.json, uses renderChat and re-mounts with initialMessage to seed a step question, and must be opened by the user in their normal signed-in browser—never by browser automation. Path B calls Client Chat server-side, parses CONTENT messages and citations, retries empty output once, and owns the escalation UI. Keep secrets server-side. Verify cited supported answers on both paths and unsupported-answer escalation only on Client Chat.",
-      "llmContext": "Path A requires an explicit VITE_GLEAN_BACKEND, validated public/steps.json, and the user's existing Glean SSO session. Start Vite, report its exact URL, and wait for the user to open it in their normal signed-in browser; never open or automate it. Seed a step question by re-mounting with initialMessage. Do not pass chatId to continue a thread: it makes the widget treat that chat as selected and look for a message in its own frame URL instead of using initialMessage, so nothing is sent. Each ask starts a fresh thread; renderChat exposes no imperative send. Path B uses server-side Client Chat with saveChat:false, CONTENT messages, fragment citations, one empty-output retry, and an application-owned escalation state.",
+      "llmContext": "Path A requires an explicit VITE_GLEAN_BACKEND, validated public/steps.json, and the user's existing Glean SSO session. Start Vite, report its exact URL, and wait for the user to open it in their normal signed-in browser; never open or automate it. Do not open or drive their browser. Seed a step question by re-mounting with initialMessage. Do not pass chatId to continue a thread: it makes the widget treat that chat as selected and look for a message in its own frame URL instead of using initialMessage, so nothing is sent. Each ask starts a fresh thread; renderChat exposes no imperative send. Path B uses server-side Client Chat with saveChat:false, CONTENT messages, fragment citations, one empty-output retry, and an application-owned escalation state. Signing in does not configure the checklist; Path A uses public/steps.json and Path B uses GLEAN_ONBOARDING_STEPS_FILE.",
       "lastVerified": "2026-08-07",
       "goDependency": false,
       "featured": false,
@@ -2336,7 +2369,6 @@
       "prerequisites": [
         "For configured runs: a Glean instance with engineering content indexed — a service catalog, runbooks, and at least one past incident review",
         "For configured runs: a work email for tenant discovery and OAuth sign-in; a scoped API token is the fallback",
-        "For configured runs: X_GLEAN_INCLUDE_EXPERIMENTAL=true (the Platform API is Experimental as of its 2026-07 launch)",
         "Node 20+"
       ],
       "demoQueries": [
@@ -2389,19 +2421,31 @@
         },
         {
           "kind": "authenticate",
-          "title": "Set credentials",
-          "description": "Only for a live run. Use npm run login for direct Search + Chat, or npm run login:agent when the user selected an existing Glean agent. Set WATCHED_SERVICES to the service already supplied and GLEAN_AGENT_ID only for the agent path.",
+          "title": "Sign in to Glean",
+          "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the SEARCH and CHAT scopes.",
           "command": "cd oncall-copilot && npm run login -- --email \"<work-email>\""
         },
         {
+          "kind": "configure",
+          "title": "Name the service this copilot watches",
+          "description": "Signing in does not pick a service for you. Open .env and set WATCHED_SERVICES to the catalog name of the service you named up front. If you watch more than one, use a comma-separated list."
+        },
+        {
+          "kind": "configure",
+          "title": "Point at an existing Glean agent, if you chose that path",
+          "description": "Skip this step if you are using Search and Chat directly. If an existing Glean agent should own the plan, run login:agent so the token also has the AGENTS scope, then set GLEAN_AGENT_ID in .env to that agent's ID.",
+          "command": "cd oncall-copilot && npm run login:agent -- --email \"<work-email>\""
+        },
+        {
           "kind": "run",
-          "title": "Run it",
+          "title": "Open the page",
+          "description": "Starts the server and prints a Local URL. Open that URL in your browser.",
           "command": "cd oncall-copilot && npm start"
         },
         {
           "kind": "verify-live",
-          "title": "Verify",
-          "description": "Fire the sample alarm and check three things: the probable cause cites a past incident rather than a runbook, approving as someone who is not on call returns 403, and forcing expiry escalates without executing anything."
+          "title": "Check it against your own content",
+          "description": "Fire an alarm for the service you named. Check that a probable cause cites a past incident from your own corpus rather than a runbook, that approving as someone who is not on call returns 403, and that forcing expiry escalates without executing anything."
         }
       ],
       "execution": {
@@ -3094,19 +3138,25 @@
         },
         {
           "kind": "authenticate",
-          "title": "Set credentials",
-          "description": "Only for a live run. Use the shipped login flow, then configure the approved source prefixes supplied up front. The app runs as the signed-in user; there is no act-as.",
+          "title": "Sign in to Glean",
+          "description": "Your email is used once to find which Glean tenant you belong to, then a browser window opens for you to approve access. The command creates the .env file for you and fills in GLEAN_SERVER_URL and GLEAN_API_TOKEN. If your tenant has not enabled OAuth, skip this command and do it by hand instead: copy .env.example to .env, then fill in your Glean instance URL and a Glean API token that has the CHAT scope.",
           "command": "cd rfp-responder && npm run login -- --email \"<work-email>\""
         },
         {
+          "kind": "configure",
+          "title": "Name the sources that may be quoted to a customer",
+          "description": "Signing in does not pick approved evidence for you. Open .env and set RFP_APPROVED_SOURCE_PREFIXES to comma-separated Glean URL prefixes your security team has cleared for customer-facing answers."
+        },
+        {
           "kind": "run",
-          "title": "Run it",
+          "title": "Open the page",
+          "description": "Starts the server and prints a Local URL. Open that URL in your browser.",
           "command": "cd rfp-responder && npm start"
         },
         {
           "kind": "verify-live",
-          "title": "Verify",
-          "description": "Load the questionnaire, confirm the column mapping, and draft. Check that a supported question (SOC 2, encryption at rest) returns a cited answer, and that an unsupported one (ISO 27001, RTO/RPO) is left blank and assigned to an SME rather than answered."
+          "title": "Check it against your own content",
+          "description": "Load a questionnaire your own documents can speak to, confirm the column mapping, and draft. A row your docs cover should come back cited. A row they do not cover should stay blank and route to an SME."
         }
       ],
       "execution": {


### PR DESCRIPTION
## Summary

Cookbook setup copy now lives on a stack of three recipe PRs, plus Customer 360 which already merged. This snapshot pulls that registry so the published pages match.

Merge after [glean-cookbook#50](https://github.com/gleanwork/glean-cookbook/pull/50), [#51](https://github.com/gleanwork/glean-cookbook/pull/51), and [#52](https://github.com/gleanwork/glean-cookbook/pull/52) land. The generated files here were synced from the tip of that stack (`cfreeman/oncall-copilot-c360-copy`). After those merge, a sync from cookbook `main` should be a no-op.

## Test plan

- [ ] Cookbook #50–#52 merged
- [ ] `pnpm recipes:compile`
- [ ] `pnpm exec vitest run src/components/Cookbook/Cookbook.test.tsx`
- [ ] `FF_COOKBOOKS=true pnpm build`
- [ ] Onboarding Hub, RFP responder, and On-call Copilot pages show Sign in separate from remaining env, with no agent-voice steps