### PR TITLE
PACT-547: Unify Gemini and A2A documentation

### DIFF
--- a/docs/guides/mcp/supported-hosts.mdx
+++ b/docs/guides/mcp/supported-hosts.mdx
@@ -6,10 +6,46 @@ hide_table_of_contents: false
 
 import { McpHostsList } from '@theme/McpHosts';
 
-Glean works with a range of MCP host applications, including IDEs, CLIs, desktop apps, and web apps. Filter by configuration ownership (user-configurable vs. organization-managed) or by client type, or search by name. Each card shows who configures the connection, supported transports and authentication, and the matching setup action.
+Glean works with a range of MCP host applications, including IDEs, CLIs, desktop apps, and web apps. Filter by configuration ownership (user-configurable vs. organization-managed) or by client type, or search by name. Each card shows who configures the connection, supported transports and authentication, and the matching setup action. The host icon and **Glean documentation** link open Glean guidance first. When a host guide is not available, they open the general Remote MCP Server guide. The vendor documentation link provides the host's own setup details.
 
 <McpHostsList />
 
 :::info
 This list comes from `@gleanwork/mcp-config-schema`, the published host catalog. Glean also works with **any MCP-spec-compliant client**. In the MCP Configurator, choose **Custom** and connect using your Glean MCP server URL.
 :::
+
+## Use Glean with Gemini Enterprise
+
+Gemini Enterprise supports two different ways to connect to Glean. Choose the path that matches what you want Gemini to use:
+
+<CardGroup cols={2}>
+  <Card
+    title="Glean MCP server"
+    icon="mcp"
+    iconSet="glean"
+    href="https://docs.glean.com/administration/platform/embedded-integrations/glean-in-gemini-chat/"
+  >
+    Connect Glean's search and knowledge tools to Gemini Enterprise through a custom MCP server data connector. Gemini authenticates each user through OAuth, and Glean applies that user's permissions to every result.
+  </Card>
+  <Card
+    title="Glean A2A server"
+    icon="Share2"
+    href="https://docs.glean.com/administration/platform/a2a-server"
+  >
+    Connect Glean Assistant to Gemini Enterprise as a remote agent through the Agent2Agent protocol. Gemini sends questions to Glean Assistant instead of calling individual Glean tools.
+  </Card>
+</CardGroup>
+
+### Connect Glean Assistant to Gemini with A2A
+
+An administrator can connect Glean Assistant to Gemini Enterprise through the Glean A2A server:
+
+1. Enable the A2A server in **Admin console → Platform → A2A server**.
+2. Copy the deployment's agent card URL from the A2A Server admin page. The URL ends with `/.well-known/agent-card.json`.
+3. In Gemini Enterprise, register Glean Assistant as a remote agent using the agent card URL.
+4. Complete the Glean OAuth flow when prompted. Each user authorizes the connection individually.
+5. Ask a question in Gemini and confirm that Glean Assistant responds.
+
+Every request runs as the signed-in Glean user, so Glean Assistant respects that user's document permissions and access to Glean Assistant. For the complete administrator setup, see [Configure the Glean A2A server](https://docs.glean.com/administration/platform/configure-a2a).
+
+MCP and A2A serve different purposes. The Glean MCP server exposes tools that Gemini can call, while the Glean A2A server exposes Glean Assistant as a remote agent. The A2A server is not another MCP host.

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.module.css
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.module.css
@@ -76,6 +76,13 @@
   color: var(--ifm-color-emphasis-600);
 }
 
