### PR TITLE
Request all OAuth scopes in API Explorer

### DIFF
--- a/src/components/ApiOAuth/oauth.test.ts
+++ b/src/components/ApiOAuth/oauth.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  allSupportedScopes,
   isOAuthEligiblePath,
   isPlaceholderServerUrl,
-  scopeForPath,
+  signInWithGlean,
 } from './oauth';
+
+const response = (body: unknown) => ({
+  ok: true,
+  json: vi.fn().mockResolvedValue(body),
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe('API Explorer OAuth helpers', () => {
   it('offers OAuth on Client and Platform API pages, not Indexing', () => {
@@ -15,28 +27,74 @@ describe('API Explorer OAuth helpers', () => {
     expect(isOAuthEligiblePath('/libraries/web-sdk/overview')).toBe(false);
   });
 
-  it('maps docs paths to their API scope', () => {
-    expect(scopeForPath('/api/client-api/search/search')).toBe('search');
-    expect(scopeForPath('/api/client-api/chat/chat')).toBe('chat');
-    expect(scopeForPath('/api/client-api/agents/run-agent')).toBe('agents');
-    expect(scopeForPath('/api/client-api/governance/x')).toBe(
-      'data_governance',
-    );
-    expect(scopeForPath('/api/client-api/authentication/createauthtoken')).toBe(
-      'auth_token_creator',
-    );
-    expect(scopeForPath('/api/platform-api/platform-agents-create-run')).toBe(
-      'agents',
-    );
-    expect(scopeForPath('/api/platform-api/platform-search')).toBe('search');
-    expect(scopeForPath('/api/platform-api/platform-skills-list')).toBe(
-      'skills',
+  it('requests every scope advertised by the authorization server', () => {
+    expect(allSupportedScopes(['openid', 'search', 'chat', 'agents'])).toBe(
+      'openid search chat agents',
     );
   });
 
-  it('returns undefined for unmapped groups so no scope is requested', () => {
-    expect(scopeForPath('/api/client-api/messages/list')).toBeUndefined();
-    expect(scopeForPath('/api/indexing-api/index-document')).toBeUndefined();
+  it('fails rather than silently requesting an under-scoped token', () => {
+    expect(() => allSupportedScopes(undefined)).toThrow(
+      'This server does not advertise any supported OAuth scopes.',
+    );
+    expect(() => allSupportedScopes([])).toThrow(
+      'This server does not advertise any supported OAuth scopes.',
+    );
+  });
+
+  it('registers and authorizes with every advertised scope', async () => {
+    const scopes = ['openid', 'search', 'chat', 'agents'];
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        response({
+          issuer: 'https://example-be.glean.com',
+          authorization_endpoint:
+            'https://example-be.glean.com/oauth/authorize',
+          token_endpoint: 'https://example-be.glean.com/oauth/token',
+          registration_endpoint: 'https://example-be.glean.com/oauth/register',
+          scopes_supported: scopes,
+        }),
+      )
+      .mockResolvedValueOnce(response({ client_id: 'explorer-client' }))
+      .mockResolvedValueOnce(response({ access_token: 'access-token' }));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('crypto', {
+      getRandomValues: (bytes: Uint8Array) => bytes.fill(1),
+      subtle: {
+        digest: async () => new Uint8Array(32).fill(2).buffer,
+      },
+    });
+    Object.defineProperty(window.location, 'origin', {
+      configurable: true,
+      value: 'https://developers.glean.com',
+    });
+    const popup = { closed: false } as Window;
+    const open = vi.spyOn(window, 'open').mockReturnValue(popup);
+
+    const tokenPromise = signInWithGlean('https://example-be.glean.com');
+
+    await vi.waitFor(() => expect(open).toHaveBeenCalledOnce());
+    const requestedScope = scopes.join(' ');
+    const registration = JSON.parse(
+      `${fetchMock.mock.calls[1][1]?.body}`,
+    ) as Record<string, unknown>;
+    expect(registration.scope).toBe(requestedScope);
+
+    const authorizationUrl = new URL(`${open.mock.calls[0][0]}`);
+    expect(authorizationUrl.searchParams.get('scope')).toBe(requestedScope);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: {
+          type: 'glean-oauth-callback',
+          code: 'authorization-code',
+          state: authorizationUrl.searchParams.get('state'),
+        },
+        origin: window.location.origin,
+      }),
+    );
+
+    await expect(tokenPromise).resolves.toBe('access-token');
   });
 
   it('treats the explorer default host as a placeholder, including braces', () => {

--- a/src/components/ApiOAuth/oauth.ts
+++ b/src/components/ApiOAuth/oauth.ts
@@ -20,39 +20,21 @@ interface ServerMetadata {
   scopes_supported?: string[];
 }
 
-/** Map a client-api docs path segment to its OAuth scope. */
-const PATH_SCOPES: Record<string, string> = {
-  activity: 'activity',
-  agents: 'agents',
-  announcements: 'announcements',
-  answers: 'answers',
-  authentication: 'auth_token_creator',
-  chat: 'chat',
-  collections: 'collections',
-  documents: 'documents',
-  entities: 'entities',
-  governance: 'data_governance',
-  insights: 'insights',
-  pins: 'pins',
-  search: 'search',
-  shortcuts: 'shortcuts',
-  skills: 'skills',
-  summarize: 'summarize',
-  tools: 'tools',
-  verification: 'verification',
-};
+interface CachedClient {
+  clientId: string;
+  scope: string;
+}
 
-/** Scope for the API group being viewed, from the docs path. */
-export function scopeForPath(pathname: string): string | undefined {
-  const client = pathname.match(/\/api\/client-api\/([^/]+)/);
-  if (client) {
-    return PATH_SCOPES[client[1]];
+/** Format every scope advertised by the authorization server for an OAuth
+ * authorization request. The API Explorer intentionally requests the complete
+ * set so one sign-in can be reused while exploring different endpoints. */
+export function allSupportedScopes(scopes: string[] | undefined): string {
+  if (!scopes?.length) {
+    throw new Error(
+      'This server does not advertise any supported OAuth scopes.',
+    );
   }
-  const platform = pathname.match(/\/api\/platform-api\/platform-([a-z]+)/);
-  if (platform) {
-    return PATH_SCOPES[platform[1]];
-  }
-  return undefined;
+  return scopes.join(' ');
 }
 
 /** OAuth tokens work on the Client and Platform APIs; the Indexing API
@@ -97,16 +79,20 @@ async function discover(serverUrl: string): Promise<ServerMetadata> {
   return res.json();
 }
 
-/** Register (or reuse) a public client for this issuer via DCR. */
-async function getClientId(metadata: ServerMetadata): Promise<string> {
-  let cache: Record<string, string> = {};
+/** Register (or reuse) a public client for this issuer and scope set via DCR. */
+async function getClientId(
+  metadata: ServerMetadata,
+  scope: string,
+): Promise<string> {
+  let cache: Record<string, CachedClient> = {};
   try {
     cache = JSON.parse(localStorage.getItem(CLIENT_ID_STORE) ?? '{}');
   } catch {
     // Corrupt cache; re-register.
   }
-  if (cache[metadata.issuer]) {
-    return cache[metadata.issuer];
+  const cachedClient = cache[metadata.issuer];
+  if (cachedClient?.scope === scope) {
+    return cachedClient.clientId;
   }
   if (!metadata.registration_endpoint) {
     throw new Error(
@@ -122,13 +108,14 @@ async function getClientId(metadata: ServerMetadata): Promise<string> {
       grant_types: ['authorization_code'],
       response_types: ['code'],
       token_endpoint_auth_method: 'none',
+      scope,
     }),
   });
   if (!res.ok) {
     throw new Error(`Client registration failed (HTTP ${res.status}).`);
   }
   const { client_id: clientId } = await res.json();
-  cache[metadata.issuer] = clientId;
+  cache[metadata.issuer] = { clientId, scope };
   localStorage.setItem(CLIENT_ID_STORE, JSON.stringify(cache));
   return clientId;
 }
@@ -224,12 +211,10 @@ async function exchangeCode(
 }
 
 /** Full flow: discovery → DCR → PKCE popup → token. */
-export async function signInWithGlean(
-  serverUrl: string,
-  scope: string | undefined,
-): Promise<string> {
+export async function signInWithGlean(serverUrl: string): Promise<string> {
   const metadata = await discover(serverUrl);
-  const clientId = await getClientId(metadata);
+  const scope = allSupportedScopes(metadata.scopes_supported);
+  const clientId = await getClientId(metadata, scope);
   const { verifier, challenge } = await pkcePair();
   const code = await authorizeInPopup(metadata, clientId, challenge, scope);
   return exchangeCode(metadata, clientId, code, verifier);

--- a/src/theme/ApiExplorer/Authorization/index.tsx
+++ b/src/theme/ApiExplorer/Authorization/index.tsx
@@ -14,7 +14,6 @@ import { setAuthData } from '@theme/ApiExplorer/Authorization/slice';
 import {
   isOAuthEligiblePath,
   isPlaceholderServerUrl,
-  scopeForPath,
   signInWithGlean,
 } from '@site/src/components/ApiOAuth/oauth';
 import { useTenantApiPersonalizationEnabled } from '@site/src/lib/tenantPersonalizationFlag';
@@ -91,7 +90,7 @@ function GleanSignIn(): React.ReactElement | null {
     }
     setStatus({ kind: 'busy' });
     try {
-      const token = await signInWithGlean(serverUrl, scopeForPath(pathname));
+      const token = await signInWithGlean(serverUrl);
       const liveServerUrl = resolveOpenApiServerUrl(serverRef.current);
       if (!mountedRef.current || liveServerUrl !== serverUrl) {
         throw new Error(


### PR DESCRIPTION
## Summary

- request every scope advertised by the instance OAuth discovery metadata
- include the complete scope set in dynamic client registration and re-register when that set changes
- remove endpoint-specific scope selection so one sign-in works across API Explorer endpoints
- add coverage for registration and authorization scope parameters

## Testing

- `pnpm test` (290 passed, 2 skipped)
- `pnpm build`
- Prettier check for changed files
