### PR TITLE
docs(indexing-sdk): verify GA examples from source

### DIFF
--- a/docs/libraries/indexing-sdk/cli.mdx
+++ b/docs/libraries/indexing-sdk/cli.mdx
@@ -7,11 +7,12 @@ The SDK ships one command, `glean-idx`. It covers the whole loop: checking your
 credentials, validating a plan, running a connector, inspecting what it
 uploaded, and deploying it on a schedule.
 
-```bash
+```bash snippet=cli/snippet-01.sh
 glean-idx doctor                    # are my credentials right?
 glean-idx validate ./my-connector   # is the plan complete, before writing code?
-glean-idx test --phase all          # mocked, then real source, then live
-glean-idx run                       # crawl for real
+glean-idx test --phase mock         # Glean mocked; connector source clients unchanged
+glean-idx test --phase integration  # real source, recorded/replayed; Glean mocked
+glean-idx run --mode incremental    # additive crawl for real
 glean-idx datasource status --datasource company_wiki
 glean-idx deploy init --cloud gcp   # Docker and Terraform for a CronJob
 ```
@@ -25,7 +26,7 @@ confusion. `glean-idx --help` restates it.
 `GLEAN_INDEXING_API_TOKEN`. They never import your code, so they run from any
 directory — including with nothing installed:
 
-```bash
+```bash snippet=cli/snippet-02.sh
 uvx --from glean-indexing-sdk glean-idx doctor
 ```
 
@@ -33,7 +34,7 @@ uvx --from glean-indexing-sdk glean-idx doctor
 connector class, so they run from inside the connector project with the SDK
 installed alongside your code:
 
-```bash
+```bash snippet=cli/snippet-03.sh
 uv run glean-idx run
 ```
 
@@ -54,8 +55,8 @@ that, and lists the directories it searched for `glean_deployment.yaml`.
 
 | Command | What it does |
 |---|---|
-| `glean-idx run` | Fetches, transforms, and uploads. `--mode incremental` overrides the project's `indexing_mode`; `--force-restart` discards a partial upload. |
-| `glean-idx test --phase PHASE` | Runs the connector at one fidelity: `mock`, `integration`, `live`, or `all`. |
+| `glean-idx run [--connector MODULE:CLASS_OR_FACTORY] [--mode full\|incremental]` | Fetches, transforms, and uploads. `--mode incremental` overrides the project's `indexing_mode`; `--force-restart` discards a partial replacement upload. |
+| `glean-idx test --phase PHASE [--connector MODULE:CLASS_OR_FACTORY]` | Runs the connector at one fidelity: `mock`, `integration`, `live`, or `all`. |
 
 `--phase` maps onto the [testing phases](/libraries/indexing-sdk/testing/overview):
 
@@ -66,19 +67,36 @@ that, and lists the directories it searched for `glean_deployment.yaml`.
 | `--phase live` | [End-to-end](/libraries/indexing-sdk/testing/end-to-end) | real | real |
 
 `--phase all` runs them in order and stops at the first failure. A phase that
-cannot run is skipped and reported rather than failing the batch — without Glean
-credentials, `live` is skipped and the earlier phases still run.
+cannot run is skipped and reported rather than failing the batch. Without Glean
+credentials, `live` is skipped and the earlier phases still run. If live can run,
+`--phase all` also requires `--allow-destructive-live`.
+
+`--max-items N` limits source consumption for every discovered data client. It
+is not a Glean-side document cap and does not guarantee a small blast radius. In
+particular, using it with a full live crawl intentionally produces a partial
+replacement, so documents outside that subset can become stale.
+
+Every live phase requires `--allow-destructive-live` and prompts you to confirm
+the resolved Glean target. For a full live crawl, the flag acknowledges that the
+run finalizes replacement state and may stale-delete documents it does not
+produce. Use a disposable datasource; `--yes` only skips the prompt, not the
+required acknowledgement.
+
+```bash snippet=cli/snippet-04.sh
+glean-idx test --phase live --mode full --allow-destructive-live
+glean-idx test --phase all --allow-destructive-live
+```
 
 ### Inspecting what landed
 
 | Command | What it does |
 |---|---|
-| `glean-idx datasource status` | Uploaded and indexed counts per object type, identity counts, visibility, and the most recent upload and processing runs. |
-| `glean-idx datasource process` | Requests processing now instead of waiting for the next scheduled run. |
-| `glean-idx datasource configure` | Registers the connector's own `configuration`, so the datasource cannot drift from what the connector uploads to. |
-| `glean-idx document status` | Whether specific documents finished indexing. `--poll` waits. |
-| `glean-idx document access` | Whether a given user can see a document. |
-| `glean-idx document events` | A document's lifecycle events, for when it uploaded but never became searchable. |
+| `glean-idx datasource status --datasource NAME` | Uploaded and indexed counts per object type, identity counts, visibility, and the most recent upload and processing runs. |
+| `glean-idx datasource process --datasource NAME` | Requests processing now instead of waiting for the next scheduled run. |
+| `glean-idx datasource configure [--connector MODULE:CLASS_OR_FACTORY]` | Registers the connector's own `configuration`, so the datasource cannot drift from what the connector uploads to. |
+| `glean-idx document status --datasource NAME --document TYPE ID [--poll]` | Whether one or more documents finished indexing. Repeat `--document TYPE ID` to check several. |
+| `glean-idx document access --datasource NAME --object-type TYPE --id ID --user EMAIL` | Whether a given user can see a document. |
+| `glean-idx document events --datasource NAME --object-type TYPE --id ID` | A document's lifecycle events, for when it uploaded but never became searchable. |
 
 `document status` and `document access` are the two worth reaching for first
 when something is missing from search — see
@@ -88,8 +106,8 @@ when something is missing from search — see
 
 | Command | What it does |
 |---|---|
-| `glean-idx document delete` | Removes specific documents from the index. Prompts unless `--yes`. |
-| `glean-idx datasource teardown` | Removes every document, keeping the datasource and its configuration. Requires typing the datasource name to confirm. |
+| `glean-idx document delete --datasource NAME --document TYPE ID` | Removes one or more documents from the index. Repeat `--document TYPE ID`; prompts unless `--yes`. |
+| `glean-idx datasource teardown --datasource NAME` | Removes every document, keeping the datasource and its configuration. Requires typing the datasource name to confirm. |
 
 :::warning
 `teardown` cannot be undone. It uploads an empty full crawl, so everything
@@ -107,7 +125,7 @@ currently indexed for that datasource becomes stale and is removed.
 Every command takes `--output json` and returns a stable envelope, which is what
 makes the CLI usable from a script or an agent:
 
-```bash
+```bash snippet=cli/snippet-05.sh
 glean-idx datasource status --datasource company_wiki --output json | jq .data.documents
 ```
 
@@ -157,7 +175,7 @@ fixes them:
 
 ## Shell completion
 
-```bash
+```bash snippet=cli/snippet-06.sh
 glean-idx completion zsh >> ~/.zshrc      # or bash, fish
 ```
 

--- a/docs/libraries/indexing-sdk/concepts/architecture.mdx
+++ b/docs/libraries/indexing-sdk/concepts/architecture.mdx
@@ -12,9 +12,9 @@ SDK owns batching, retries, upload sessions, and stale-document cleanup.
 
 ## The indexing lifecycle
 
-`connector.index_data()` runs a fixed sequence every time. Each stage is timed
-separately, so a slow connector can be attributed to fetch, transform, or
-upload without adding instrumentation.
+`BaseDatasourceConnector.index_data()` runs the sequence below. Each stage is
+timed separately, so a slow connector can be attributed to fetch, transform,
+or upload without adding instrumentation.
 
 <Stages stages={[
   { owner: 'sdk', title: <>Start observability</>, body: <>Begins execution timing and assigns a <code>run_id</code> for the run.</> },
@@ -22,9 +22,15 @@ upload without adding instrumentation.
   { owner: 'you', title: <>Resolve <code>since</code></>, body: <>On an incremental crawl, calls <code>_get_last_crawl_timestamp()</code>. The base implementation returns <code>None</code>.</> },
   { owner: 'you', title: <>Content crawl &mdash; <code>get_data()</code></>, body: <>Delegates to your data client&rsquo;s <code>get_source_data()</code>.</> },
   { owner: 'you', title: <>Transform &mdash; <code>transform()</code></>, body: <>Your mapping from source records to Glean entity definitions.</> },
-  { owner: 'sdk', title: <>Upload</>, body: <>Hands documents to <code>PushUploader.bulk_index_documents()</code>, which batches, parallelizes, retries, and triggers stale-document cleanup.</> },
+  { owner: 'sdk', title: <>Upload</>, body: <>A full crawl calls <code>PushUploader.bulk_index_documents()</code> for replacement and stale cleanup. An incremental crawl calls additive <code>index_documents()</code>.</> },
   { owner: 'sdk', title: <>End observability</>, body: <>Records totals. On exception, increments the error counter and re-raises so a scheduler sees a non-zero exit.</> },
 ]} />
+
+Sync and async streaming datasource connectors keep fetch/transform memory
+bounded, but their indexing implementations do **not** run the optional
+`get_identities()` crawl. Push identities separately before a streaming content
+crawl. Their full uploads still use replacement semantics, while incremental
+batches use additive uploads.
 
 ## Class hierarchy
 

--- a/docs/libraries/indexing-sdk/concepts/connector-types.mdx
+++ b/docs/libraries/indexing-sdk/concepts/connector-types.mdx
@@ -19,7 +19,7 @@ streaming variant later means changing the base class and the return type of
 `get_source_data()` returns a `Sequence`. The connector fetches everything,
 transforms everything, then uploads in batches of `batch_size` (default 1000).
 
-```python
+```python snippet=connector-types/snippet-01.py
 class WikiDataClient(BaseDataClient[WikiPage]):
     def get_source_data(self, since=None, **kwargs):
         return fetch_all_pages()
@@ -42,7 +42,7 @@ batching happens after transform.
 `get_source_data()` is a generator. The connector pulls `batch_size` items at a
 time, transforms that slice, and uploads it before pulling more.
 
-```python
+```python snippet=connector-types/snippet-02.py
 from collections.abc import Generator
 
 from glean.indexing.connectors import (
@@ -70,7 +70,9 @@ class ArticleConnector(BaseStreamingDatasourceConnector[Article]):
 ```
 
 Note that `transform()` still receives a `Sequence` — the SDK slices the
-generator into batches for you. You never write batching logic.
+generator into batches for you. You never write batching logic. Full-mode
+batches form one replacement upload; incremental-mode batches use additive
+`index_documents()` calls.
 
 :::tip
 If your source is a paginated HTTP API, use
@@ -110,6 +112,13 @@ await connector.index_data_async(mode=IndexingMode.FULL)
 
 `transform()` stays synchronous. Only fetching is async.
 
+:::warning[Push identities separately]
+The sync and async streaming connector implementations do not call the optional
+`get_identities()` crawl inherited from `BaseDatasourceConnector`. If streamed
+documents reference datasource users or groups, upload those identities before
+the streaming content run.
+:::
+
 :::info
 Async connectors also expose the synchronous `index_data()`, which wraps the
 async path in `asyncio.run()`. That works from a plain script but fails inside
@@ -124,7 +133,7 @@ from inside a running loop.
 `DocumentDefinition`. Configuration, `batch_size`, and observability behave the
 same.
 
-```python
+```python snippet=connector-types/snippet-04.py
 class EmployeeConnector(BasePeopleConnector[EmployeeRecord]):
     configuration = CustomDatasourceConfig(name="hris", display_name="HRIS")
 
@@ -140,7 +149,7 @@ document ACLs — see [Permissions](/libraries/indexing-sdk/permissions).
 
 All four classes expose `batch_size`, defaulting to 1000.
 
-```python
+```python snippet=connector-types/snippet-05.py
 connector = WikiConnector(name="wiki", data_client=client)
 connector.batch_size = 250
 ```

--- a/docs/libraries/indexing-sdk/concepts/indexing-modes.mdx
+++ b/docs/libraries/indexing-sdk/concepts/indexing-modes.mdx
@@ -3,7 +3,7 @@ title: Indexing modes
 description: Full versus incremental crawls, stale document deletion, and checkpointing in the Glean Indexing SDK
 ---
 
-```python
+```python snippet=indexing-modes/snippet-01.py
 from glean.indexing.models import IndexingMode
 
 connector.index_data(mode=IndexingMode.FULL)
@@ -67,7 +67,7 @@ Everything below is the developer-owned path.
 An incremental crawl passes a `since` timestamp down to your data client so you
 can query only what changed:
 
-```python
+```python snippet=indexing-modes/snippet-02.py
 class WikiDataClient(BaseDataClient[WikiPage]):
     def get_source_data(self, since=None, **kwargs):
         if since:
@@ -75,9 +75,15 @@ class WikiDataClient(BaseDataClient[WikiPage]):
         return fetch_all_pages()
 ```
 
