### PR TITLE
Guide users through API URL setup

### DIFF
--- a/docs/api-info/client/getting-started/overview.mdx
+++ b/docs/api-info/client/getting-started/overview.mdx
@@ -10,13 +10,23 @@ import TenantProfileControl from '@site/src/components/TenantProfile';
 
 Make a permission-aware search request with the Client API. This is the shortest path from a credential to a successful response; use the [Client API overview](/api/client-api) to choose other capabilities.
 
-<TenantProfileControl />
-
 ## Before you begin
 
-1. Identify your Glean API URL.
-2. Configure OAuth or a user-scoped Glean-issued token with the [Client API authentication guide](/api-info/client/authentication/overview).
-3. Have a query that should return content the authenticated user can access.
+<Steps>
+  <Step title="Find your API URL">
+    <TenantProfileControl />
+
+    If automatic discovery is unavailable, ask a Glean admin for the complete **Server instance (QE)** value. Glean admins can copy it from the [About Glean page](https://app.glean.com/admin/about-glean).
+  </Step>
+
+  <Step title="Configure authentication">
+    Configure OAuth or a user-scoped Glean-issued token with the [Client API authentication guide](/api-info/client/authentication/overview).
+  </Step>
+
+  <Step title="Choose a test query">
+    Use a query that should return content the authenticated user can access.
+  </Step>
+</Steps>
 
 ## Make your first request
 

--- a/docs/api-info/indexing/getting-started/overview.mdx
+++ b/docs/api-info/indexing/getting-started/overview.mdx
@@ -10,13 +10,23 @@ import TenantProfileControl from '@site/src/components/TenantProfile';
 
 Create a datasource and index one document. This is the shortest end-to-end path to making custom content available to Glean; use the [Indexing API overview](/api/indexing-api) to explore other content types and workflows.
 
-<TenantProfileControl />
-
 ## Before you begin
 
-1. Identify your Glean API URL.
-2. Create an Indexing API token by following the [Indexing API authentication guide](/api-info/indexing/authentication/overview).
-3. Choose a stable datasource name and a URL pattern that matches the documents you plan to index.
+<Steps>
+  <Step title="Find your API URL">
+    <TenantProfileControl />
+
+    If automatic discovery is unavailable, ask a Glean admin for the complete **Server instance (QE)** value. Glean admins can copy it from the [About Glean page](https://app.glean.com/admin/about-glean).
+  </Step>
+
+  <Step title="Create an API token">
+    Create an Indexing API token by following the [Indexing API authentication guide](/api-info/indexing/authentication/overview).
+  </Step>
+
+  <Step title="Plan your datasource">
+    Choose a stable datasource name and a URL pattern that matches the documents you plan to index.
+  </Step>
+</Steps>
 
 ## 1. Create a datasource
 

--- a/docs/api-info/platform/getting-started/overview.mdx
+++ b/docs/api-info/platform/getting-started/overview.mdx
@@ -11,13 +11,23 @@ import TenantProfileControl from '@site/src/components/TenantProfile';
 
 The Platform API is Glean's recommended API for new application integrations when the capability and stability level fit the use case. It provides modern endpoints under the `/api` path. Review the applicable stability notices before adopting a capability or endpoint.
 
-<TenantProfileControl />
-
 ## Before you begin
 
-1. Review the [Platform API authentication guide](/api/platform-api/authentication).
-2. Confirm or identify your Glean API URL and choose the credentials for your integration.
-3. Start with the capability that matches your application: [Search](/api/platform-api/search-overview), [Agents](/api/platform-api/agents-overview), [Skills](/api/platform-api/skills-overview), or [Chat](/api/platform-api/chat-overview).
+<Steps>
+  <Step title="Find your API URL">
+    <TenantProfileControl />
+
+    If automatic discovery is unavailable, ask a Glean admin for the complete **Server instance (QE)** value. Glean admins can copy it from the [About Glean page](https://app.glean.com/admin/about-glean).
+  </Step>
+
+  <Step title="Configure authentication">
+    Review the [Platform API authentication guide](/api/platform-api/authentication) and choose the credentials for your integration.
+  </Step>
+
+  <Step title="Choose a capability">
+    Start with the capability that matches your application: [Search](/api/platform-api/search-overview), [Agents](/api/platform-api/agents-overview), [Skills](/api/platform-api/skills-overview), or [Chat](/api/platform-api/chat-overview).
+  </Step>
+</Steps>
 
 ## Choose Platform API over Client API
 

--- a/docs/get-started/authentication.mdx
+++ b/docs/get-started/authentication.mdx
@@ -15,11 +15,9 @@ Glean's three REST API families use different authentication models. Start by ch
 
 All Glean API requests require your organization's **server URL**. That is the complete backend origin, for example `https://acme-be.glean.com`. It is not the hostname you use for the Glean web app, which is often `app.glean.com`.
 
-Copy the **Server instance (QE)** value from the [Glean About page](https://app.glean.com/admin/about-glean). Use the entire value, including `https://`.
-
-If you cannot open the About page, ask a Glean admin for that field. The **instance name** is only the slug inside a Glean-hosted URL (`acme` in `https://acme-be.glean.com`). Most API clients and the API Explorer want the full server URL.
-
 <TenantProfileControl />
+
+If automatic discovery is unavailable, ask a Glean admin for the complete **Server instance (QE)** value, including `https://`. Glean admins can copy it from the [About Glean page](https://app.glean.com/admin/about-glean). The **instance name** is only the slug inside a Glean-hosted URL (`acme` in `https://acme-be.glean.com`); most API clients and the API Explorer require the full server URL.
 
 The same API URL is used for each API family:
 


### PR DESCRIPTION
## Summary

- embed tenant URL discovery in the first guided step of each API Quickstart
- remove redundant API URL prerequisites from the Platform, Client, and Indexing flows
- make the About Glean page an explicit admin-only fallback instead of the default discovery path

## Validation

- `pnpm test` (269 passed, 2 skipped)
- `pnpm format:check`
- `pnpm snippets:check`
- `pnpm sidebar:check`
- `pnpm build`
- `FF_TENANT_API_PERSONALIZATION=true pnpm build`