### PR TITLE
chore(changelog): 2026-08-23

### DIFF
--- a/changelog/entries/2026-08-21-api-client-go-0-14-0.md
+++ b/changelog/entries/2026-08-21-api-client-go-0-14-0.md
@@ -1,0 +1,23 @@
+---
+title: 'api-client-go v0.14.0'
+categories: ['API Clients']
+---
+
+Api-client-go v0.14.0 includes 4 additions, 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.ChatRequest.Messages[].Citations[].SourceSkill` to `client.chat.create()`.
+- Added `response.Messages[].Citations[].SourceSkill` to `client.chat.create()`.
+- Added `response.ChatResult.Chat.Messages[].Citations[].SourceSkill` to `client.chat.retrieve()`.
+- Added `request.ChatRequest.Messages[].Citations[].SourceSkill` to `client.chat.createstream()`.
+- Changed `request.Request.Input.union(Array<PlatformChatInputMessage>)[].Role` on `chat.create()`.
+- Changed `response` on `chat.create()`.
+- Changed `request.FeedRequest.Categories[]` on `client.search.retrievefeed()`.
+- Changed `response.Results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.14.0)

--- a/changelog/entries/2026-08-21-api-client-java-0-16-0.md
+++ b/changelog/entries/2026-08-21-api-client-java-0-16-0.md
@@ -1,0 +1,23 @@
+---
+title: 'api-client-java v0.16.0'
+categories: ['API Clients']
+---
+
+Api-client-java v0.16.0 includes 4 additions, 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.chatRequest.messages[].citations[].sourceSkill` to `client.chat.create()`.
+- Added `response.messages[].citations[].sourceSkill` to `client.chat.create()`.
+- Added `response.chatResult.chat.messages[].citations[].sourceSkill` to `client.chat.retrieve()`.
+- Added `request.chatRequest.messages[].citations[].sourceSkill` to `client.chat.createstream()`.
+- Changed `request.input.union(Array<PlatformChatInputMessage>)[].role` on `chat.create()`.
+- Changed `response` on `chat.create()`.
+- Changed `request.feedRequest.categories[]` on `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.16.0)

--- a/changelog/entries/2026-08-21-api-client-python-0-16-0.md
+++ b/changelog/entries/2026-08-21-api-client-python-0-16-0.md
@@ -1,0 +1,23 @@
+---
+title: 'api-client-python v0.16.0'
+categories: ['API Clients']
+---
+
+Api-client-python v0.16.0 includes 4 additions, 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.messages[].citations[].source_skill` to `client.chat.create()`.
+- Added `response.messages[].citations[].source_skill` to `client.chat.create()`.
+- Added `response.chat_result.chat.messages[].citations[].source_skill` to `client.chat.retrieve()`.
+- Added `request.messages[].citations[].source_skill` to `client.chat.create_stream()`.
+- Changed `request.input.union(Array<PlatformChatInputMessage>)[].role` on `chat.create()`.
+- Changed `response` on `chat.create()`.
+- Changed `request.categories[]` on `client.search.retrieve_feed()`.
+- Changed `response.results[]` on `client.search.retrieve_feed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.16.0)

--- a/changelog/entries/2026-08-21-api-client-typescript-0-19-0.md
+++ b/changelog/entries/2026-08-21-api-client-typescript-0-19-0.md
@@ -1,0 +1,23 @@
+---
+title: 'api-client-typescript v0.19.0'
+categories: ['API Clients']
+---
+
+Api-client-typescript v0.19.0 includes 4 additions, 4 changes.
+
+{/* truncate */}
+
+## Changes
+
+- Added `request.chatRequest.messages[].citations[].sourceSkill` to `client.chat.create()`.
+- Added `response.messages[].citations[].sourceSkill` to `client.chat.create()`.
+- Added `response.chatResult.chat.messages[].citations[].sourceSkill` to `client.chat.retrieve()`.
+- Added `request.chatRequest.messages[].citations[].sourceSkill` to `client.chat.createstream()`.
+- Changed `request.input.union(Array<PlatformChatInputMessage>)[].role` on `chat.create()`.
+- Changed `response` on `chat.create()`.
+- Changed `request.feedRequest.categories[]` on `client.search.retrievefeed()`.
+- Changed `response.results[]` on `client.search.retrievefeed()`.
+
+## Source
+
+- [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.19.0)


### PR DESCRIPTION
Adds 4 changelog entries generated on 2026-08-23.

## Generated entries

| Repo/source | Tag/date | Parser | Entry | Source links |
| --- | --- | --- | --- | --- |
| api-client-java | v0.16.0 | speakeasy | `changelog/entries/2026-08-21-api-client-java-0-16-0.md` | [Release notes](https://github.com/gleanwork/api-client-java/releases/tag/v0.16.0) |
| api-client-python | v0.16.0 | speakeasy | `changelog/entries/2026-08-21-api-client-python-0-16-0.md` | [Release notes](https://github.com/gleanwork/api-client-python/releases/tag/v0.16.0) |
| api-client-typescript | v0.19.0 | speakeasy | `changelog/entries/2026-08-21-api-client-typescript-0-19-0.md` | [Release notes](https://github.com/gleanwork/api-client-typescript/releases/tag/v0.19.0) |
| api-client-go | v0.14.0 | speakeasy | `changelog/entries/2026-08-21-api-client-go-0-14-0.md` | [Release notes](https://github.com/gleanwork/api-client-go/releases/tag/v0.14.0) |

## Reviewer checklist

- Confirm generated entries use the normalized changelog format.
- Confirm deleted or skipped releases are no-op entries or older than the latest local entry.
- Confirm parser warnings and errors are actionable.
- Confirm source links point to the upstream release, PR, or commit.

## Skipped

| Repo/tag | Reason | Classification |
| --- | --- | --- |
| glean-agent-toolkit | no newer release than latest entry | older than latest entry |
| mcp-server | no newer release than latest entry | older than latest entry |
| mcp-config | no newer release than latest entry | older than latest entry |
| configure-mcp-server | no newer release than latest entry | older than latest entry |
| glean-indexing-sdk | no newer release than latest entry | older than latest entry |
| langchain-glean | no newer release than latest entry | older than latest entry |
| open-api | no new open-api commits | skip |