-Incremental crawls do **not** delete stale documents. Only a full crawl
-reconciles deletions, which is why most connectors run incrementally on a short
-cadence and fully on a longer one.
+Incremental crawls upload documents additively with `index_documents()`: they
+add or update records and do **not** delete documents omitted from that run. An
+empty incremental result is a no-op. Only a full crawl reconciles deletions,
+which is why most connectors run incrementally on a short cadence and fully on
+a longer one.
+
+A full crawl always finalizes replacement state, including when the source is
+empty. A successful empty full crawl sends one complete empty bulk page so all
+previously indexed documents are reconciled as stale.
 
 ### The SDK does not persist checkpoints
 
@@ -89,7 +95,7 @@ back to a full fetch.
 To get real incremental behavior, override it and supply the timestamp from
 wherever you store it:
 
-```python
+```python snippet=indexing-modes/snippet-03.py
 class WikiConnector(BaseDatasourceConnector[WikiPage]):
     def _get_last_crawl_timestamp(self):
         # your storage: file, S3, DynamoDB, database
@@ -109,7 +115,7 @@ crawl was in flight; writing on failure silently skips a window.
 
 `ConnectorOptions` adjusts upload behavior for a single run.
 
-```python
+```python snippet=indexing-modes/snippet-04.py
 from glean.indexing.models import ConnectorOptions
 
 connector.index_data(
@@ -124,17 +130,13 @@ connector.index_data(
 | `disable_stale_deletion_check` | `False` | Forces synchronous stale-document deletion after the upload completes. |
 | `upload_timeout_ms` | `None` | Per-call timeout for bulk upload requests only. Raise it for large batches. |
 | `upload_max_workers` | `5` | Concurrent middle-page uploads. First and last pages are always sequential. |
-| `document_batch_size_bytes` | `5 MiB` | Intended byte cap per document batch. **This override is not applied today** — see below. |
+| `document_batch_size_bytes` | `5 MiB` | Maximum serialized bytes per document batch. Set `None` to batch by document count only. |
 
-:::warning
-Setting `document_batch_size_bytes` has no effect: the connector base classes
-don't forward it to the uploader. Batches are still capped at 5&nbsp;MiB,
-because `PushUploader` applies that as its own default — you just can't change
-it from `ConnectorOptions` yet. To use a different cap, call
-[`PushUploader`](/libraries/indexing-sdk/push/uploader) directly with
-`max_batch_bytes`. Tracked in
-[issue #106](https://github.com/gleanwork/glean-indexing-sdk/issues/106).
-:::
+Datasource and streaming connectors forward `document_batch_size_bytes` to the
+document batch processor. A connector can override `_resolve_max_batch_bytes()`
+when the byte cap must be selected dynamically; that connector-level result
+takes precedence over the option. Direct `PushUploader` calls expose the same
+limit as `max_batch_bytes`.
 
 ## Choosing a schedule
 

--- a/docs/libraries/indexing-sdk/deployment/overview.mdx
+++ b/docs/libraries/indexing-sdk/deployment/overview.mdx
@@ -9,24 +9,17 @@ A connector is a batch job: it runs on a schedule, pulls from a source, pushes t
 Glean, and exits. `glean-idx deploy` generates the scaffolding for that — a
 Dockerfile, an entrypoint, and Terraform for a Kubernetes CronJob on GKE or EKS.
 
-```bash
-glean-idx deploy init --cloud gcp --connector-class CompanyWikiConnector
+```bash snippet=overview/snippet-21.sh
+glean-idx deploy init --cloud gcp \
+  --connector-class CompanyWikiConnector \
+  --connector-factory create_connector
 ```
 
 :::danger
-**The generated infrastructure has not been validated against a real cloud
-account.** Two known issues affect it today:
-
-- The AWS IRSA trust policy uses the wrong OIDC condition-key format and is
-  likely to fail at runtime
-  ([issue #103](https://github.com/gleanwork/glean-indexing-sdk/issues/103)).
-- The GCP service account is granted secret access at **project** scope rather
-  than scoped to the connector's own secrets
-  ([issue #105](https://github.com/gleanwork/glean-indexing-sdk/issues/105)).
-
-Treat the output as a starting point to review, not as production-ready IaC. Have
-someone who owns the target account read the Terraform before applying it.
-Broader validation is tracked in
+**The generated infrastructure has not been validated end to end against a real
+cloud account.** Treat the output as a starting point to review, not as
+production-ready IaC. Have someone who owns the target account read the
+Terraform before applying it. Broader validation is tracked in
 [issue #104](https://github.com/gleanwork/glean-indexing-sdk/issues/104).
 :::
 
@@ -49,6 +42,7 @@ Options for `init`:
 | `--connector-name` | current directory name | Used for resource naming. |
 | `--connector-class` | `MyConnector` | Class the entrypoint instantiates. |
 | `--connector-module` | `connector` | Module to import it from. |
+| `--connector-factory` | — | Optional zero-argument factory in the connector module. |
 | `--output-dir` | `.` | Where to write. |
 
 ## Configuration
@@ -81,16 +75,20 @@ full nightly. See
   { title: <>Generate &mdash; <code>glean-idx deploy init</code></>, body: <>Writes the Dockerfile, entrypoint, Terraform, and config template.</> },
   { title: <>Configure</>, body: <>Edit <code>glean_deployment.yaml</code> (cluster, region, registry, schedule), then <code>cp .env.example .env</code> and fill in credentials.</> },
   { title: <>Build and push &mdash; <code>glean-idx deploy build --push</code></>, body: <>Builds the container image and pushes it to your registry.</> },
-  { title: <>Upload secrets &mdash; <code>glean-idx deploy secrets upload</code></>, body: <>Reads <code>.env</code> and writes to Secret Manager (GCP) or Secrets Manager (AWS). <code>secrets list</code> and <code>secrets delete</code> are also available.</> },
-  { title: <>Apply &mdash; <code>glean-idx deploy apply</code></>, body: <>Runs Terraform. Read the plan first &mdash; see the warning below.</> },
-  { title: <>Verify</>, body: <><code>glean-idx deploy status</code> and <code>glean-idx deploy logs --follow</code>, then confirm documents landed with <code>glean-idx document status</code>. A CronJob that exits zero has not necessarily indexed anything.</> },
+  { title: <>Upload secrets &mdash; <code>glean-idx deploy secrets upload</code></>, body: <>Reads <code>.env</code>, writes each secret to the cloud provider, and atomically records the validated environment keys in local <code>.glean_secret_keys</code>.</> },
+  { title: <>Apply &mdash; <code>glean-idx deploy apply</code></>, body: <>Reads that manifest and passes its keys to Terraform at apply time so IAM and the CronJob name the exact runtime secrets.</> },
+  { title: <>Verify</>, body: <><code>glean-idx deploy status</code> and <code>glean-idx deploy logs --follow</code>, then confirm a document with <code>glean-idx document status --datasource NAME --document TYPE ID</code>. A CronJob that exits zero has not necessarily indexed anything.</> },
 ]} />
 
+Build and push the image **before** uploading secrets. The local manifest is
+created by `secrets upload`, excluded from the Docker build context, and consumed
+by `deploy apply`; it is not baked into the image. Uploading before build is
+neither required nor recommended.
+
 :::warning
-`apply` runs `terraform apply -auto-approve` with **no confirmation prompt**,
-unlike `destroy` which requires two. Run `terraform plan` in the generated
-directory and read it before applying. Tracked in
-[issue #111](https://github.com/gleanwork/glean-indexing-sdk/issues/111).
+`apply` prompts once before invoking `terraform apply -auto-approve`; `--yes`
+skips that prompt for unattended use. Run `terraform plan` in the generated
+`terraform/` directory and review it before applying.
 :::
 
 ## Secrets
@@ -98,18 +96,20 @@ directory and read it before applying. Tracked in
 Credentials are read from the environment at runtime and injected from the cloud
 secret store. Never bake them into the image or commit `.env`.
 
-Deployment-control variables are filtered out rather than uploaded as connector
-secrets. That filter is a blocklist, so a newly added config key could be treated
-as a secret unexpectedly — review `secrets list` output after upgrading
-([issue #120](https://github.com/gleanwork/glean-indexing-sdk/issues/120)).
+`secrets upload` validates environment-variable keys and writes their sorted
+names to `.glean_secret_keys`. At apply time, Terraform grants the workload
+access to each exact declared secret: one secret-level IAM member per key on
+GCP, or the exact resolved secret ARNs on AWS. The generated runtime receives
+the declared key list and fetches those values directly. It has no permission to
+enumerate secrets and does not discover them by connector-name prefix.
 
-The generated Terraform grants the connector's service account access to those
-secrets — subject to the GCP project-scope caveat above. Review and tighten that
-binding.
+`glean-idx deploy secrets list` remains an operator command; the deployed
+connector does not use it. Startup fails if any declared secret cannot be
+loaded. A missing or empty manifest produces a secretless deployment.
 
 ## Teardown
 
-```bash
+```bash snippet=overview/snippet-22.sh
 glean-idx deploy destroy
 ```
 

--- a/docs/libraries/indexing-sdk/observability.mdx
+++ b/docs/libraries/indexing-sdk/observability.mdx
@@ -7,7 +7,7 @@ Every connector base class creates a `ConnectorObservability` instance and wires
 it into the indexing lifecycle. You get stage timings, item counts, and
 structured logs without adding any instrumentation.
 
-```python
+```python snippet=observability/snippet-01.py
 connector.index_data(mode=IndexingMode.FULL)
 print(connector.observability.get_metrics_summary())
 ```
@@ -35,7 +35,7 @@ success/failure.
 
 ## Structured logging
 
-```python
+```python snippet=observability/snippet-02.py
 from glean.indexing.observability import setup_connector_logging
 
 setup_connector_logging("company_wiki", log_level="INFO")
@@ -64,7 +64,7 @@ to attach them elsewhere.
 `NoOpMetricsProvider` — metrics are recorded in-process for
 `get_metrics_summary()` but not exported.
 
-```python
+```python snippet=observability/snippet-03.py
 from glean.indexing.observability import ConnectorObservability, InMemoryMetricsProvider
 
 observability = ConnectorObservability(
@@ -84,22 +84,16 @@ observability = ConnectorObservability(
 
 Each observability instance gets a `run_id` (a UUID unless you pass one), which
 is how you correlate every log line and metric from a single crawl.
-
-:::warning
-`InMemoryMetricsProvider` has a data race under concurrent uploads, and parallel
-uploads are on by default (`upload_max_workers=5`). Counters can undercount.
-It's fine for Phase 1 tests; don't assert on exact counts under concurrency.
-`NoOpMetricsProvider` and the cloud providers are unaffected. Tracked in
-[issue #107](https://github.com/gleanwork/glean-indexing-sdk/issues/107).
-:::
+`InMemoryMetricsProvider` synchronizes concurrent metric updates, so exact
+counter assertions are safe during parallel uploads.
 
 ## AWS
 
-```bash
+```bash snippet=observability/snippet-04.sh
 pip install "glean-indexing-sdk[aws]"
 ```
 
-```python
+```python snippet=observability/snippet-05.py
 from glean.indexing.observability import ConnectorObservability, setup_connector_logging
 from glean.indexing.observability.plugins.aws import (
     CloudWatchLogsProvider,
@@ -108,7 +102,11 @@ from glean.indexing.observability.plugins.aws import (
 
 setup_connector_logging(
     "company_wiki",
-    logger_provider=CloudWatchLogsProvider(log_group="/glean/connectors"),
+    logger_provider=CloudWatchLogsProvider(
+        log_group="/glean/connectors",
+        log_stream="company_wiki",
+        region_name="us-east-1",
+    ),
 )
 
 observability = ConnectorObservability(
@@ -121,13 +119,16 @@ observability = ConnectorObservability(
 )
 ```
 
+The logging provider is named `CloudWatchLogsProvider` and requires both
+`log_group` and `log_stream`; there is no `CloudWatchLoggerProvider`.
+
 ## GCP
 
-```bash
+```bash snippet=observability/snippet-06.sh
 pip install "glean-indexing-sdk[gcp]"
 ```
 
-```python
+```python snippet=observability/snippet-07.py
 from glean.indexing.observability.plugins.gcp import (
     CloudLoggingProvider,
     CloudMonitoringProvider,
@@ -169,7 +170,7 @@ the base class in terms of `emit_metric()`.
 
 ## Manual instrumentation
 
-```python
+```python snippet=observability/snippet-09.py
 obs = connector.observability
 
 obs.start_timer("enrichment")

--- a/docs/libraries/indexing-sdk/permissions.mdx
+++ b/docs/libraries/indexing-sdk/permissions.mdx
@@ -28,10 +28,11 @@ means re-indexing everything. Get them right in the first run.
 
 Attach a `DocumentPermissionsDefinition` to each document:
 
-```python
+```python snippet=permissions/snippet-01.py
 from glean.api_client.models import (
     DocumentDefinition,
     DocumentPermissionsDefinition,
+    PermissionsGroupIntersectionDefinition,
     UserReferenceDefinition,
 )
 
@@ -49,6 +50,11 @@ def transform(self, data):
                     UserReferenceDefinition(email=email)
                     for email in article["visible_to_users"]
                 ],
+                allowed_group_intersections=[
+                    PermissionsGroupIntersectionDefinition(
+                        required_groups=["engineering", "employees"]
+                    )
+                ],
             ),
         )
         for article in data
@@ -59,7 +65,7 @@ def transform(self, data):
 |---|---|
 | `allowed_users` | Users who can see the document, by email or datasource user ID. |
 | `allowed_groups` | Group names that can see the document. |
-| `allowed_group_intersections` | Requires membership in *all* listed groups — for sources with AND-style ACLs. |
+| `allowed_group_intersections` | A list of `PermissionsGroupIntersectionDefinition(required_groups=[...])` entries. A user must belong to every group within one entry; multiple entries are alternative intersections. |
 
 Map your source's model onto these directly. Don't flatten groups into user
 lists: group membership changes constantly, and a flattened ACL is stale the
@@ -69,7 +75,7 @@ moment someone joins a team.
 
 Implement `get_identities()` to push the identity graph:
 
-```python
+```python snippet=permissions/snippet-02.py
 from glean.indexing.models import DatasourceIdentityDefinitions
 
 
@@ -81,8 +87,12 @@ def get_identities(self) -> DatasourceIdentityDefinitions:
     )
 ```
 
-`index_data()` runs this **before** the content crawl, so identities exist by the
-time documents referencing them arrive.
+`BaseDatasourceConnector.index_data()` runs this **before** its content crawl, so
+identities exist by the time documents referencing them arrive. The sync and
+async streaming connector implementations do not call `get_identities()`; push
+their users, groups, and memberships separately before indexing documents, or
+use a non-streaming datasource connector when you need the built-in identity
+crawl.
 
 :::info
 If you return `groups`, you must also return `memberships`. The SDK raises
@@ -97,7 +107,7 @@ Setting `is_user_referenced_by_email=True` on the datasource config lets you
 reference users by email, which is usually simplest when your source and Glean
 share an identity provider:
 
-```python
+```python snippet=permissions/snippet-03.py
 configuration = CustomDatasourceConfig(
     name="company_wiki",
     display_name="Company Wiki",
@@ -113,22 +123,25 @@ user record mapping each ID.
 Counting indexed documents proves nothing about permissions. Test the negative
 case: a user who should *not* see a document must not see it.
 
-The test harness supports this directly. List identities that should never
-appear in any ACL:
+The test harness supports this directly. List identities that must not have
+access to any transformed document:
 
-```yaml title="testing_config.yaml"
+```yaml title="testing_config.yaml" snippet=permissions/snippet-04.yaml
 testing:
   negative_test_identities:
     - contractor@example.com
     - external-partners
 ```
 
-Phase 2 asserts they're absent from every transformed document. See
-[Integration testing](/libraries/indexing-sdk/testing/integration).
+Phase 2 checks literal references in `allowed_users`, `allowed_groups`, and each
+intersection's `required_groups`. It also rejects missing `permissions`,
+`allow_anonymous_access=True`, and `allow_all_datasource_users_access=True`,
+because any of those prevents the harness from proving a configured identity is
+denied. See [Integration testing](/libraries/indexing-sdk/testing/integration).
 
 You can also assert in code:
 
-```python
+```python snippet=permissions/snippet-05.py
 from glean.indexing.testing import assert_negative_identities_absent, extract_permission_refs
 
 result = run_connector(connector)

--- a/docs/libraries/indexing-sdk/pull/data-clients.mdx
+++ b/docs/libraries/indexing-sdk/pull/data-clients.mdx
@@ -6,7 +6,7 @@ description: BasePullHttpStreamingDataClient - paginated HTTP data clients with 
 A data client is the source-facing half of a connector. At minimum it
 implements `get_source_data()`:
 
-```python
+```python snippet=data-clients/snippet-01.py
 from glean.indexing.connectors import BaseDataClient
 
 
@@ -25,7 +25,7 @@ base class that already knows how to page.
 [pagination](/libraries/indexing-sdk/pull/pagination) and yields records one at
 a time. For a well-behaved JSON API you often need no method body at all:
 
-```python
+```python snippet=data-clients/snippet-02.py
 from glean.indexing.recipes.pull import BasePullHttpStreamingDataClient, PullOptions
 
 
@@ -91,7 +91,7 @@ its envelope.
 Everything above is a starting point. Override `get_source_data()` when your
 source needs something the base class doesn't model, and reuse `self.http`:
 
-```python
+```python snippet=data-clients/snippet-04.py
 class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
     def get_source_data(self, **kwargs):
         for article in super().get_source_data(**kwargs):
@@ -107,7 +107,7 @@ common, and the N+1 request cost is exactly why you want a
 
 The client owns an HTTP connection. Close it when the crawl finishes:
 
-```python
+```python snippet=data-clients/snippet-05.py
 try:
     connector.index_data(mode=IndexingMode.FULL)
 finally:
@@ -119,7 +119,7 @@ finally:
 `max_items` caps the number of records fetched, which keeps iteration fast while
 you're still shaping `transform()`:
 
-```python
+```python snippet=data-clients/snippet-06.py
 ArticleDataClient(token, max_items=25)
 ```
 

--- a/docs/libraries/indexing-sdk/pull/http-client.mdx
+++ b/docs/libraries/indexing-sdk/pull/http-client.mdx
@@ -11,7 +11,7 @@ It exists because every hand-rolled connector ends up reimplementing the same
 things: session reuse, retry with backoff, honoring `Retry-After`, and keeping
 API keys out of logs.
 
-```python
+```python snippet=http-client/snippet-01.py
 from glean.indexing.recipes.pull import PullHttpClient, PullOptions
 
 with PullHttpClient(
@@ -41,7 +41,7 @@ work without extra bookkeeping.
 `PullResponse` is a frozen dataclass with two accessors that fail loudly on
 shape mismatches:
 
-```python
+```python snippet=http-client/snippet-02.py
 response.status_code   # int
 response.headers       # dict[str, str]
 response.url           # str
@@ -57,7 +57,7 @@ boundary instead of an `AttributeError` deep inside `transform()`.
 
 Retry behavior lives on `PullRetryOptions`:
 
-```python
+```python snippet=http-client/snippet-03.py
 options = PullOptions(
     timeout_seconds=30.0,
     retries=PullRetryOptions(
@@ -121,7 +121,7 @@ exception message you construct yourself.
 `get_bytes()` takes a `max_bytes` cap, useful when indexing attachments from a
 source that can return arbitrarily large files:
 
-```python
+```python snippet=http-client/snippet-05.py
 content, content_type = http.get_bytes("/attachments/42", max_bytes=10 * 1024 * 1024)
 ```
 

--- a/docs/libraries/indexing-sdk/pull/pagination.mdx
+++ b/docs/libraries/indexing-sdk/pull/pagination.mdx
@@ -18,7 +18,7 @@ records until the source runs out or `max_items` is reached.
 
 The default. GitHub, GitLab, and most APIs that follow RFC 5988 use this.
 
-```python
+```python snippet=pagination/snippet-01.py
 super().__init__(
     base_url="https://api.example.com/v2",
     path="/articles",
@@ -36,7 +36,7 @@ The parser tolerates the messy variants seen in the wild: commas inside URLs,
 
 ## Offset
 
-```python
+```python snippet=pagination/snippet-02.py
 super().__init__(
     base_url="https://api.example.com/v2",
     path="/articles",
@@ -60,7 +60,7 @@ it.
 
 ## Cursor
 
-```python
+```python snippet=pagination/snippet-03.py
 super().__init__(
     base_url="https://api.example.com/v2",
     path="/articles",
@@ -103,7 +103,7 @@ If your source does something else — a page number, a timestamp watermark, a
 `has_more` boolean — override `get_source_data()` and drive `self.http`
 yourself:
 
-```python
+```python snippet=pagination/snippet-06.py
 class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
     def get_source_data(self, **kwargs):
         page = 1

--- a/docs/libraries/indexing-sdk/pull/rate-limiting.mdx
+++ b/docs/libraries/indexing-sdk/pull/rate-limiting.mdx
@@ -10,7 +10,7 @@ reason someone else's integration gets throttled.
 
 ## Token bucket
 
-```python
+```python snippet=rate-limiting/snippet-01.py
 from glean.indexing.recipes.pull import (
     BasePullHttpStreamingDataClient,
     TokenBucketRateLimiter,
@@ -46,7 +46,7 @@ rate.
 The limiter is thread-safe, so it can be shared across data clients that hit the
 same API:
 
-```python
+```python snippet=rate-limiting/snippet-02.py
 shared = TokenBucketRateLimiter(rate_per_second=10, capacity=20)
 
 articles = ArticleDataClient(token, rate_limiter=shared)
@@ -67,7 +67,7 @@ the same token. A source allowing 600 requests/minute is 10/second; running at
 `acquire()` blocks indefinitely by default. To fail instead of waiting forever,
 set a rate-limit timeout:
 
-```python
+```python snippet=rate-limiting/snippet-03.py
 from glean.indexing.recipes.pull import PullOptions
 
 options = PullOptions(rate_limit_timeout_seconds=30.0)
@@ -86,7 +86,7 @@ They solve different problems and both should be on:
   `PullRetryOptions` backs off and tries again, honoring `Retry-After` by
   default.
 
-```python
+```python snippet=rate-limiting/snippet-04.py
 super().__init__(
     base_url="https://api.example.com/v2",
     path="/articles",

--- a/docs/libraries/indexing-sdk/push/batching.mdx
+++ b/docs/libraries/indexing-sdk/push/batching.mdx
@@ -9,7 +9,8 @@ timing out, running too slowly, or overwhelming your source.
 | Knob | Where | Default | Reach for it when… |
 |---|---|---|---|
 | `connector.batch_size` | Connector attribute | `1000` | Batches time out — **lower** it. |
-| `max_batch_bytes` | `PushUploader` argument | `5 MiB` | Rarely. This tracks the API payload limit. |
+| `document_batch_size_bytes` | `ConnectorOptions` | `5 MiB` | Tune the serialized byte cap for connector-managed uploads; `None` disables the byte cap. |
+| `max_batch_bytes` | `PushUploader` argument | `5 MiB` | The equivalent cap for direct uploader calls. |
 | `upload_timeout_ms` | `ConnectorOptions` | client default | Large batches hit timeouts. |
 | `upload_max_workers` | `ConnectorOptions` | `5` | Many small batches over a high-latency link. |
 
@@ -18,7 +19,7 @@ timing out, running too slowly, or overwhelming your source.
 Before tuning anything, look at where time is going. The SDK times fetch,
 transform, and upload separately:
 
-```python
+```python snippet=batching/snippet-01.py
 connector.index_data(mode=IndexingMode.FULL)
 print(connector.observability.get_metrics_summary())
 ```
@@ -37,10 +38,24 @@ nothing. See [Observability](/libraries/indexing-sdk/observability).
 Batches close on whichever limit hits first: `batch_size` documents or
 `max_batch_bytes` serialized bytes.
 
-```python
+```python snippet=batching/snippet-02.py
 connector = WikiConnector(name="wiki", data_client=client)
 connector.batch_size = 250
 ```
+
+Set the byte cap for a connector-managed run with the exact
+`ConnectorOptions` field:
+
+```python snippet=batching/snippet-03.py
+connector.index_data(
+    options=ConnectorOptions(document_batch_size_bytes=2 * 1024 * 1024)
+)
+```
+
+The connector forwards that value to byte-aware batching for in-memory, sync
+streaming, and async streaming uploads. Custom connectors can override the
+static `_resolve_max_batch_bytes(options)` hook when the cap must be selected at
+runtime; the hook's result is the effective cap.
 
 Lower `batch_size` when your documents are large. A connector indexing full page
 bodies will hit the 5 MiB byte cap long before 1000 documents, so the count
@@ -56,7 +71,7 @@ binds first.
 A batch that exceeds the request timeout fails and retries the whole batch,
 which is expensive. If you see timeouts, do one of:
 
-```python
+```python snippet=batching/snippet-04.py
 # Give large batches longer.
 connector.index_data(options=ConnectorOptions(upload_timeout_ms=120_000))
 
@@ -71,7 +86,7 @@ and give more granular progress in logs.
 
 `upload_max_workers` controls how many middle pages upload at once:
 
-```python
+```python snippet=batching/snippet-05.py
 connector.index_data(options=ConnectorOptions(upload_max_workers=10))
 ```
 

--- a/docs/libraries/indexing-sdk/push/error-handling.mdx
+++ b/docs/libraries/indexing-sdk/push/error-handling.mdx
@@ -7,7 +7,7 @@ Every SDK exception derives from `GleanError` and carries a `fix_suggestion` —
 and often a `docs_url` — that are included in `str(error)`. An unhandled failure
 prints what to do about it, not just what went wrong.
 
-```python
+```python snippet=error-handling/snippet-01.py
 from glean.indexing.exceptions import GleanError
 
 try:
@@ -74,7 +74,7 @@ one record whose payload is malformed. Skip it, log it, continue.
 **Never swallow:** anything that makes the result set incomplete — a failed page
 of results, an auth expiry mid-crawl, a source-side 500 on a list endpoint.
 
-```python
+```python snippet=error-handling/snippet-03.py
 def get_source_data(self, **kwargs):
     for summary in self.list_articles():        # raises on failure — correct
         try:
@@ -101,7 +101,7 @@ configuration. If an upload session fails partway, the next run picks up cleanly
 — but a session left in a stuck state can block subsequent uploads. Clear it
 with:
 
-```python
+```python snippet=error-handling/snippet-04.py
 connector.index_data(
     mode=IndexingMode.FULL,
     options=ConnectorOptions(force_restart=True),
@@ -116,7 +116,7 @@ upload state.
 `index_data()` increments an error counter and re-raises, so failures are
 visible in metrics as well as logs:
 
-```python
+```python snippet=error-handling/snippet-05.py
 try:
     connector.index_data(mode=IndexingMode.FULL)
 except Exception:

--- a/docs/libraries/indexing-sdk/push/uploader.mdx
+++ b/docs/libraries/indexing-sdk/push/uploader.mdx
@@ -9,7 +9,7 @@ reach for it when you need to push data outside the
 `fetch → transform → upload` lifecycle: event-driven updates, one-off
 backfills, or targeted deletes.
 
-```python
+```python snippet=uploader/snippet-01.py
 from glean.indexing.push import PushUploader
 
 uploader = PushUploader(datasource="company_wiki")
@@ -38,7 +38,7 @@ everywhere else in the SDK.
 `bulk_index_documents()` replaces the datasource's documents. This is what a
 full crawl runs, and it is what deletes stale documents.
 
-```python
+```python snippet=uploader/snippet-02.py
 uploader.bulk_index_documents(
     documents,
     batch_size=1000,
@@ -56,7 +56,9 @@ uploader.bulk_index_documents(
 
 Batching applies both limits: a batch closes when it hits `batch_size` documents
 **or** `max_batch_bytes` serialized bytes, whichever comes first. That keeps one
-unusually large document from pushing a batch past the API's payload limit.
+unusually large document from pushing a batch past the API's payload limit. An
+empty input still sends one page marked as both first and last, completing an
+empty replacement so previously indexed documents are reconciled as stale.
 
 :::danger
 `bulk_index_documents()` is a **replacement**. Documents absent from the call
@@ -66,10 +68,11 @@ are deleted as stale. Never call it with a partial result set — see
 
 ### Incremental updates
 
-To add or update documents without touching anything else, use
-`index_documents()`:
+To add or update documents without touching anything else, use the additive
+`index_documents()`. Incremental connector runs use this method (once per
+streamed batch), and an empty incremental run makes no document request:
 
-```python
+```python snippet=uploader/snippet-03.py
 uploader.index_documents(documents)
 ```
 
@@ -77,7 +80,7 @@ This is the right call for event-driven connectors reacting to a webhook.
 
 ### Deleting
 
-```python
+```python snippet=uploader/snippet-04.py
 uploader.delete_document(object_type="article", document_id="page_123")
 ```
 
@@ -86,7 +89,7 @@ uploader.delete_document(object_type="article", document_id="page_123")
 If you're already producing batches — a streaming connector, or your own
 chunking — hand them over directly:
 
-```python
+```python snippet=uploader/snippet-05.py
 uploader.bulk_index_document_batches(batches, batch_count=len(batches))
 ```
 
@@ -98,7 +101,7 @@ page, which is what triggers stale-document cleanup.
 Document ACLs only evaluate if Glean knows about the users and groups they
 reference. See [Permissions](/libraries/indexing-sdk/permissions).
 
-```python
+```python snippet=uploader/snippet-06.py
 uploader.bulk_index_users(users=users, batch_size=1000)
 uploader.bulk_index_groups(groups=groups, batch_size=1000)
 uploader.bulk_index_memberships(memberships=memberships, batch_size=1000)
@@ -119,7 +122,7 @@ memberships.
 
 For people data, separate from document ACLs:
 
-```python
+```python snippet=uploader/snippet-07.py
 uploader.bulk_index_employees(employees=employees, batch_size=1000)
 ```
 
@@ -130,24 +133,16 @@ pool sized by `upload_max_workers` (default 5). The **first and last pages are
 always sequential** — the first opens the upload session, the last closes it and
 triggers stale deletion, so neither can race.
 
-```python
+```python snippet=uploader/snippet-08.py
 uploader = PushUploader(datasource="company_wiki", upload_max_workers=10)
 ```
 
 Raise it for many small batches over a high-latency link; lower it to `1` to
 make an upload fully sequential when debugging.
 
-:::warning
-Parallel uploads are on by default. If you wire up `InMemoryMetricsProvider` for
-local testing, be aware it has a data race under concurrent uploads and can
-undercount. The default `NoOpMetricsProvider` and the cloud providers are
-unaffected. Tracked in
-[issue #107](https://github.com/gleanwork/glean-indexing-sdk/issues/107).
-:::
-
 ## Parameter naming
 
-Document methods take `disable_stale_document_deletion_check`; user, group,
-membership, and employee methods take `disable_stale_data_deletion_check`. The
-behavior is analogous. Tracked in
-[issue #116](https://github.com/gleanwork/glean-indexing-sdk/issues/116).
+Document methods take `disable_stale_document_deletion_check`; user, group, and
+employee bulk methods take `disable_stale_data_deletion_check`. Membership bulk
+uploads do not expose a stale-deletion option; they accept
+`force_restart_upload` and optional `group` scoping.

--- a/docs/libraries/indexing-sdk/quickstart.mdx
+++ b/docs/libraries/indexing-sdk/quickstart.mdx
@@ -14,13 +14,13 @@ builds both and indexes a document you can find in search.
 
 ## Install
 
-```bash
+```bash snippet=quickstart/snippet-01.sh
 pip install glean-indexing-sdk
 ```
 
 Optional cloud observability plugins:
 
-```bash
+```bash snippet=quickstart/snippet-02.sh
 pip install "glean-indexing-sdk[aws]"   # CloudWatch logs + metrics
 pip install "glean-indexing-sdk[gcp]"   # Cloud Logging + Cloud Monitoring
 ```
@@ -31,9 +31,11 @@ The SDK reads these from the environment. Never hardcode them.
 
 <TenantProfileControl />
 
-```bash
+```bash snippet=quickstart/snippet-03.sh
 export GLEAN_SERVER_URL="https://your-company-be.glean.com"
 export GLEAN_INDEXING_API_TOKEN="your-indexing-api-token"
+export WIKI_BASE_URL="https://wiki.company.com"
+export WIKI_API_TOKEN="your-source-api-token"
 ```
 
 :::info
@@ -51,7 +53,7 @@ something with a real permission model already in it — 29 documents, six group
 a few deliberately restricted files, and one restricted to named users rather than
 a group — there is a complete runnable example you can copy instead:
 
-```bash
+```bash snippet=quickstart/snippet-04.sh
 npx tiged --mode=git gleanwork/glean-cookbook/examples/sample-catalog sample-catalog
 cd sample-catalog && cat README.md
 ```
@@ -66,7 +68,7 @@ for the concepts; that example is just content to point them at.
 A data client implements one method, `get_source_data()`. The `since` argument
 is populated on [incremental crawls](/libraries/indexing-sdk/concepts/indexing-modes).
 
-```python
+```python snippet=quickstart/snippet-05.py
 from typing import Any, Optional, Sequence, TypedDict
 
 from glean.indexing.connectors import BaseDataClient
@@ -105,7 +107,8 @@ class WikiDataClient(BaseDataClient[WikiPage]):
 The connector declares its datasource configuration and maps source records to
 `DocumentDefinition` objects.
 
-```python
+```python snippet=quickstart/snippet-06.py
+import os
 from datetime import datetime
 from typing import List
 
@@ -141,7 +144,22 @@ class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
             )
             for page in data
         ]
+
+
+def create_connector() -> CompanyWikiConnector:
+    """Construct the connector from runtime configuration."""
+    return CompanyWikiConnector(
+        name="company_wiki",
+        data_client=WikiDataClient(
+            base_url=os.environ["WIKI_BASE_URL"],
+            api_token=os.environ["WIKI_API_TOKEN"],
+        ),
+    )
 ```
+
+Save the data client, connector, and factory in `connector.py`. The
+zero-argument `create_connector()` factory gives the CLI and generated deployment
+entrypoint one construction path without hardcoding credentials.
 
 :::warning
 `created_at` and `updated_at` are **integers** — Unix epoch seconds. Passing an
@@ -152,9 +170,10 @@ upload error.
 
 ## Test it before you push
 
-Run the connector against a recording mock. No network, no credentials.
+Start with a static data client and a recording Glean mock. This check uses no
+network and needs no credentials:
 
-```python
+```python snippet=quickstart/snippet-07.py
 from glean.indexing.testing import StaticDataClient, run_connector
 
 result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
@@ -171,32 +190,54 @@ result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
 result.assert_documents_posted(count=1, datasource="company_wiki")
 ```
 
+Then move through the CLI phases one at a time. Both `mock` and `integration`
+keep Glean mocked, but they call the connector's real source client; integration
+also records and replays source responses.
+
+```bash snippet=quickstart/snippet-08.sh
+glean-idx test --phase mock --connector connector:create_connector --max-items 5
+glean-idx test --phase integration --connector connector:create_connector --max-items 5
+```
+
+`max_items` limits how many source items each registered client consumes. It is
+not a Glean-side upload cap or a blast-radius guarantee.
+
 See [Testing](/libraries/indexing-sdk/testing/overview) for the full
 three-phase workflow.
 
 ## Register and index
 
-`configure_datasource()` registers the datasource with Glean. You only need it
-on the first run or when the configuration changes.
+Register the datasource after the mocked phases pass. You only need to
+reconfigure it when its configuration changes.
 
-```python
-from glean.indexing.models import IndexingMode
-
-connector = CompanyWikiConnector(
-    name="company_wiki",
-    data_client=WikiDataClient(base_url="https://wiki.company.com", api_token="..."),
-)
-
-connector.configure_datasource()
-connector.index_data(mode=IndexingMode.FULL)
+```bash snippet=quickstart/snippet-09.sh
+glean-idx datasource configure --connector connector:CompanyWikiConnector
 ```
+
+For the first live full crawl, use a disposable datasource and verify the target
+shown by the confirmation prompt. A full live test is a replacement and can
+stale-delete documents it does not produce, so the explicit acknowledgement is
+required:
+
+```bash snippet=quickstart/snippet-10.sh
+glean-idx test --phase live \
+  --connector connector:create_connector \
+  --mode full \
+  --max-items 5 \
+  --allow-destructive-live
+```
+
+Do not rely on `--max-items` to make a shared datasource safe: limiting source
+consumption makes a full replacement partial, which can delete everything not
+included. After validating against a disposable datasource, run the same factory
+for the intended complete crawl with `glean-idx run`.
 
 ## Verify it landed
 
 Indexing is asynchronous — an accepted upload is not yet a searchable
 document. Check status from the CLI:
 
-```bash
+```bash snippet=quickstart/snippet-11.sh
 glean-idx document status --datasource company_wiki --document article page_123 --poll
 ```
 

--- a/docs/libraries/indexing-sdk/status-and-debugging.mdx
+++ b/docs/libraries/indexing-sdk/status-and-debugging.mdx
@@ -16,9 +16,9 @@ Work through it in order. Each step rules out one layer.
 
 <Stages stages={[
   { title: <>Did the connector actually upload it?</>, body: <>Run against a recording mock and print <code>result.documents_posted</code>. If the document isn&rsquo;t there, the bug is in your data client or <code>transform()</code>, not in Glean. Stop here.</> },
-  { title: <>Has it finished indexing?</>, body: <>Run <code>glean-idx document status --poll</code>. If it&rsquo;s still pending, wait &mdash; large uploads take longer.</> },
-  { title: <>Is the datasource healthy?</>, body: <><code>glean-idx datasource status</code> reports uploaded and indexed counts side by side. A gap between them points at rejected documents rather than slow indexing.</> },
-  { title: <>Can the user see it?</>, body: <>If the document is indexed but one person can&rsquo;t find it, it&rsquo;s a permissions problem. <code>glean-idx document access --user them@example.com</code> answers it directly &mdash; a correct-looking ACL is still wrong if the identities it names were never pushed.</> },
+  { title: <>Has it finished indexing?</>, body: <>Run <code>glean-idx document status --datasource NAME --document TYPE ID --poll</code>. If it&rsquo;s still pending, wait &mdash; large uploads take longer.</> },
+  { title: <>Is the datasource healthy?</>, body: <><code>glean-idx datasource status --datasource NAME</code> reports uploaded and indexed counts side by side. A gap between them points at rejected documents rather than slow indexing.</> },
+  { title: <>Can the user see it?</>, body: <>If the document is indexed but one person can&rsquo;t find it, it&rsquo;s a permissions problem. <code>glean-idx document access --datasource NAME --object-type TYPE --id ID --user them@example.com</code> answers it directly &mdash; a correct-looking ACL is still wrong if the identities it names were never pushed.</> },
 ]} />
 
 ## StatusClient
@@ -44,7 +44,7 @@ environment.
 The SDK ships one CLI, `glean-idx`. This needs only credentials, so it runs
 anywhere — including with no install:
 
-```bash
+```bash snippet=status-and-debugging/snippet-02.sh
 glean-idx document status \
   --datasource company_wiki \
   --document article page_123 \
@@ -58,7 +58,7 @@ instead of once.
 
 In Python:
 
-```python
+```python snippet=status-and-debugging/snippet-03.py
 from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import check_documents_status, poll_documents_status
 
@@ -90,8 +90,10 @@ crawl that fetched an incomplete result set. A full crawl deletes anything it
 didn't include.
 
 Look for a partial fetch that was allowed to complete successfully — a source
-error swallowed inside a paging loop, an auth token expiring mid-crawl, a
-`max_items` left set from local testing. Alert on `documents_indexed` dropping
+error swallowed inside a paging loop, an auth token expiring mid-crawl, or a
+`max_items` cap left set from local testing. `max_items` limits source
+consumption; it is not a blast-radius guarantee, and on a full crawl it can make
+the replacement dangerously incomplete. Alert on `documents_indexed` dropping
 sharply between runs; that catches it before the deletion propagates. See
 [Indexing modes](/libraries/indexing-sdk/concepts/indexing-modes).
 

--- a/docs/libraries/indexing-sdk/testing/end-to-end.mdx
+++ b/docs/libraries/indexing-sdk/testing/end-to-end.mdx
@@ -5,14 +5,16 @@ description: Phase 3 - run a connector against a real source and a real Glean in
 
 
 :::tip Run this from the CLI
-`glean-idx test --phase live` runs this phase without writing a test file.
-See the [CLI reference](/libraries/indexing-sdk/cli).
+`glean-idx test --phase live --mode full --allow-destructive-live` runs a full
+live phase without writing a test file. It displays the resolved Glean target
+for confirmation. See the [CLI reference](/libraries/indexing-sdk/cli).
 :::
 
 Phase 3 removes all mocking. The connector fetches from your real source and
 uploads to whatever `GLEAN_SERVER_URL` points at.
 
-```python
+```python snippet=end-to-end/snippet-01.py
+from glean.indexing.models import IndexingMode
 from glean.indexing.testing import TestConfig, TestHarness
 
 harness = TestHarness(
@@ -21,27 +23,40 @@ harness = TestHarness(
     clients={"data_client": real_data_client},
 )
 
-result = harness.run_end_to_end()
+result = harness.run_end_to_end(
+    mode=IndexingMode.FULL,
+    confirm=True,
+    allow_destructive=True,
+    confirmed_target="https://test-company-be.glean.com",
+)
 ```
 
 :::danger
 **This writes real documents to a real Glean instance.** The harness does not
-sandbox the datasource — your connector's own datasource name is used as-is, and
-`run_id_prefix` is logged but does not namespace anything. Point
-`GLEAN_SERVER_URL` at a dedicated test instance. There is no automatic cleanup
-and no guard against a production URL. Tracked in
-[issue #112](https://github.com/gleanwork/glean-indexing-sdk/issues/112).
+sandbox the datasource: your connector's own datasource name is used as-is, and
+`run_id_prefix` is logged but does not namespace anything. There is no automatic
+cleanup.
+
+Programmatic runs refuse to start unless `confirm=True` and
+`allow_destructive=True`; `confirmed_target` also detects a target change between
+review and execution. Those acknowledgements do not identify production for
+you. Point `GLEAN_SERVER_URL` at a dedicated test instance and compare it with
+the confirmed target.
 :::
 
 ## Before you run it
 
 - `GLEAN_SERVER_URL` points at a **test** instance, verified by eye, not by memory.
 - `GLEAN_INDEXING_API_TOKEN` is scoped to the test datasource.
-- `max_items` is set low in `TestConfig` so a mistake stays small.
+- `max_items` is set low in `TestConfig` to limit source consumption.
 - You know how you'll clean up.
 
-Per-client `max_items` limits are applied in Phase 3 too, which is the main thing
-standing between a typo and a full production crawl. Keep them small.
+Per-client `max_items` limits are applied in Phase 3 too, but they only stop
+consuming registered source clients after N items. They do not cap Glean-side
+writes, constrain unregistered clients, or guarantee a small blast radius. With
+`mode=IndexingMode.FULL`, a low limit creates a partial replacement and can
+stale-delete every existing document outside that subset. Use a disposable
+datasource.
 
 ## What it returns
 
@@ -50,8 +65,13 @@ uploaded no documents. Because indexing is asynchronous, an accepted upload is
 not yet a searchable document — the result reflects the indexing outcome, not
 just the HTTP response.
 
-```python
-result = harness.run_end_to_end()
+```python snippet=end-to-end/snippet-02.py
+result = harness.run_end_to_end(
+    mode=IndexingMode.FULL,
+    confirm=True,
+    allow_destructive=True,
+    confirmed_target="https://test-company-be.glean.com",
+)
 
 if result is None:
     raise AssertionError("connector uploaded nothing")
@@ -61,7 +81,7 @@ if result is None:
 
 Poll indexing status for specific documents:
 
-```python
+```python snippet=end-to-end/snippet-03.py
 from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import poll_documents_status
 
@@ -74,7 +94,7 @@ print(snapshot.result)
 
 `check_documents_status()` is the single-shot variant. Or from the shell:
 
-```bash
+```bash snippet=end-to-end/snippet-04.sh
 glean-idx document status --datasource company_wiki --document article page_123 --poll
 ```
 
@@ -101,7 +121,7 @@ incomplete.
 Nothing is cleaned up for you. Write teardown that deletes what the test
 created:
 
-```python
+```python snippet=end-to-end/snippet-06.py
 from glean.indexing.push import PushUploader
 
 uploader = PushUploader(datasource="company_wiki")
@@ -109,14 +129,14 @@ for doc_id in created_ids:
     uploader.delete_document(object_type="article", document_id=doc_id)
 ```
 
-Identity records need explicit deletion too: `delete_user()`, `delete_group()`,
-`delete_membership()`.
+The live harness rejects people connectors and datasource connectors that
+override `get_identities()`, because it cannot automatically reverse identity
+mutations. Test identity payloads with mocked Glean instead.
 
 :::info
-There is no API to delete a datasource *registration*. Teardown removes
-documents, identities, and employees; the empty datasource remains. Re-running
-the connector repopulates it. To remove the datasource entirely, use the Glean
-admin console.
+There is no API to delete a datasource *registration*. Deleting the test
+documents leaves the empty datasource registered. Re-running the connector
+repopulates it. To remove the datasource entirely, use the Glean admin console.
 :::
 
 ## When to run it

--- a/docs/libraries/indexing-sdk/testing/integration.mdx
+++ b/docs/libraries/indexing-sdk/testing/integration.mdx
@@ -17,7 +17,7 @@ That combination is what makes it useful: you validate your data client against
 responses the source actually produced, then re-run those exact responses
 forever, offline and deterministically.
 
-```python
+```python snippet=integration/snippet-01.py
 from glean.indexing.testing import TestConfig, TestHarness
 
 harness = TestHarness(
@@ -34,7 +34,7 @@ result.assert_documents_posted()
 
 `clients` maps **connector attribute names** to data client instances:
 
-```python
+```python snippet=integration/snippet-02.py
 harness = TestHarness(
     connector=my_connector,
     clients={
@@ -53,7 +53,7 @@ recorded.
 
 `testing_config.yaml` at the connector root, with a top-level `testing:` key:
 
-```yaml title="testing_config.yaml"
+```yaml title="testing_config.yaml" snippet=integration/snippet-03.yaml
 testing:
   cache_dir: .glean_test_cache/
   use_cache: true
@@ -75,12 +75,12 @@ testing:
 | `use_cache` | `true` | Replay from cache when a valid fixture exists. |
 | `refresh_cache` | `false` | Force re-recording even on a cache hit. |
 | `run_id_prefix` | `sdk_test` | Prefix for Phase 3 upload run IDs. |
-| `clients.<name>.max_items` | `5` | Records/replays at most N items for that client. `null` disables the cap. |
-| `negative_test_identities` | `[]` | Identities that must **not** appear in any document ACL. |
+| `clients.<name>.max_items` | `5` | Limits source consumption to at most N items for that client. `null` disables the cap. This is not an upload or blast-radius limit. |
+| `negative_test_identities` | `[]` | Identities that must not be able to access any transformed document. |
 
 Load it explicitly, or build one in process:
 
-```python
+```python snippet=integration/snippet-04.py
 config = TestConfig.from_yaml("testing_config.yaml")
 config = TestConfig(cache_dir=".glean_test_cache/", use_cache=True)
 ```
@@ -115,24 +115,33 @@ and cheap to commit.
 
 Raise it for a client whose pagination you specifically want to exercise:
 
-```yaml
+```yaml snippet=integration/snippet-05.yaml
 clients:
   articles_client:
-    max_items: 250     # spans several pages
+    max_items: 250 # spans several pages
 ```
+
+The wrapper stops consuming the registered source client after the cap. It does
+not cap transformed documents at Glean, constrain unregistered clients, or make
+a full replacement safe. Never treat `max_items` as a blast-radius guarantee.
 
 ## Asserting permissions
 
 Identities in `negative_test_identities` are checked against every transformed
-document's ACL after the run. If one appears, the test fails.
+document after the run. The assertion fails when a configured identity appears
+literally in `allowed_users`, `allowed_groups`, or any intersection's
+`required_groups`. It also fails conservatively when `permissions` is missing,
+`allow_anonymous_access=True`, or
+`allow_all_datasource_users_access=True`, because the identity's lack of access
+cannot be established.
 
 This is the cheapest real permissions test you can run: it uses
-production-shaped data, needs no Glean instance, and catches "this ACL field was
-`null` so we defaulted to allow-all" before it reaches an index.
+production-shaped data, needs no Glean instance, and rejects both literal ACL
+leaks and broad access before either reaches an index.
 
 You can also assert positively:
 
-```python
+```python snippet=integration/snippet-06.py
 from glean.indexing.testing import extract_permission_refs
 
 result = harness.run_integration_test()

--- a/docs/libraries/indexing-sdk/testing/overview.mdx
+++ b/docs/libraries/indexing-sdk/testing/overview.mdx
@@ -19,11 +19,25 @@ Most of your tests should be Phase 1. Phase 2 catches the class of bug you can't
 mock your way to — a source field that's `null` more often than the docs
 suggest. Phase 3 is a pre-release check, not something you run on every commit.
 
+From the CLI, move through the phases explicitly:
+
+```bash snippet=overview/snippet-23.sh
+glean-idx test --phase mock --max-items 5
+glean-idx test --phase integration --max-items 5
+glean-idx test --phase live --mode full --max-items 5 --allow-destructive-live
+```
+
+The CLI's mock phase mocks Glean but leaves the connector's source clients
+unchanged; use static clients for a no-network Phase 1. Every live phase requires
+`--allow-destructive-live` and target confirmation. A full live phase replaces
+the datasource, and `max_items` only limits registered source-client
+consumption—it is not a Glean-side cap or blast-radius guarantee.
+
 ## The harness
 
 `TestHarness` wraps a connector and drives all three phases:
 
-```python
+```python snippet=overview/snippet-24.py
 from glean.indexing.testing import TestConfig, TestHarness
 
 harness = TestHarness(

--- a/docs/libraries/indexing-sdk/testing/unit.mdx
+++ b/docs/libraries/indexing-sdk/testing/unit.mdx
@@ -5,8 +5,10 @@ description: Phase 1 - test connectors with a fully mocked Glean client and no n
 
 
 :::tip Run this from the CLI
-`glean-idx test --phase mock` runs this phase without writing a test file.
-See the [CLI reference](/libraries/indexing-sdk/cli).
+`glean-idx test --phase mock` runs this phase without writing a test file and
+mocks Glean. It leaves the connector's source clients unchanged, so use static
+clients when the phase must make no network calls. See the
+[CLI reference](/libraries/indexing-sdk/cli).
 :::
 
 Phase 1 runs your connector end to end with the Glean API mocked and static data
@@ -17,7 +19,7 @@ where most of your connector tests should live.
 
 Pair `run_connector` with a static data client:
 
-```python
+```python snippet=unit/snippet-01.py
 from glean.indexing.testing import StaticDataClient, run_connector
 
 result = run_connector(
@@ -42,7 +44,7 @@ Static clients exist for each connector shape:
 
 ## Assertions
 
-```python
+```python snippet=unit/snippet-02.py
 result.assert_documents_posted(count=2, datasource="my_ds")
 result.assert_employees_posted(count=10)
 result.assert_users_posted(count=5)
@@ -55,7 +57,7 @@ Omit `count` to assert only that something was posted.
 
 For anything more specific, read the recorded objects directly:
 
-```python
+```python snippet=unit/snippet-03.py
 docs = result.documents_posted
 
 assert [d.id for d in docs] == ["1", "2"]
@@ -71,7 +73,7 @@ Available collections: `documents_posted`, `employees_posted`, `users_posted`,
 
 Use the async runner:
 
-```python
+```python snippet=unit/snippet-04.py
 import pytest
 
 from glean.indexing.testing import StaticAsyncStreamingDataClient, run_connector_async
@@ -92,7 +94,7 @@ otherwise get.
 
 ## Testing modes and options
 
-```python
+```python snippet=unit/snippet-05.py
 from glean.indexing.models import ConnectorOptions, IndexingMode
 
 result = run_connector(
@@ -107,7 +109,7 @@ result = run_connector(
 When you need to interleave calls or inspect state between them, use the context
 manager instead:
 
-```python
+```python snippet=unit/snippet-06.py
 from glean.indexing.testing import mock_glean_client
 
 with mock_glean_client() as client:
@@ -122,7 +124,7 @@ The yielded client is a facade over a `MagicMock(spec=Glean)`, so the whole
 generated client surface is reachable — and typos fail loudly rather than
 silently passing:
 
-```python
+```python snippet=unit/snippet-07.py
 client.indexing.documents.bulk_index.assert_called_once()   # real method
 client.indexing.documents.bluk_index                        # AttributeError
 ```
@@ -141,7 +143,7 @@ need manual control.
 The SDK's own suite uses `pytest-socket` to fail any test that opens a socket.
 It's a cheap way to guarantee a "unit" test stayed a unit test:
 
-```bash
+```bash snippet=unit/snippet-08.sh
 pytest -p no:socket tests/unit
 ```
 

--- a/snippets/batching/snippet-01.py
+++ b/snippets/batching/snippet-01.py
@@ -1,0 +1,2 @@
+connector.index_data(mode=IndexingMode.FULL)
+print(connector.observability.get_metrics_summary())

--- a/snippets/batching/snippet-02.py
+++ b/snippets/batching/snippet-02.py
@@ -1,0 +1,2 @@
+connector = WikiConnector(name="wiki", data_client=client)
+connector.batch_size = 250

--- a/snippets/batching/snippet-03.py
+++ b/snippets/batching/snippet-03.py
@@ -1,0 +1,3 @@
+connector.index_data(
+    options=ConnectorOptions(document_batch_size_bytes=2 * 1024 * 1024)
+)

--- a/snippets/batching/snippet-04.py
+++ b/snippets/batching/snippet-04.py
@@ -1,0 +1,5 @@
+# Give large batches longer.
+connector.index_data(options=ConnectorOptions(upload_timeout_ms=120_000))
+
+# Or make the batches smaller.
+connector.batch_size = 250

--- a/snippets/batching/snippet-05.py
+++ b/snippets/batching/snippet-05.py
@@ -1,0 +1,1 @@
+connector.index_data(options=ConnectorOptions(upload_max_workers=10))

--- a/snippets/cli/snippet-01.sh
+++ b/snippets/cli/snippet-01.sh
@@ -1,0 +1,7 @@
+glean-idx doctor                    # are my credentials right?
+glean-idx validate ./my-connector   # is the plan complete, before writing code?
+glean-idx test --phase mock         # Glean mocked; connector source clients unchanged
+glean-idx test --phase integration  # real source, recorded/replayed; Glean mocked
+glean-idx run --mode incremental    # additive crawl for real
+glean-idx datasource status --datasource company_wiki
+glean-idx deploy init --cloud gcp   # Docker and Terraform for a CronJob

--- a/snippets/cli/snippet-02.sh
+++ b/snippets/cli/snippet-02.sh
@@ -1,0 +1,1 @@
+uvx --from glean-indexing-sdk glean-idx doctor

--- a/snippets/cli/snippet-03.sh
+++ b/snippets/cli/snippet-03.sh
@@ -1,0 +1,1 @@
+uv run glean-idx run

--- a/snippets/cli/snippet-04.sh
+++ b/snippets/cli/snippet-04.sh
@@ -1,0 +1,2 @@
+glean-idx test --phase live --mode full --allow-destructive-live
+glean-idx test --phase all --allow-destructive-live

--- a/snippets/cli/snippet-05.sh
+++ b/snippets/cli/snippet-05.sh
@@ -1,0 +1,1 @@
+glean-idx datasource status --datasource company_wiki --output json | jq .data.documents

--- a/snippets/cli/snippet-06.sh
+++ b/snippets/cli/snippet-06.sh
@@ -1,0 +1,1 @@
+glean-idx completion zsh >> ~/.zshrc      # or bash, fish

--- a/snippets/connector-types/snippet-01.py
+++ b/snippets/connector-types/snippet-01.py
@@ -1,0 +1,10 @@
+class WikiDataClient(BaseDataClient[WikiPage]):
+    def get_source_data(self, since=None, **kwargs):
+        return fetch_all_pages()
+
+
+class WikiConnector(BaseDatasourceConnector[WikiPage]):
+    configuration = CustomDatasourceConfig(name="wiki", display_name="Wiki")
+
+    def transform(self, data):
+        return [to_document(page) for page in data]

--- a/snippets/connector-types/snippet-02.py
+++ b/snippets/connector-types/snippet-02.py
@@ -1,0 +1,24 @@
+from collections.abc import Generator
+
+from glean.indexing.connectors import (
+    BaseStreamingDataClient,
+    BaseStreamingDatasourceConnector,
+)
+
+
+class ArticleDataClient(BaseStreamingDataClient[Article]):
+    def get_source_data(self, **kwargs) -> Generator[Article, None, None]:
+        page = 1
+        while True:
+            batch = fetch_page(page)
+            if not batch:
+                return
+            yield from batch
+            page += 1
+
+
+class ArticleConnector(BaseStreamingDatasourceConnector[Article]):
+    configuration = CustomDatasourceConfig(name="articles", display_name="Articles")
+
+    def transform(self, data):
+        return [to_document(article) for article in data]

--- a/snippets/connector-types/snippet-04.py
+++ b/snippets/connector-types/snippet-04.py
@@ -1,0 +1,5 @@
+class EmployeeConnector(BasePeopleConnector[EmployeeRecord]):
+    configuration = CustomDatasourceConfig(name="hris", display_name="HRIS")
+
+    def transform(self, data):
+        return [to_employee(record) for record in data]

--- a/snippets/connector-types/snippet-05.py
+++ b/snippets/connector-types/snippet-05.py
@@ -1,0 +1,2 @@
+connector = WikiConnector(name="wiki", data_client=client)
+connector.batch_size = 250

--- a/snippets/data-clients/snippet-01.py
+++ b/snippets/data-clients/snippet-01.py
@@ -1,0 +1,6 @@
+from glean.indexing.connectors import BaseDataClient
+
+
+class WikiDataClient(BaseDataClient[WikiPage]):
+    def get_source_data(self, since=None, **kwargs):
+        return fetch_all_pages()

--- a/snippets/data-clients/snippet-02.py
+++ b/snippets/data-clients/snippet-02.py
@@ -1,0 +1,14 @@
+from glean.indexing.recipes.pull import BasePullHttpStreamingDataClient, PullOptions
+
+
+class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
+    def __init__(self, token: str):
+        super().__init__(
+            base_url="https://api.example.com/v2",
+            path="/articles",
+            items_key="items",
+            pagination="link",
+            page_size=100,
+            headers={"Authorization": f"Bearer {token}"},
+            options=PullOptions(timeout_seconds=30.0),
+        )

--- a/snippets/data-clients/snippet-04.py
+++ b/snippets/data-clients/snippet-04.py
@@ -1,0 +1,5 @@
+class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
+    def get_source_data(self, **kwargs):
+        for article in super().get_source_data(**kwargs):
+            detail = self.http.get(f"/articles/{article['id']}")
+            yield {**article, "body": detail.json_dict()["body"]}

--- a/snippets/data-clients/snippet-05.py
+++ b/snippets/data-clients/snippet-05.py
@@ -1,0 +1,4 @@
+try:
+    connector.index_data(mode=IndexingMode.FULL)
+finally:
+    data_client.close()

--- a/snippets/data-clients/snippet-06.py
+++ b/snippets/data-clients/snippet-06.py
@@ -1,0 +1,1 @@
+ArticleDataClient(token, max_items=25)

--- a/snippets/end-to-end/snippet-01.py
+++ b/snippets/end-to-end/snippet-01.py
@@ -1,0 +1,15 @@
+from glean.indexing.models import IndexingMode
+from glean.indexing.testing import TestConfig, TestHarness
+
+harness = TestHarness(
+    connector=my_connector,
+    config=TestConfig.from_yaml("testing_config.yaml"),
+    clients={"data_client": real_data_client},
+)
+
+result = harness.run_end_to_end(
+    mode=IndexingMode.FULL,
+    confirm=True,
+    allow_destructive=True,
+    confirmed_target="https://test-company-be.glean.com",
+)

--- a/snippets/end-to-end/snippet-02.py
+++ b/snippets/end-to-end/snippet-02.py
@@ -1,0 +1,9 @@
+result = harness.run_end_to_end(
+    mode=IndexingMode.FULL,
+    confirm=True,
+    allow_destructive=True,
+    confirmed_target="https://test-company-be.glean.com",
+)
+
+if result is None:
+    raise AssertionError("connector uploaded nothing")

--- a/snippets/end-to-end/snippet-03.py
+++ b/snippets/end-to-end/snippet-03.py
@@ -1,0 +1,8 @@
+from glean.api_client.models import DebugDocumentRequest
+from glean.indexing.testing import poll_documents_status
+
+snapshot = poll_documents_status(
+    "company_wiki",
+    [DebugDocumentRequest(object_type="article", doc_id="page_123")],
+)
+print(snapshot.result)

--- a/snippets/end-to-end/snippet-04.sh
+++ b/snippets/end-to-end/snippet-04.sh
@@ -1,0 +1,1 @@
+glean-idx document status --datasource company_wiki --document article page_123 --poll

--- a/snippets/end-to-end/snippet-06.py
+++ b/snippets/end-to-end/snippet-06.py
@@ -1,0 +1,5 @@
+from glean.indexing.push import PushUploader
+
+uploader = PushUploader(datasource="company_wiki")
+for doc_id in created_ids:
+    uploader.delete_document(object_type="article", document_id=doc_id)

--- a/snippets/error-handling/snippet-01.py
+++ b/snippets/error-handling/snippet-01.py
@@ -1,0 +1,8 @@
+from glean.indexing.exceptions import GleanError
+
+try:
+    connector.index_data(mode=IndexingMode.FULL)
+except GleanError as error:
+    print(error)            # message + "How to fix:" + "Documentation:"
+    print(error.fix_suggestion)
+    print(error.docs_url)

--- a/snippets/error-handling/snippet-03.py
+++ b/snippets/error-handling/snippet-03.py
@@ -1,0 +1,9 @@
+def get_source_data(self, **kwargs):
+    for summary in self.list_articles():        # raises on failure — correct
+        try:
+            yield self.fetch_detail(summary["id"])
+        except PullHttpError as error:
+            if error.status_code == 404:
+                logger.warning("Article %s vanished mid-crawl", summary["id"])
+                continue
+            raise

--- a/snippets/error-handling/snippet-04.py
+++ b/snippets/error-handling/snippet-04.py
@@ -1,0 +1,4 @@
+connector.index_data(
+    mode=IndexingMode.FULL,
+    options=ConnectorOptions(force_restart=True),
+)

--- a/snippets/error-handling/snippet-05.py
+++ b/snippets/error-handling/snippet-05.py
@@ -1,0 +1,5 @@
+try:
+    connector.index_data(mode=IndexingMode.FULL)
+except Exception:
+    logger.exception("Crawl failed")
+    raise                      # let the scheduler see a non-zero exit

--- a/snippets/http-client/snippet-01.py
+++ b/snippets/http-client/snippet-01.py
@@ -1,0 +1,9 @@
+from glean.indexing.recipes.pull import PullHttpClient, PullOptions
+
+with PullHttpClient(
+    base_url="https://api.example.com/v2",
+    headers={"Authorization": f"Bearer {token}"},
+    options=PullOptions(timeout_seconds=30.0),
+) as http:
+    response = http.get("/articles", params={"limit": 100})
+    articles = response.json_dict()["items"]

--- a/snippets/http-client/snippet-02.py
+++ b/snippets/http-client/snippet-02.py
@@ -1,0 +1,5 @@
+response.status_code   # int
+response.headers       # dict[str, str]
+response.url           # str
+response.json_dict()   # dict — raises TypeError if the body was a list
+response.json_list()   # list — raises TypeError if the body was an object

--- a/snippets/http-client/snippet-03.py
+++ b/snippets/http-client/snippet-03.py
@@ -1,0 +1,13 @@
+options = PullOptions(
+    timeout_seconds=30.0,
+    retries=PullRetryOptions(
+        max_attempts=5,
+        initial_backoff_seconds=1.0,
+        max_backoff_seconds=60.0,
+        backoff_multiplier=2.0,
+        retry_status_codes={429, 500, 502, 503, 504},
+        retry_connection_errors=True,
+        respect_retry_after=True,
+        jitter_seconds=1.0,
+    ),
+)

--- a/snippets/http-client/snippet-05.py
+++ b/snippets/http-client/snippet-05.py
@@ -1,0 +1,1 @@
+content, content_type = http.get_bytes("/attachments/42", max_bytes=10 * 1024 * 1024)

--- a/snippets/indexing-modes/snippet-01.py
+++ b/snippets/indexing-modes/snippet-01.py
@@ -1,0 +1,4 @@
+from glean.indexing.models import IndexingMode
+
+connector.index_data(mode=IndexingMode.FULL)
+connector.index_data(mode=IndexingMode.INCREMENTAL)

--- a/snippets/indexing-modes/snippet-02.py
+++ b/snippets/indexing-modes/snippet-02.py
@@ -1,0 +1,5 @@
+class WikiDataClient(BaseDataClient[WikiPage]):
+    def get_source_data(self, since=None, **kwargs):
+        if since:
+            return fetch_pages_modified_after(since)
+        return fetch_all_pages()

--- a/snippets/indexing-modes/snippet-03.py
+++ b/snippets/indexing-modes/snippet-03.py
@@ -1,0 +1,9 @@
+class WikiConnector(BaseDatasourceConnector[WikiPage]):
+    def _get_last_crawl_timestamp(self):
+        # your storage: file, S3, DynamoDB, database
+        return read_checkpoint("company_wiki")
+
+    def index_data(self, mode=IndexingMode.FULL, options=None):
+        started_at = datetime.now(timezone.utc).isoformat()
+        super().index_data(mode=mode, options=options)
+        write_checkpoint("company_wiki", started_at)  # only on success

--- a/snippets/indexing-modes/snippet-04.py
+++ b/snippets/indexing-modes/snippet-04.py
@@ -1,0 +1,6 @@
+from glean.indexing.models import ConnectorOptions
+
+connector.index_data(
+    mode=IndexingMode.FULL,
+    options=ConnectorOptions(force_restart=True),
+)

--- a/snippets/integration/snippet-01.py
+++ b/snippets/integration/snippet-01.py
@@ -1,0 +1,10 @@
+from glean.indexing.testing import TestConfig, TestHarness
+
+harness = TestHarness(
+    connector=my_connector,
+    config=TestConfig.from_yaml("testing_config.yaml"),
+    clients={"data_client": real_data_client},
+)
+
+result = harness.run_integration_test()
+result.assert_documents_posted()

--- a/snippets/integration/snippet-02.py
+++ b/snippets/integration/snippet-02.py
@@ -1,0 +1,7 @@
+harness = TestHarness(
+    connector=my_connector,
+    clients={
+        "data_client": articles_client,
+        "comments_client": comments_client,
+    },
+)

--- a/snippets/integration/snippet-03.yaml
+++ b/snippets/integration/snippet-03.yaml
@@ -1,0 +1,13 @@
+testing:
+  cache_dir: .glean_test_cache/
+  use_cache: true
+  refresh_cache: false
+  run_id_prefix: sdk_test
+  clients:
+    data_client:
+      max_items: 5
+    comments_client:
+      max_items: 20
+  negative_test_identities:
+    - contractor@example.com
+    - external-partners

--- a/snippets/integration/snippet-04.py
+++ b/snippets/integration/snippet-04.py
@@ -1,0 +1,2 @@
+config = TestConfig.from_yaml("testing_config.yaml")
+config = TestConfig(cache_dir=".glean_test_cache/", use_cache=True)

--- a/snippets/integration/snippet-05.yaml
+++ b/snippets/integration/snippet-05.yaml
@@ -1,0 +1,3 @@
+clients:
+  articles_client:
+    max_items: 250 # spans several pages

--- a/snippets/integration/snippet-06.py
+++ b/snippets/integration/snippet-06.py
@@ -1,0 +1,7 @@
+from glean.indexing.testing import extract_permission_refs
+
+result = harness.run_integration_test()
+refs = extract_permission_refs(result.documents_posted)
+
+assert "engineering" in refs.group_ids
+assert "contractor@example.com" not in refs.user_ids

--- a/snippets/observability/snippet-01.py
+++ b/snippets/observability/snippet-01.py
@@ -1,0 +1,2 @@
+connector.index_data(mode=IndexingMode.FULL)
+print(connector.observability.get_metrics_summary())

--- a/snippets/observability/snippet-02.py
+++ b/snippets/observability/snippet-02.py
@@ -1,0 +1,3 @@
+from glean.indexing.observability import setup_connector_logging
+
+setup_connector_logging("company_wiki", log_level="INFO")

--- a/snippets/observability/snippet-03.py
+++ b/snippets/observability/snippet-03.py
@@ -1,0 +1,8 @@
+from glean.indexing.observability import ConnectorObservability, InMemoryMetricsProvider
+
+observability = ConnectorObservability(
+    connector_name="company_wiki",
+    datasource="company_wiki",
+    crawl_mode="full",
+    metrics_provider=InMemoryMetricsProvider(),
+)

--- a/snippets/observability/snippet-04.sh
+++ b/snippets/observability/snippet-04.sh
@@ -1,0 +1,1 @@
+pip install "glean-indexing-sdk[aws]"

--- a/snippets/observability/snippet-05.py
+++ b/snippets/observability/snippet-05.py
@@ -1,0 +1,23 @@
+from glean.indexing.observability import ConnectorObservability, setup_connector_logging
+from glean.indexing.observability.plugins.aws import (
+    CloudWatchLogsProvider,
+    CloudWatchMetricsProvider,
+)
+
+setup_connector_logging(
+    "company_wiki",
+    logger_provider=CloudWatchLogsProvider(
+        log_group="/glean/connectors",
+        log_stream="company_wiki",
+        region_name="us-east-1",
+    ),
+)
+
+observability = ConnectorObservability(
+    connector_name="company_wiki",
+    metrics_provider=CloudWatchMetricsProvider(
+        namespace="GleanConnectors",
+        region_name="us-east-1",
+        dimensions={"connector": "company_wiki"},
+    ),
+)

--- a/snippets/observability/snippet-06.sh
+++ b/snippets/observability/snippet-06.sh
@@ -1,0 +1,1 @@
+pip install "glean-indexing-sdk[gcp]"

--- a/snippets/observability/snippet-07.py
+++ b/snippets/observability/snippet-07.py
@@ -1,0 +1,4 @@
+from glean.indexing.observability.plugins.gcp import (
+    CloudLoggingProvider,
+    CloudMonitoringProvider,
+)

--- a/snippets/observability/snippet-09.py
+++ b/snippets/observability/snippet-09.py
@@ -1,0 +1,8 @@
+obs = connector.observability
+
+obs.start_timer("enrichment")
+enrich(documents)
+obs.end_timer("enrichment")
+
+obs.record_metric("enriched_documents", len(documents))
+obs.increment_counter("enrichment_failures")

--- a/snippets/overview/snippet-21.sh
+++ b/snippets/overview/snippet-21.sh
@@ -1,0 +1,3 @@
+glean-idx deploy init --cloud gcp \
+  --connector-class CompanyWikiConnector \
+  --connector-factory create_connector

--- a/snippets/overview/snippet-22.sh
+++ b/snippets/overview/snippet-22.sh
@@ -1,0 +1,1 @@
+glean-idx deploy destroy

--- a/snippets/overview/snippet-23.sh
+++ b/snippets/overview/snippet-23.sh
@@ -1,0 +1,3 @@
+glean-idx test --phase mock --max-items 5
+glean-idx test --phase integration --max-items 5
+glean-idx test --phase live --mode full --max-items 5 --allow-destructive-live

--- a/snippets/overview/snippet-24.py
+++ b/snippets/overview/snippet-24.py
@@ -1,0 +1,7 @@
+from glean.indexing.testing import TestConfig, TestHarness
+
+harness = TestHarness(
+    connector=my_connector,
+    config=TestConfig(),
+    clients={"data_client": real_data_client},   # required for Phase 2 and 3
+)

--- a/snippets/pagination/snippet-01.py
+++ b/snippets/pagination/snippet-01.py
@@ -1,0 +1,6 @@
+super().__init__(
+    base_url="https://api.example.com/v2",
+    path="/articles",
+    pagination="link",
+    page_size=100,
+)

--- a/snippets/pagination/snippet-02.py
+++ b/snippets/pagination/snippet-02.py
@@ -1,0 +1,9 @@
+super().__init__(
+    base_url="https://api.example.com/v2",
+    path="/articles",
+    pagination="offset",
+    page_size=100,        # required, must be > 0
+    offset_param="offset",
+    limit_param="limit",
+    start_offset=0,
+)

--- a/snippets/pagination/snippet-03.py
+++ b/snippets/pagination/snippet-03.py
@@ -1,0 +1,8 @@
+super().__init__(
+    base_url="https://api.example.com/v2",
+    path="/articles",
+    pagination="cursor",
+    cursor_param="cursor",       # request parameter name
+    cursor_key="next_cursor",    # response body key
+    page_size=100,
+)

--- a/snippets/pagination/snippet-06.py
+++ b/snippets/pagination/snippet-06.py
@@ -1,0 +1,10 @@
+class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
+    def get_source_data(self, **kwargs):
+        page = 1
+        while True:
+            response = self.http.get(self.path, params={"page": page, "per_page": 100})
+            body = response.json_dict()
+            yield from body["items"]
+            if not body.get("has_more"):
+                return
+            page += 1

--- a/snippets/permissions/snippet-01.py
+++ b/snippets/permissions/snippet-01.py
@@ -1,0 +1,30 @@
+from glean.api_client.models import (
+    DocumentDefinition,
+    DocumentPermissionsDefinition,
+    PermissionsGroupIntersectionDefinition,
+    UserReferenceDefinition,
+)
+
+
+def transform(self, data):
+    return [
+        DocumentDefinition(
+            id=article["id"],
+            title=article["title"],
+            datasource=self.name,
+            view_url=article["url"],
+            permissions=DocumentPermissionsDefinition(
+                allowed_groups=article["visible_to_groups"],
+                allowed_users=[
+                    UserReferenceDefinition(email=email)
+                    for email in article["visible_to_users"]
+                ],
+                allowed_group_intersections=[
+                    PermissionsGroupIntersectionDefinition(
+                        required_groups=["engineering", "employees"]
+                    )
+                ],
+            ),
+        )
+        for article in data
+    ]

--- a/snippets/permissions/snippet-02.py
+++ b/snippets/permissions/snippet-02.py
@@ -1,0 +1,9 @@
+from glean.indexing.models import DatasourceIdentityDefinitions
+
+
+def get_identities(self) -> DatasourceIdentityDefinitions:
+    return DatasourceIdentityDefinitions(
+        users=fetch_users(),
+        groups=fetch_groups(),
+        memberships=fetch_memberships(),
+    )

--- a/snippets/permissions/snippet-03.py
+++ b/snippets/permissions/snippet-03.py
@@ -1,0 +1,5 @@
+configuration = CustomDatasourceConfig(
+    name="company_wiki",
+    display_name="Company Wiki",
+    is_user_referenced_by_email=True,
+)

--- a/snippets/permissions/snippet-04.yaml
+++ b/snippets/permissions/snippet-04.yaml
@@ -1,0 +1,4 @@
+testing:
+  negative_test_identities:
+    - contractor@example.com
+    - external-partners

--- a/snippets/permissions/snippet-05.py
+++ b/snippets/permissions/snippet-05.py
@@ -1,0 +1,7 @@
+from glean.indexing.testing import assert_negative_identities_absent, extract_permission_refs
+
+result = run_connector(connector)
+refs = extract_permission_refs(result.documents_posted)
+
+assert "engineering" in refs.group_ids
+assert_negative_identities_absent(result.documents_posted, ["contractor@example.com"])

--- a/snippets/quickstart/snippet-01.sh
+++ b/snippets/quickstart/snippet-01.sh
@@ -1,0 +1,1 @@
+pip install glean-indexing-sdk

--- a/snippets/quickstart/snippet-02.sh
+++ b/snippets/quickstart/snippet-02.sh
@@ -1,0 +1,2 @@
+pip install "glean-indexing-sdk[aws]"   # CloudWatch logs + metrics
+pip install "glean-indexing-sdk[gcp]"   # Cloud Logging + Cloud Monitoring

--- a/snippets/quickstart/snippet-03.sh
+++ b/snippets/quickstart/snippet-03.sh
@@ -1,0 +1,4 @@
+export GLEAN_SERVER_URL="https://your-company-be.glean.com"
+export GLEAN_INDEXING_API_TOKEN="your-indexing-api-token"
+export WIKI_BASE_URL="https://wiki.company.com"
+export WIKI_API_TOKEN="your-source-api-token"

--- a/snippets/quickstart/snippet-04.sh
+++ b/snippets/quickstart/snippet-04.sh
@@ -1,0 +1,2 @@
+npx tiged --mode=git gleanwork/glean-cookbook/examples/sample-catalog sample-catalog
+cd sample-catalog && cat README.md

--- a/snippets/quickstart/snippet-05.py
+++ b/snippets/quickstart/snippet-05.py
@@ -1,0 +1,31 @@
+from typing import Any, Optional, Sequence, TypedDict
+
+from glean.indexing.connectors import BaseDataClient
+
+
+class WikiPage(TypedDict):
+    id: str
+    title: str
+    content: str
+    author: str
+    updated_at: str
+    url: str
+
+
+class WikiDataClient(BaseDataClient[WikiPage]):
+    def __init__(self, base_url: str, api_token: str):
+        self.base_url = base_url
+        self.api_token = api_token
+
+    def get_source_data(self, since: Optional[str] = None, **kwargs: Any) -> Sequence[WikiPage]:
+        # Replace with a real API call against your source.
+        return [
+            {
+                "id": "page_123",
+                "title": "Engineering Onboarding Guide",
+                "content": "Welcome to the engineering team...",
+                "author": "jane.smith@company.com",
+                "updated_at": "2026-02-01T14:30:00Z",
+                "url": f"{self.base_url}/pages/123",
+            }
+        ]

--- a/snippets/quickstart/snippet-06.py
+++ b/snippets/quickstart/snippet-06.py
@@ -1,0 +1,47 @@
+import os
+from datetime import datetime
+from typing import List
+
+from glean.indexing.connectors import BaseDatasourceConnector
+from glean.indexing.models import (
+    ContentDefinition,
+    CustomDatasourceConfig,
+    DocumentDefinition,
+    UserReferenceDefinition,
+)
+
+
+class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
+    configuration = CustomDatasourceConfig(
+        name="company_wiki",
+        display_name="Company Wiki",
+        url_regex=r"https://wiki\.company\.com/.*",
+        is_user_referenced_by_email=True,
+    )
+
+    def transform(self, data: Sequence[WikiPage]) -> List[DocumentDefinition]:
+        return [
+            DocumentDefinition(
+                id=page["id"],
+                title=page["title"],
+                datasource=self.name,
+                view_url=page["url"],
+                body=ContentDefinition(mime_type="text/plain", text_content=page["content"]),
+                author=UserReferenceDefinition(email=page["author"]),
+                updated_at=int(
+                    datetime.fromisoformat(page["updated_at"].replace("Z", "+00:00")).timestamp()
+                ),
+            )
+            for page in data
+        ]
+
+
+def create_connector() -> CompanyWikiConnector:
+    """Construct the connector from runtime configuration."""
+    return CompanyWikiConnector(
+        name="company_wiki",
+        data_client=WikiDataClient(
+            base_url=os.environ["WIKI_BASE_URL"],
+            api_token=os.environ["WIKI_API_TOKEN"],
+        ),
+    )

--- a/snippets/quickstart/snippet-07.py
+++ b/snippets/quickstart/snippet-07.py
@@ -1,0 +1,14 @@
+from glean.indexing.testing import StaticDataClient, run_connector
+
+result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
+    {
+        "id": "page_123",
+        "title": "Engineering Onboarding Guide",
+        "content": "Welcome...",
+        "author": "jane.smith@company.com",
+        "updated_at": "2026-02-01T14:30:00Z",
+        "url": "https://wiki.company.com/pages/123",
+    }
+])))
+
+result.assert_documents_posted(count=1, datasource="company_wiki")

--- a/snippets/quickstart/snippet-08.sh
+++ b/snippets/quickstart/snippet-08.sh
@@ -1,0 +1,2 @@
+glean-idx test --phase mock --connector connector:create_connector --max-items 5
+glean-idx test --phase integration --connector connector:create_connector --max-items 5

--- a/snippets/quickstart/snippet-09.sh
+++ b/snippets/quickstart/snippet-09.sh
@@ -1,0 +1,1 @@
+glean-idx datasource configure --connector connector:CompanyWikiConnector

--- a/snippets/quickstart/snippet-10.sh
+++ b/snippets/quickstart/snippet-10.sh
@@ -1,0 +1,5 @@
+glean-idx test --phase live \
+  --connector connector:create_connector \
+  --mode full \
+  --max-items 5 \
+  --allow-destructive-live

--- a/snippets/quickstart/snippet-11.sh
+++ b/snippets/quickstart/snippet-11.sh
@@ -1,0 +1,1 @@
+glean-idx document status --datasource company_wiki --document article page_123 --poll

--- a/snippets/rate-limiting/snippet-01.py
+++ b/snippets/rate-limiting/snippet-01.py
@@ -1,0 +1,17 @@
+from glean.indexing.recipes.pull import (
+    BasePullHttpStreamingDataClient,
+    TokenBucketRateLimiter,
+)
+
+
+class ArticleDataClient(BasePullHttpStreamingDataClient[Article]):
+    def __init__(self, token: str):
+        super().__init__(
+            base_url="https://api.example.com/v2",
+            path="/articles",
+            headers={"Authorization": f"Bearer {token}"},
+            rate_limiter=TokenBucketRateLimiter(
+                rate_per_second=10,
+                capacity=20,
+            ),
+        )

--- a/snippets/rate-limiting/snippet-02.py
+++ b/snippets/rate-limiting/snippet-02.py
@@ -1,0 +1,4 @@
+shared = TokenBucketRateLimiter(rate_per_second=10, capacity=20)
+
+articles = ArticleDataClient(token, rate_limiter=shared)
+comments = CommentDataClient(token, rate_limiter=shared)

--- a/snippets/rate-limiting/snippet-03.py
+++ b/snippets/rate-limiting/snippet-03.py
@@ -1,0 +1,3 @@
+from glean.indexing.recipes.pull import PullOptions
+
+options = PullOptions(rate_limit_timeout_seconds=30.0)

--- a/snippets/rate-limiting/snippet-04.py
+++ b/snippets/rate-limiting/snippet-04.py
@@ -1,0 +1,8 @@
+super().__init__(
+    base_url="https://api.example.com/v2",
+    path="/articles",
+    rate_limiter=TokenBucketRateLimiter(rate_per_second=10, capacity=20),
+    options=PullOptions(
+        retries=PullRetryOptions(max_attempts=5, respect_retry_after=True),
+    ),
+)

--- a/snippets/status-and-debugging/snippet-02.sh
+++ b/snippets/status-and-debugging/snippet-02.sh
@@ -1,0 +1,5 @@
+glean-idx document status \
+  --datasource company_wiki \
+  --document article page_123 \
+  --document article page_124 \
+  --poll

--- a/snippets/status-and-debugging/snippet-03.py
+++ b/snippets/status-and-debugging/snippet-03.py
@@ -1,0 +1,8 @@
+from glean.api_client.models import DebugDocumentRequest
+from glean.indexing.testing import check_documents_status, poll_documents_status
+
+snapshot = poll_documents_status(
+    "company_wiki",
+    [DebugDocumentRequest(object_type="article", doc_id="page_123")],
+)
+print(snapshot.result)

--- a/snippets/unit/snippet-01.py
+++ b/snippets/unit/snippet-01.py
@@ -1,0 +1,10 @@
+from glean.indexing.testing import StaticDataClient, run_connector
+
+result = run_connector(
+    MyConnector("my_ds", StaticDataClient([
+        {"id": "1", "title": "Doc 1", "url": "https://example.com/1"},
+        {"id": "2", "title": "Doc 2", "url": "https://example.com/2"},
+    ]))
+)
+
+result.assert_documents_posted(count=2, datasource="my_ds")

--- a/snippets/unit/snippet-02.py
+++ b/snippets/unit/snippet-02.py
@@ -1,0 +1,6 @@
+result.assert_documents_posted(count=2, datasource="my_ds")
+result.assert_employees_posted(count=10)
+result.assert_users_posted(count=5)
+result.assert_groups_posted(count=2)
+result.assert_memberships_posted(count=8)
+result.assert_datasource_configured(name="my_ds")

--- a/snippets/unit/snippet-03.py
+++ b/snippets/unit/snippet-03.py
@@ -1,0 +1,6 @@
+docs = result.documents_posted
+
+assert [d.id for d in docs] == ["1", "2"]
+assert docs[0].title == "Doc 1"
+assert docs[0].body.text_content.startswith("Welcome")
+assert docs[0].updated_at == 1769956200        # epoch seconds, not a string

--- a/snippets/unit/snippet-04.py
+++ b/snippets/unit/snippet-04.py
@@ -1,0 +1,11 @@
+import pytest
+
+from glean.indexing.testing import StaticAsyncStreamingDataClient, run_connector_async
+
+
+@pytest.mark.asyncio
+async def test_async_connector():
+    result = await run_connector_async(
+        MyAsyncConnector("my_ds", StaticAsyncStreamingDataClient(fixtures))
+    )
+    result.assert_documents_posted(count=10)

--- a/snippets/unit/snippet-05.py
+++ b/snippets/unit/snippet-05.py
@@ -1,0 +1,7 @@
+from glean.indexing.models import ConnectorOptions, IndexingMode
+
+result = run_connector(
+    connector,
+    mode=IndexingMode.INCREMENTAL,
+    options=ConnectorOptions(force_restart=True),
+)

--- a/snippets/unit/snippet-06.py
+++ b/snippets/unit/snippet-06.py
@@ -1,0 +1,8 @@
+from glean.indexing.testing import mock_glean_client
+
+with mock_glean_client() as client:
+    connector.configure_datasource()
+    connector.index_data(mode=IndexingMode.INCREMENTAL)
+
+    client.assert_datasource_configured(name="my_ds")
+    client.assert_documents_posted(count=2)

--- a/snippets/unit/snippet-07.py
+++ b/snippets/unit/snippet-07.py
@@ -1,0 +1,2 @@
+client.indexing.documents.bulk_index.assert_called_once()   # real method
+client.indexing.documents.bluk_index                        # AttributeError

--- a/snippets/unit/snippet-08.sh
+++ b/snippets/unit/snippet-08.sh
@@ -1,0 +1,1 @@
+pytest -p no:socket tests/unit

--- a/snippets/uploader/snippet-01.py
+++ b/snippets/uploader/snippet-01.py
@@ -1,0 +1,4 @@
+from glean.indexing.push import PushUploader
+
+uploader = PushUploader(datasource="company_wiki")
+uploader.bulk_index_documents(documents)

--- a/snippets/uploader/snippet-02.py
+++ b/snippets/uploader/snippet-02.py
@@ -1,0 +1,5 @@
+uploader.bulk_index_documents(
+    documents,
+    batch_size=1000,
+    max_batch_bytes=5 * 1024 * 1024,
+)

--- a/snippets/uploader/snippet-03.py
+++ b/snippets/uploader/snippet-03.py
@@ -1,0 +1,1 @@
+uploader.index_documents(documents)

--- a/snippets/uploader/snippet-04.py
+++ b/snippets/uploader/snippet-04.py
@@ -1,0 +1,1 @@
+uploader.delete_document(object_type="article", document_id="page_123")

--- a/snippets/uploader/snippet-05.py
+++ b/snippets/uploader/snippet-05.py
@@ -1,0 +1,1 @@
+uploader.bulk_index_document_batches(batches, batch_count=len(batches))

--- a/snippets/uploader/snippet-06.py
+++ b/snippets/uploader/snippet-06.py
@@ -1,0 +1,3 @@
+uploader.bulk_index_users(users=users, batch_size=1000)
+uploader.bulk_index_groups(groups=groups, batch_size=1000)
+uploader.bulk_index_memberships(memberships=memberships, batch_size=1000)

--- a/snippets/uploader/snippet-07.py
+++ b/snippets/uploader/snippet-07.py
@@ -1,0 +1,1 @@
+uploader.bulk_index_employees(employees=employees, batch_size=1000)

--- a/snippets/uploader/snippet-08.py
+++ b/snippets/uploader/snippet-08.py
@@ -1,0 +1,1 @@
+uploader = PushUploader(datasource="company_wiki", upload_max_workers=10)


### PR DESCRIPTION
## Summary

Bounded pre-GA review of the feature-flagged Python Indexing SDK documentation.

- correct documented CLI, testing, permission, batching, observability, indexing-mode, and deployment behavior against SDK `main`
- add a zero-argument connector factory and safe mock → integration → disposable-live quickstart
- document exact per-secret deployment access from gleanwork/glean-indexing-sdk#197
- document additive incremental uploads and empty-full reconciliation from gleanwork/glean-indexing-sdk#195
- document strict negative-identity checks from gleanwork/glean-indexing-sdk#196
- extract 97 executable examples into markdown-code source files

The large file count is mechanical: 20 existing docs plus 97 extracted snippet sources.

## Verification

- scoped `md-code check`: passed
- 72 extracted Python snippets: AST parse passed
- 22 extracted shell snippets: `bash -n` passed
- assembled quickstart data client + connector + mock test: executed successfully against the SDK
- `pnpm build`: passed
- `git diff --check`: passed
- no files outside Indexing SDK docs/generated snippet sources changed

— sent via Glean Desktop