### PR TITLE
Refine API Explorer base URL display

### DIFF
--- a/src/components/TenantProfile/TenantProfile.test.tsx
+++ b/src/components/TenantProfile/TenantProfile.test.tsx
@@ -9,8 +9,9 @@ import TenantProfileControl from './index';
 function renderTenantProfile(
   enabled = true,
   outerSubmit?: React.FormEventHandler<HTMLFormElement>,
+  compact = false,
 ) {
-  const control = <TenantProfileControl />;
+  const control = <TenantProfileControl compact={compact} />;
   return render(
     <FeatureFlagsContext.Provider
       value={
@@ -64,12 +65,29 @@ describe('TenantProfileControl', () => {
     });
   });
 
+  it('uses a status label instead of repeating the API URL heading in compact mode', async () => {
+    const user = userEvent.setup();
+    renderTenantProfile(true, undefined, true);
+
+    await user.click(screen.getByText('Enter URL manually'));
+    await user.type(
+      screen.getByLabelText('Glean API URL'),
+      'https://knowledge.example.org',
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Configured')).toBeInTheDocument();
+    expect(screen.getByLabelText('API URL')).toHaveValue(
+      'https://knowledge.example.org',
+    );
+  });
+
   it('does not submit the API Explorer request form when saving a manual URL', async () => {
     const outerSubmit = vi.fn((event: React.FormEvent<HTMLFormElement>) =>
       event.preventDefault(),
     );
     const user = userEvent.setup();
-    renderTenantProfile(true, outerSubmit);
+    renderTenantProfile(true, outerSubmit, true);
 
     await user.click(screen.getByText('Enter URL manually'));
     await user.type(

--- a/src/components/TenantProfile/index.tsx
+++ b/src/components/TenantProfile/index.tsx
@@ -86,7 +86,7 @@ function TenantProfileControlContent({
         <div className={styles.configuredField}>
           <label className={styles.configuredLabel} htmlFor={configuredUrlId}>
             <span className={styles.statusDot} aria-hidden="true" />
-            API URL
+            {compact ? 'Configured' : 'API URL'}
             {state.kind === 'configured' &&
             state.persistence === 'memory-only' ? (
               <span className={styles.persistenceWarning}>
@@ -95,7 +95,13 @@ function TenantProfileControlContent({
             ) : null}
           </label>
           <div className={styles.copyField}>
-            <input id={configuredUrlId} readOnly type="url" value={apiUrl} />
+            <input
+              aria-label="API URL"
+              id={configuredUrlId}
+              readOnly
+              type="url"
+              value={apiUrl}
+            />
             <button
               aria-label={copied ? 'API URL copied' : 'Copy API URL'}
               className={styles.copyButton}

--- a/src/theme/ApiExplorer/Server/index.tsx
+++ b/src/theme/ApiExplorer/Server/index.tsx
@@ -95,14 +95,7 @@ function PersonalizedServer({
 
   if (options.length === 0) return null;
 
-  return (
-    <div className="openapi-explorer__server-container">
-      <TenantProfileControl compact />
-      <small className="openapi-explorer__server-description">
-        Request URL: {apiUrl ?? effectiveServerUrl ?? DEFAULT_API_URL}
-      </small>
-    </div>
-  );
+  return <TenantProfileControl compact />;
 }
 
 export default function Server(


### PR DESCRIPTION
## Summary

- replace the redundant compact `API URL` label with the truthful status `Configured`
- retain `API URL` as the read-only field accessible name
- remove the duplicate `Request URL` line, which displayed only the server origin rather than the complete operation URL
- add regression coverage for the compact Explorer label

The full tenant-profile control outside the Explorer continues to use `API URL`.

## Validation

- `pnpm test` (273 passed, 2 skipped)
- `pnpm format:check`
- `pnpm snippets:check`
- `pnpm sidebar:check`
- `pnpm build`
- `FF_TENANT_API_PERSONALIZATION=true pnpm build`
- rendered-page verification with tenant personalization enabled