### PR TITLE
PACT-460: Map FF_COOKBOOKS to the cookbook feature flag

### DIFF
--- a/src/utils/buildTimeFlags.test.ts
+++ b/src/utils/buildTimeFlags.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalCookbooks = process.env.FF_COOKBOOKS;
+
+afterEach(() => {
+  if (originalCookbooks === undefined) {
+    delete process.env.FF_COOKBOOKS;
+  } else {
+    process.env.FF_COOKBOOKS = originalCookbooks;
+  }
+  vi.resetModules();
+});
+
+describe('getBuildTimeFlags', () => {
+  it('maps the documented FF_COOKBOOKS variable to the cookbook flag', async () => {
+    process.env.FF_COOKBOOKS = 'true';
+    vi.resetModules();
+
+    const { getBuildTimeFlags } = await import('./buildTimeFlags');
+
+    expect(getBuildTimeFlags()).toMatchObject({
+      cookbook: { enabled: true },
+    });
+    expect(getBuildTimeFlags()).not.toHaveProperty('cookbooks');
+  });
+});

--- a/src/utils/buildTimeFlags.ts
+++ b/src/utils/buildTimeFlags.ts
@@ -19,6 +19,10 @@ export function getBuildTimeFlags(): FeatureFlagsMap {
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith('FF_')) continue;
     // converts FF_FOO_BAZ_BAR to foo-baz-bar
+    // AGENTS.md documents FF_COOKBOOKS=true, but the sidebar and homepage
+    // gate on `cookbook` (the /cookbook route and plugin name). The generic
+    // slugger would emit `cookbooks` and the documented preview command
+    // would silently do nothing. Alias until PACT-461 removes the flag.
     const slug =
       key === 'FF_COOKBOOKS'
         ? 'cookbook'

--- a/src/utils/buildTimeFlags.ts
+++ b/src/utils/buildTimeFlags.ts
@@ -19,7 +19,10 @@ export function getBuildTimeFlags(): FeatureFlagsMap {
   for (const [key, value] of Object.entries(process.env)) {
     if (!key.startsWith('FF_')) continue;
     // converts FF_FOO_BAZ_BAR to foo-baz-bar
-    const slug = key.replace(/^FF_/, '').toLowerCase().replace(/_/g, '-');
+    const slug =
+      key === 'FF_COOKBOOKS'
+        ? 'cookbook'
+        : key.replace(/^FF_/, '').toLowerCase().replace(/_/g, '-');
     flags[slug] = { enabled: value === 'true' };
   }
 


### PR DESCRIPTION
Fixes [PACT-460](https://linear.app/gleanwork/issue/PACT-460/site-s1-cookbook-section-launch-readiness-ff-cookbooks).

## The documented way to preview the Cookbooks section did nothing

`AGENTS.md` tells you to build with `FF_COOKBOOKS=true` to see the Cookbooks nav and homepage band. That has never worked. The build-time loader derives a flag id from the env var by stripping `FF_`, lowercasing, and hyphenating, which yields `cookbooks`. Both gates ask for the singular `cookbook`: the sidebar Cookbook category and the homepage band. So the flag was set, nothing read it, and the build came out identical to an unflagged one with no warning.

That is also why the PACT-460 checklist item to review nav and homepage with the flag on could not be satisfied: flag on and flag off produced the same site.

## Outcome for a reviewer checking this out

`FF_COOKBOOKS=true pnpm build` now renders the sidebar Cookbook category and the homepage Cookbooks strip. `FF_COOKBOOKS=false` now genuinely disables them instead of writing a key nobody reads.

Nothing changes for anyone who does not set that variable. The flag stays off by default, so this is not a production behavior change, and it does not unflag the section. The `FEATURE_FLAGS_JSON` and Edge Config paths already used `cookbook` and are untouched.

## Why an alias rather than a rename

The route, the plugin name, and both gates are singular `cookbook`. The env var is the only plural spelling, so renaming the docs to `FF_COOKBOOK` would be the tidier long-term fix and would keep the slugger free of special cases. The flag is removed entirely at launch under PACT-461, so I kept the documented command working instead of renaming a variable with days left to live. If you would rather have the generic path stay clean, say so and I will flip the docs and the AGENTS instructions instead.

## Test plan
- [x] `pnpm vitest run src/utils/buildTimeFlags.test.ts` covers the alias and asserts no `cookbooks` key is produced
- [x] `pnpm test` (244 passed, 2 skipped)
- [x] `FF_COOKBOOKS=true pnpm build`, then confirmed the built HTML contains the homepage strip and the `/cookbook` sidebar route
- [x] Flagged preview spot-checked in light and dark mode on the index and a recipe page
