### PR TITLE
Fix API Explorer tenant URL persistence

### DIFF
--- a/scripts/openapi-server-url.mjs
+++ b/scripts/openapi-server-url.mjs
@@ -3,11 +3,10 @@
 /**
  * Rewrite an OpenAPI spec's `servers` to a single fully-variable server URL.
  *
- * The upstream specs template the Glean-hosted shape
- * (https://{instance}-be.glean.com), but customers may also run non-Glean
- * hosted deployments — the SDKs take a full `serverUrl` for the same reason.
+ * The upstream specs template a Glean-hosted hostname shape, but a tenant's
+ * server URL is an opaque HTTPS origin and may use a vanity or custom domain.
  * A wholly-variable server URL makes the API Explorer's base-URL field a
- * free-form input that accepts either shape.
+ * free-form input without implying a particular deployment hostname.
  *
  * Usage: node openapi-server-url.mjs spec.yaml [output.yaml]
  */
@@ -28,18 +27,14 @@ spec.servers = [
   {
     url: '{serverUrl}',
     description:
-      'Replace the placeholder with your Glean API server URL. Copy the ' +
-      'complete Server instance (QE) value from ' +
-      'https://app.glean.com/admin/about-glean. Glean-hosted deployments use ' +
-      'https://{instance}-be.glean.com. How to find it: ' +
-      'https://developers.glean.com/get-started/authentication#finding-your-server-url',
+      'Replace {serverUrl} with your complete Glean API server URL. Find it at ' +
+      'https://developers.glean.com/get-started/authentication#finding-your-server-url.',
     variables: {
       serverUrl: {
-        default: 'https://{instance-name}-be.glean.com',
+        default: '{serverUrl}',
         description:
-          'Your Glean API server URL. Glean-hosted deployments use ' +
-          'https://{instance}-be.glean.com. Custom domains are also valid. ' +
-          'Find it at app.glean.com/admin/about-glean.',
+          'Your complete Glean API HTTPS origin. Glean-hosted, vanity, custom, ' +
+          'and non-Glean-hosted domains are supported.',
       },
     },
   },

--- a/src/components/TenantProfile/TenantProfile.test.tsx
+++ b/src/components/TenantProfile/TenantProfile.test.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { tenantProfileStore } from '@site/src/lib/tenantProfile';
 import { FeatureFlagsContext } from '@site/src/theme/Root';
 import TenantProfileControl from './index';
 
-function renderTenantProfile(enabled = true) {
+function renderTenantProfile(
+  enabled = true,
+  outerSubmit?: React.FormEventHandler<HTMLFormElement>,
+) {
+  const control = <TenantProfileControl />;
   return render(
     <FeatureFlagsContext.Provider
       value={
@@ -17,7 +21,7 @@ function renderTenantProfile(enabled = true) {
         } as React.ContextType<typeof FeatureFlagsContext>
       }
     >
-      <TenantProfileControl />
+      {outerSubmit ? <form onSubmit={outerSubmit}>{control}</form> : control}
     </FeatureFlagsContext.Provider>,
   );
 }
@@ -58,6 +62,23 @@ describe('TenantProfileControl', () => {
       kind: 'configured',
       profile: { apiUrl: 'https://knowledge.example.org', source: 'manual' },
     });
+  });
+
+  it('does not submit the API Explorer request form when saving a manual URL', async () => {
+    const outerSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) =>
+      event.preventDefault(),
+    );
+    const user = userEvent.setup();
+    renderTenantProfile(true, outerSubmit);
+
+    await user.click(screen.getByText('Enter URL manually'));
+    await user.type(
+      screen.getByLabelText('Glean API URL'),
+      'https://knowledge.example.org',
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(outerSubmit).not.toHaveBeenCalled();
   });
 
   it('shows privacy guidance before email discovery', async () => {

--- a/src/components/TenantProfile/index.tsx
+++ b/src/components/TenantProfile/index.tsx
@@ -51,14 +51,22 @@ function TenantProfileControlContent({
     }
   }, [onConfigured, state]);
 
-  const discover = async (event: React.FormEvent) => {
-    event.preventDefault();
+  const discover = async () => {
     await tenantProfileStore.discover(email);
   };
 
-  const saveManual = (event: React.FormEvent) => {
-    event.preventDefault();
+  const saveManual = () => {
     tenantProfileStore.setManualApiUrl(manualUrl);
+  };
+
+  const submitOnEnter = (
+    event: React.KeyboardEvent<HTMLInputElement>,
+    submit: () => void | Promise<void>,
+  ) => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    event.stopPropagation();
+    void submit();
   };
 
   const copy = async () => {
@@ -159,7 +167,7 @@ function TenantProfileControlContent({
       ) : null}
 
       {mode === 'discover' ? (
-        <form className={styles.form} onSubmit={discover}>
+        <div className={styles.form}>
           <label htmlFor={emailId}>Work email</label>
           <div className={styles.inputRow}>
             <input
@@ -168,6 +176,7 @@ function TenantProfileControlContent({
               disabled={state.kind === 'resolving'}
               id={emailId}
               onChange={(event) => setEmail(event.target.value)}
+              onKeyDown={(event) => submitOnEnter(event, discover)}
               placeholder="you@company.com"
               type="email"
               value={email}
@@ -175,7 +184,8 @@ function TenantProfileControlContent({
             <button
               className={styles.primaryButton}
               disabled={state.kind === 'resolving'}
-              type="submit"
+              onClick={discover}
+              type="button"
             >
               {state.kind === 'resolving' ? 'Finding…' : 'Find API URL'}
             </button>
@@ -191,21 +201,26 @@ function TenantProfileControlContent({
           >
             Enter the URL manually instead
           </button>
-        </form>
+        </div>
       ) : null}
 
       {mode === 'manual' ? (
-        <form className={styles.form} onSubmit={saveManual}>
+        <div className={styles.form}>
           <label htmlFor={manualId}>Glean API URL</label>
           <div className={styles.inputRow}>
             <input
               id={manualId}
               onChange={(event) => setManualUrl(event.target.value)}
+              onKeyDown={(event) => submitOnEnter(event, saveManual)}
               placeholder="https://company-be.glean.com"
               type="url"
               value={manualUrl}
             />
-            <button className={styles.primaryButton} type="submit">
+            <button
+              className={styles.primaryButton}
+              onClick={saveManual}
+              type="button"
+            >
               Save
             </button>
           </div>
@@ -221,7 +236,7 @@ function TenantProfileControlContent({
           >
             Find it from my work email instead
           </button>
-        </form>
+        </div>
       ) : null}
 
       {state.kind === 'error' ? (

--- a/src/lib/tenantProfile.test.ts
+++ b/src/lib/tenantProfile.test.ts
@@ -278,15 +278,44 @@ describe('tenant profile persistence', () => {
     });
   });
 
-  it('does not migrate a placeholder OpenAPI server value', () => {
+  it.each([
+    'https://instance-name-be.glean.com',
+    'https://{instance-name}-be.glean.com',
+  ])('does not migrate the placeholder OpenAPI server value %s', (apiUrl) => {
     const storage = new MemoryStorage();
     storage.setItem(
       OPENAPI_SERVER_STORAGE_KEY,
       JSON.stringify({
         url: '{serverUrl}',
         variables: {
+          serverUrl: { default: apiUrl },
+        },
+      }),
+    );
+    const store = createTenantProfileStore({ storage });
+
+    expect(store.getSnapshot()).toEqual({ kind: 'unconfigured' });
+    expect(storage.getItem(TENANT_PROFILE_STORAGE_KEY)).toBeNull();
+  });
+
+  it('ignores a persisted profile created from a placeholder server', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(
+      TENANT_PROFILE_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        apiUrl: 'https://{instance-name}-be.glean.com',
+        source: 'manual',
+        updatedAt: 55,
+      }),
+    );
+    storage.setItem(
+      OPENAPI_SERVER_STORAGE_KEY,
+      JSON.stringify({
+        url: '{serverUrl}',
+        variables: {
           serverUrl: {
-            default: 'https://instance-name-be.glean.com',
+            default: 'https://{instance-name}-be.glean.com',
           },
         },
       }),
@@ -404,6 +433,7 @@ describe('OpenAPI server personalization', () => {
 describe('API URL placeholder personalization', () => {
   it('replaces approved origins while preserving paths and unrelated URLs', () => {
     const source = [
+      'curl https://{instance-name}-be.glean.com/api/agents',
       'curl https://instance-name-be.glean.com/api/search',
       'curl https://<instance>-be.glean.com/rest/api/v1/search',
       'docs https://example.com/instance-name-be.glean.com',
@@ -413,6 +443,7 @@ describe('API URL placeholder personalization', () => {
       personalizeApiUrlPlaceholders(source, 'https://custom.example.org'),
     ).toBe(
       [
+        'curl https://custom.example.org/api/agents',
         'curl https://custom.example.org/api/search',
         'curl https://custom.example.org/rest/api/v1/search',
         'docs https://example.com/instance-name-be.glean.com',
@@ -450,8 +481,12 @@ describe('API URL placeholder personalization', () => {
     ).toBe(false);
   });
 
-  it('leaves placeholders intact when no profile is configured', () => {
-    const source = 'https://instance-name-be.glean.com/api/search';
-    expect(personalizeApiUrlPlaceholders(source, undefined)).toBe(source);
+  it('standardizes placeholders when no profile is configured', () => {
+    expect(
+      personalizeApiUrlPlaceholders(
+        'https://{instance-name}-be.glean.com/api/search',
+        undefined,
+      ),
+    ).toBe('{serverUrl}/api/search');
   });
 });

--- a/src/lib/tenantProfile.ts
+++ b/src/lib/tenantProfile.ts
@@ -122,6 +122,14 @@ function sameOrigin(left: unknown, right: unknown): boolean {
   }
 }
 
+function isPlaceholderApiUrl(apiUrl: string): boolean {
+  return (
+    apiUrl.includes(PLACEHOLDER_HOST) ||
+    apiUrl.includes('{') ||
+    apiUrl.includes('}')
+  );
+}
+
 function parsePersistedProfile(raw: string | null): TenantProfile | null {
   if (!raw) return null;
   try {
@@ -131,6 +139,7 @@ function parsePersistedProfile(raw: string | null): TenantProfile | null {
     if (
       value.version !== 1 ||
       !apiUrl ||
+      isPlaceholderApiUrl(apiUrl) ||
       (value.source !== 'discovered' && value.source !== 'manual') ||
       typeof value.updatedAt !== 'number'
     ) {
@@ -196,7 +205,7 @@ function readLegacyOpenApiServer(storage: Storage): string | null {
     if (!raw) return null;
     const server = JSON.parse(raw);
     const apiUrl = resolveOpenApiServerUrl(server);
-    return apiUrl && !apiUrl.includes(PLACEHOLDER_HOST) ? apiUrl : null;
+    return apiUrl && !isPlaceholderApiUrl(apiUrl) ? apiUrl : null;
   } catch {
     return null;
   }
@@ -538,6 +547,8 @@ export function useTenantProfile(): TenantProfileState {
 }
 
 export const API_URL_PLACEHOLDERS = [
+  '{serverUrl}',
+  'https://{instance-name}-be.glean.com',
   'https://instance-name-be.glean.com',
   'https://<instance>-be.glean.com',
   'https://your-instance-be.glean.com',
@@ -551,9 +562,9 @@ export function personalizeApiUrlPlaceholders(
   source: string,
   apiUrl: string | undefined,
 ): string {
-  if (!apiUrl) return source;
+  const replacement = apiUrl ?? API_URL_PLACEHOLDERS[0];
   return API_URL_PLACEHOLDERS.reduce(
-    (result, placeholder) => result.replaceAll(placeholder, apiUrl),
+    (result, placeholder) => result.replaceAll(placeholder, replacement),
     source,
   );
 }


### PR DESCRIPTION
## Summary

- prevent tenant URL controls from submitting the API Explorer request form
- reject both legacy and braced instance placeholders during migration and persisted-profile loading
- standardize the unconfigured API URL placeholder on `{serverUrl}` without assuming `-be.glean.com`
- preserve complete vanity, custom, and non-Glean-hosted HTTPS origins unchanged
- update the OpenAPI server transform so future regeneration emits the same full-URL placeholder

## Root cause

`TenantProfileControl` rendered nested forms inside the API Explorer request form. Saving a URL bubbled into the outer form and navigated the page, resetting Explorer state. Separately, legacy migration rejected `instance-name-be.glean.com` but accepted and persisted `{instance-name}-be.glean.com` as if it were a real tenant URL.

## Validation

- production failure reproduced before the fix
- focused regression tests failed before and pass after the fix
- `pnpm test` (272 passed, 2 skipped)
- `pnpm format:check`
- `pnpm snippets:check`
- `pnpm sidebar:check`
- `pnpm build`
- `FF_TENANT_API_PERSONALIZATION=true pnpm build`
- built-site browser verification: clear URL → `{serverUrl}`; save full vanity origin → endpoint, sample, and request URL update without navigation