+.iconLink {
+  display: inline-flex;
+  width: 100%;
+  height: 100%;
+  color: inherit;
+}
+
 .cardPills {
   display: flex;
   flex-wrap: wrap;

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.test.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.test.tsx
@@ -59,6 +59,15 @@ vi.mock('@gleanwork/mcp-config-schema/browser', async (importOriginal) => {
             supportedAuth: ['oauth:dcr'] as const,
           },
           {
+            id: 'gemini-enterprise',
+            displayName: 'Gemini Enterprise',
+            types: ['web'] as const,
+            userConfigurable: false,
+            documentationUrl: 'https://example.test/gemini-enterprise',
+            transports: ['http'] as const,
+            supportedAuth: [] as const,
+          },
+          {
             id: 'fixture-empty',
             displayName: 'Fixture Empty',
             types: ['web'] as const,
@@ -160,6 +169,33 @@ describe('McpHostsList', () => {
     ).toHaveAttribute('href', 'https://example.test/fixture-ide');
   });
 
+  it('links supported hosts to Glean documentation before vendor documentation', async () => {
+    render(<McpHostsList />);
+    await searchFor('Gemini Enterprise');
+
+    expect(
+      screen.getByRole('link', {
+        name: 'Open Gemini Enterprise Glean documentation',
+      }),
+    ).toHaveAttribute(
+      'href',
+      'https://docs.glean.com/administration/platform/embedded-integrations/glean-in-gemini-chat/',
+    );
+    expect(
+      screen.getByRole('link', {
+        name: 'Read Gemini Enterprise Glean documentation',
+      }),
+    ).toHaveAttribute(
+      'href',
+      'https://docs.glean.com/administration/platform/embedded-integrations/glean-in-gemini-chat/',
+    );
+    expect(
+      screen.getByRole('link', {
+        name: 'Read Gemini Enterprise vendor documentation',
+      }),
+    ).toHaveAttribute('href', 'https://example.test/gemini-enterprise');
+  });
+
   it('routes managed hosts with a setup URL to the host admin destination', async () => {
     const { container } = render(<McpHostsList />);
     await searchFor('ChatGPT');
@@ -221,6 +257,11 @@ describe('McpHostsList', () => {
         name: 'Open MCP Configurator for Fixture IDE',
       }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {
+        name: 'Read Fixture IDE Glean documentation',
+      }),
+    ).toHaveAttribute('href', 'https://docs.glean.com/guides/mcp/mcp');
     expect(
       screen.getByRole('link', {
         name: 'Read Fixture IDE vendor documentation',

--- a/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
+++ b/packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.tsx
@@ -21,6 +21,7 @@ interface McpHost {
   types: readonly ClientType[];
   userConfigurable: boolean;
   documentationUrl?: string;
+  gleanDocumentationUrl?: string;
   managedSetupUrl?: string;
   transports: readonly Transport[];
   supportedAuth: readonly SupportedAuth[];
@@ -38,6 +39,8 @@ const EXTRA_HOSTS: McpHost[] = [
     userConfigurable: false,
     documentationUrl:
       'https://learn.microsoft.com/en-us/microsoft-copilot-studio/mcp-add-existing-server-to-agent',
+    gleanDocumentationUrl:
+      'https://docs.glean.com/administration/platform/mcp/host-guides/copilot-studio',
     transports: ['http'],
     supportedAuth: ['token', 'oauth:dcr'],
   },
@@ -45,6 +48,22 @@ const EXTRA_HOSTS: McpHost[] = [
 
 const ORGANIZATION_GUIDANCE_URL =
   'https://docs.glean.com/administration/platform/mcp/about';
+const GLEAN_MCP_GUIDANCE_URL = 'https://docs.glean.com/guides/mcp/mcp';
+
+// Prefer Glean's host guides when they cover the connection. The registry's
+// documentationUrl remains available as the vendor documentation link.
+const GLEAN_DOCUMENTATION_URLS = {
+  chatgpt:
+    'https://docs.glean.com/administration/platform/mcp/host-guides/chatgpt',
+  'claude-desktop':
+    'https://docs.glean.com/administration/platform/mcp/host-guides/claude-desktop',
+  'copilot-studio':
+    'https://docs.glean.com/administration/platform/mcp/host-guides/copilot-studio',
+  'gemini-enterprise':
+    'https://docs.glean.com/administration/platform/embedded-integrations/glean-in-gemini-chat/',
+  librechat:
+    'https://docs.glean.com/administration/platform/mcp/host-guides/librechat',
+} as const;
 
 // Matches GLEAN_REGISTRY_OPTIONS.managedSetupUrls in @gleanwork/mcp-config-glean.
 const GLEAN_MANAGED_SETUP_URLS = {
@@ -64,6 +83,8 @@ function buildHosts(): McpHost[] {
     types: c.types,
     userConfigurable: c.userConfigurable,
     documentationUrl: c.documentationUrl,
+    gleanDocumentationUrl:
+      GLEAN_DOCUMENTATION_URLS[c.id] ?? GLEAN_MCP_GUIDANCE_URL,
     managedSetupUrl: registry.getManagedSetupUrl(c.id),
     transports: c.transports,
     supportedAuth: c.supportedAuth,
@@ -232,7 +253,19 @@ export default function McpHostsList({
               key={host.id}
               title={host.displayName}
               color="var(--ifm-font-color-base)"
-              icon={<McpHostIcon clientId={host.id} alt={host.displayName} />}
+              icon={
+                host.gleanDocumentationUrl ? (
+                  <Link
+                    className={styles.iconLink}
+                    to={host.gleanDocumentationUrl}
+                    aria-label={`Open ${host.displayName} Glean documentation`}
+                  >
+                    <McpHostIcon clientId={host.id} alt={host.displayName} />
+                  </Link>
+                ) : (
+                  <McpHostIcon clientId={host.id} alt={host.displayName} />
+                )
+              }
             >
               <span className={styles.cardPills}>
                 {host.types.map((t) => (
@@ -293,6 +326,15 @@ export default function McpHostsList({
                     aria-label={`Organization setup guidance for ${host.displayName}`}
                   >
                     Organization setup guidance
+                  </Link>
+                )}
+                {host.gleanDocumentationUrl && (
+                  <Link
+                    className="button button--sm button--secondary"
+                    to={host.gleanDocumentationUrl}
+                    aria-label={`Read ${host.displayName} Glean documentation`}
+                  >
+                    Glean documentation
                   </Link>
                 )}
                 {host.documentationUrl ? (


### PR DESCRIPTION
## Summary

- Add Gemini Enterprise MCP guidance to the Supported MCP Hosts page.
- Document how to connect Glean Assistant to Gemini Enterprise through A2A and distinguish that flow from MCP.
- Link host icons and host cards to Glean documentation first, with vendor documentation as a secondary link.
- Add component coverage for Gemini and the internal documentation link precedence.

## Linear issue

PACT-547

## Validation

- `pnpm exec vitest run packages/docusaurus-theme-glean/src/theme/McpHosts/McpHostsList.test.tsx packages/docusaurus-theme-glean/src/theme/McpHosts/mcp-config-schema-compat.test.ts`
- `pnpm build`
- `git diff --check`

`pnpm test` ran 29 test files. It reported 27 passing files and one unrelated timeout in `scripts/sync-api-sidebar.test.ts`; 243 tests passed and the MCP host tests passed.

## Notes

No Harshi pull request exists for this issue. This change is based on the PACT-547 Linear requirements and the existing MCP and A2A documentation.