### PR TITLE
docs(cursor): add install-first plugin guide behind flag

### DIFF
--- a/docs/guides/mcp/cursor.mdx
+++ b/docs/guides/mcp/cursor.mdx
@@ -4,30 +4,95 @@ description: Install the official Glean plugin for Cursor — enterprise search 
 ---
 
 import PluginPage from '@site/src/components/PluginPage';
+import FeatureFlag from '@site/src/components/FeatureFlag';
 
-<PluginPage
-  name="Cursor"
-  tagline="You use Cursor. Glean brings the enterprise context."
-  clientId="cursor"
-  mono
-  steps={[
-    {
-      type: 'cta',
-      label: 'Set up the Glean MCP Server',
-      description: 'The plugin requires a Glean MCP connection. Use the Glean configurator to connect Cursor to your organization\'s Glean instance. Authentication uses Glean\'s OAuth server where enabled, or a Glean API token as a fallback.',
-      ctaText: 'Open MCP Configurator',
-      ctaHref: 'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=cursor',
-    },
-    {
-      type: 'list',
-      label: 'Install the Glean Plugin',
-      description: 'Find and install the Glean plugin directly from Cursor Settings.',
-      image: '/img/cursor-plugin-install.png',
-      items: [
-        'Open Cursor Settings → Marketplace',
-        'Search for "Glean"',
-        'Click Add to Cursor',
-      ],
-    },
-  ]}
-/>
+{/* Install instructions synced from https://github.com/gleanwork/cursor-plugins/blob/main/README.md */}
+
+{/* New page is gated behind `cursor-plugin-v2`. The current page is preserved as
+    the fallback and renders whenever the flag is turned off. */}
+
+<FeatureFlag
+  flag="cursor-plugin-v2"
+  fallback={
+    <PluginPage
+      name="Cursor"
+      tagline="You use Cursor. Glean brings the enterprise context."
+      clientId="cursor"
+      mono
+      steps={[
+        {
+          type: 'cta',
+          label: 'Set up the Glean MCP Server',
+          description:
+            "The plugin requires a Glean MCP connection. Use the Glean configurator to connect Cursor to your organization's Glean instance. Authentication uses Glean's OAuth server where enabled, or a Glean API token as a fallback.",
+          ctaText: 'Open MCP Configurator',
+          ctaHref:
+            'https://app.glean.com/settings/install?mcpConfigure=true&mcpHost=cursor',
+        },
+        {
+          type: 'list',
+          label: 'Install the Glean Plugin',
+          description: 'Find and install the Glean plugin directly from Cursor Settings.',
+          image: '/img/cursor-plugin-install.png',
+          items: [
+            'Open Cursor Settings → Marketplace',
+            'Search for "Glean"',
+            'Click Add to Cursor',
+          ],
+        },
+      ]}
+    />
+  }
+>
+  <PluginPage
+    name="Cursor"
+    tagline="You use Cursor. Glean brings the enterprise context."
+    clientId="cursor"
+    mono
+    whatsIncluded={
+      <>
+        The Glean plugin turns Cursor into a front door to your company:
+        Glean&rsquo;s expert skills — search, code exploration, people, meetings,
+        onboarding, productivity — the custom skills your team authors in Glean,
+        and every tool configured centrally in Glean, each paired with skills
+        tuned to use it well. Those tools are surfaced with Glean&rsquo;s security
+        and permission guardrails fully enforced, all running through a Glean
+        MCP server so it works right in your editor.{' '}
+        <a
+          href="https://github.com/gleanwork/cursor-plugins/blob/main/README.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          See everything included in the plugin →
+        </a>
+      </>
+    }
+    steps={[
+      {
+        type: 'list',
+        label: 'Install the Glean Plugin',
+        description: 'Find and install the Glean plugin directly from Cursor Settings.',
+        image: '/img/cursor-plugin-install.png',
+        items: [
+          'Open Cursor Settings → Marketplace',
+          'Search for "Glean"',
+          'Click Add to Cursor',
+        ],
+      },
+      {
+        type: 'list',
+        label: 'Setup the Glean MCP connection',
+        description:
+          "Connect the plugin to your Glean instance through Glean's OAuth sign-in. You only need to do this once per machine.",
+        items: [
+          <>
+            In Cursor, prompt: <code>Set up Glean for me</code>
+          </>,
+          'Enter your work email when prompted.',
+          'Complete Glean OAuth in the browser window that opens and approve access.',
+          'Back in Cursor, confirm Glean tools are available — you now have every skill and tool provisioned for you in Glean, right in your editor. Search company knowledge, take action across your connected apps, and move through real work faster without leaving your development workflow.',
+        ],
+      },
+    ]}
+  />
+</FeatureFlag>


### PR DESCRIPTION
## Summary

Updates `/guides/mcp/cursor` with an install-first experience for the Glean Cursor plugin behind the existing `cursor-plugin-v2` feature flag.

The new page is off when the flag is absent. The current Cursor page is preserved as the fallback and remains visible until the feature is enabled through the existing runtime flag configuration.

### New page

- **What's included** — explains that the plugin brings Glean's expert skills, custom skills authored by teams in Glean, and centrally configured Glean tools with security and permission guardrails enforced.
- Links to the [`cursor-plugins` README](https://github.com/gleanwork/cursor-plugins/blob/main/README.md) for more detail about the plugin contents.
- **Installation** — install Glean from Cursor Settings → Marketplace.
- **Setup the Glean MCP connection** — prompt Cursor with `Set up Glean for me`, enter a work email, complete browser OAuth, and confirm the Glean tools are available.
- Removes the new-page dependency on the MCP Configurator or manually copied remote MCP server details. The existing configurator flow remains available in the fallback page.

## Flag rollout

No new flag infrastructure is introduced. `cursor-plugin-v2` follows the existing behavior: missing flags are off, and the page can be enabled through the existing `feature-flags` item in the `glean-developer-feature-flags` Edge Config:

```json
{
  "cursor-plugin-v2": {
    "enabled": true
  }
}
```

For local or preview testing, use:

```text
/guides/mcp/cursor?ff_cursor-plugin-v2=true
```

To force the fallback page:

```text
/guides/mcp/cursor?ff_cursor-plugin-v2=false
```

## Implementation

- `docs/guides/mcp/cursor.mdx` — new Cursor page plus preserved fallback.
- Existing `PluginPage` support is used for the What's included content.
- No generated API Reference content or feature-flag infrastructure was modified.

## Validation

- `pnpm prettier --check .` ✅
- `pnpm test` ✅ — 227 passed, 2 skipped
- `pnpm build:nocache` ✅ — fallback page renders when the flag is absent
- `FF_CURSOR_PLUGIN_V2=true pnpm build:nocache` ✅ — new page renders
- Signed commit authored by Eshwar Sundar ✅
