### PR TITLE
docs(indexing-sdk): document managed deployment workflows

### DIFF
--- a/docs/libraries/indexing-sdk/cli.mdx
+++ b/docs/libraries/indexing-sdk/cli.mdx
@@ -13,14 +13,14 @@ glean-idx validate ./my-connector   # is the plan complete, before writing code?
 glean-idx test --phase mock         # Glean mocked; connector source clients unchanged
 glean-idx test --phase integration  # real source, recorded/replayed; Glean mocked
 glean-idx run --mode incremental    # additive crawl for real
-glean-idx datasource status --datasource company_wiki
+glean-idx datasource status --datasource companywiki
 glean-idx deploy init --cloud gcp   # Docker and Terraform for a CronJob
 ```
 
 ## Where each command runs
 
-Commands fall into two groups, and knowing which is which saves the most common
-confusion. `glean-idx --help` restates it.
+Commands fall into three groups, and knowing which is which saves the most
+common confusion. `glean-idx --help` restates it.
 
 **Credentials only.** Most commands need nothing but `GLEAN_SERVER_URL` and
 `GLEAN_INDEXING_API_TOKEN`. They never import your code, so they run from any
@@ -40,6 +40,13 @@ uv run glean-idx run
 
 A command in the second group run from the wrong directory tells you exactly
 that, and lists the directories it searched for `glean_deployment.yaml`.
+
+**Deployment config plus standard tools.** `deploy` commands read
+`glean_deployment.yaml` and delegate to Docker Buildx, Terraform, the selected
+provider, or `kubectl`. Install and authenticate those tools first. The SDK owns
+connector-specific naming, image selection, exact secret manifests, Terraform
+variables, and workload discovery; it does not create or authenticate your
+cloud account, cluster, registry, identity foundation, or namespace.
 
 ## Commands
 
@@ -93,7 +100,7 @@ glean-idx test --phase all --allow-destructive-live
 |---|---|
 | `glean-idx datasource status --datasource NAME` | Uploaded and indexed counts per object type, identity counts, visibility, and the most recent upload and processing runs. |
 | `glean-idx datasource process --datasource NAME` | Requests processing now instead of waiting for the next scheduled run. |
-| `glean-idx datasource configure [--connector MODULE:CLASS_OR_FACTORY]` | Registers the connector's own `configuration`, so the datasource cannot drift from what the connector uploads to. |
+| `glean-idx datasource configure [--connector MODULE:CLASS_OR_FACTORY]` | Validates and registers the connector's own `configuration`, so the datasource cannot drift from what the connector uploads to. API-facing datasource names may contain only ASCII letters and digits. An ambiguous transport failure is reconciled by reading state back, never by blindly repeating the write. |
 | `glean-idx document status --datasource NAME --document TYPE ID [--poll]` | Whether one or more documents finished indexing. Repeat `--document TYPE ID` to check several. |
 | `glean-idx document access --datasource NAME --object-type TYPE --id ID --user EMAIL` | Whether a given user can see a document. |
 | `glean-idx document events --datasource NAME --object-type TYPE --id ID` | A document's lifecycle events, for when it uploaded but never became searchable. |
@@ -116,9 +123,20 @@ currently indexed for that datasource becomes stale and is removed.
 
 ### Deploying
 
-`glean-idx deploy` generates and operates a scheduled job in your own cloud —
-`init`, `build`, `secrets`, `apply`, `status`, `logs`, and `destroy`. See
-[Deployment](/libraries/indexing-sdk/deployment/overview).
+`glean-idx deploy` generates and operates a scheduled job in your own cloud:
+
+| Command | What it does |
+|---|---|
+| `deploy init` | Generates Docker, Terraform, runtime, and YAML artifacts. |
+| `deploy build [--push]` | Delegates to Docker Buildx using the YAML image tag. The compatibility `--tag` option must match the YAML so build and apply cannot diverge. |
+| `deploy secrets upload` | Uploads exact `.env` values and records only validated key names locally. |
+| `deploy apply` | Runs Terraform init, displays an exact saved plan, prompts, and applies that same plan. |
+| `deploy run` | Delegates to `kubectl` to create one immediate Job from the configured CronJob. |
+| `deploy status` / `deploy logs` | Uses `kubectl` against the currently selected cluster. |
+| `deploy destroy` | Removes Terraform resources and manifest-owned secrets, then reports retained image, namespace, datasource registration, and local files. |
+
+See [Deployment](/libraries/indexing-sdk/deployment/overview) for prerequisites,
+provider authentication, namespace ownership, and cleanup boundaries.
 
 ## Output and exit codes
 
@@ -126,13 +144,13 @@ Every command takes `--output json` and returns a stable envelope, which is what
 makes the CLI usable from a script or an agent:
 
 ```bash snippet=cli/snippet-05.sh
-glean-idx datasource status --datasource company_wiki --output json | jq .data.documents
+glean-idx datasource status --datasource companywiki --output json | jq .data.documents
 ```
 
 ```json
 {
   "ok": true,
-  "data": { "datasource": "company_wiki", "documents": { "uploaded": { "article": 42 } } }
+  "data": { "datasource": "companywiki", "documents": { "uploaded": { "article": 42 } } }
 }
 ```
 
@@ -142,7 +160,10 @@ goes to **stdout whether the command succeeded or not** — an `ok: false` resul
 is still the result — so there is one stream to parse. Text-mode errors go to
 stderr, as does connector logging from `run`.
 
-Exit codes are stable:
+SDK-owned exit codes are stable. When a deployment subprocess starts and exits
+nonzero, the CLI preserves that Docker, Terraform, or `kubectl` exit code (from
+`1` through `255`) and includes the command and captured diagnostics in the
+error envelope.
 
 | Code | Meaning |
 |---|---|

--- a/docs/libraries/indexing-sdk/concepts/indexing-modes.mdx
+++ b/docs/libraries/indexing-sdk/concepts/indexing-modes.mdx
@@ -99,12 +99,12 @@ wherever you store it:
 class WikiConnector(BaseDatasourceConnector[WikiPage]):
     def _get_last_crawl_timestamp(self):
         # your storage: file, S3, DynamoDB, database
-        return read_checkpoint("company_wiki")
+        return read_checkpoint("companywiki")
 
     def index_data(self, mode=IndexingMode.FULL, options=None):
         started_at = datetime.now(timezone.utc).isoformat()
         super().index_data(mode=mode, options=options)
-        write_checkpoint("company_wiki", started_at)  # only on success
+        write_checkpoint("companywiki", started_at)  # only on success
 ```
 
 Record the timestamp from *before* the crawl started, and only write it after

--- a/docs/libraries/indexing-sdk/deployment/overview.mdx
+++ b/docs/libraries/indexing-sdk/deployment/overview.mdx
@@ -1,13 +1,123 @@
 ---
 title: Deployment overview
-description: Generate Docker and Terraform for a Glean connector with glean-idx deploy
+description: Build and operate a scheduled Glean connector on GKE or EKS with glean-idx deploy
 ---
 
 import { Stages } from '@site/src/components/IndexingSdk/diagrams';
 
-A connector is a batch job: it runs on a schedule, pulls from a source, pushes to
-Glean, and exits. `glean-idx deploy` generates the scaffolding for that — a
-Dockerfile, an entrypoint, and Terraform for a Kubernetes CronJob on GKE or EKS.
+A connector is a batch job: it starts, pulls from a source, pushes to Glean, and
+exits. `glean-idx deploy` generates and operates a Docker image and Terraform for
+a Kubernetes CronJob on GKE or EKS.
+
+`glean-idx` is the connector-specific interface. It delegates image operations
+to Docker, infrastructure operations to Terraform, and workload inspection to
+`kubectl`. You install and authenticate those standard tools, and your platform
+team continues to own the cloud project or account, cluster, registry, identity
+foundation, and Kubernetes namespace.
+
+## Before you begin
+
+Install the cloud extra for the provider you use:
+
+```bash
+pip install "glean-indexing-sdk[gcp]"  # GKE, Artifact Registry, Secret Manager
+# or
+pip install "glean-indexing-sdk[aws]"  # EKS, ECR, Secrets Manager
+```
+
+All deployments require:
+
+- Docker with a running daemon and Buildx.
+- Terraform 1.0 or later.
+- `kubectl`, authenticated to the target cluster. GKE users also need the
+  `gke-gcloud-auth-plugin` executable available on `PATH`.
+- A connector project with `glean-indexing-sdk` installed.
+- `GLEAN_SERVER_URL`, `GLEAN_INDEXING_API_TOKEN`, and every source credential
+  your connector reads.
+- An existing container registry repository and Kubernetes namespace.
+- Permission to push images, create the generated workload identity and IAM
+  bindings, manage connector secrets, and create Kubernetes resources in the
+  namespace.
+
+The generated Terraform does **not** create a project/account, cluster, registry,
+Workload Identity/IRSA foundation, or namespace. It reads the namespace before
+planning, so a missing or inaccessible namespace fails before resources are
+mutated. Use a dedicated namespace when your organization permits it; never let
+connector teardown own a shared namespace.
+
+### GCP prerequisites
+
+GCP requires an existing GKE cluster and Artifact Registry repository. Enable
+the GKE, Artifact Registry, Secret Manager, IAM, Cloud Logging, and Cloud
+Monitoring APIs. Enable Workload Identity on the cluster and its node pools.
+
+Set these shell variables to your environment before running the checks:
+`PROJECT_ID`, `GKE_LOCATION`, `CLUSTER_NAME`, `ARTIFACT_REGISTRY_LOCATION`,
+`ARTIFACT_REGISTRY_REPOSITORY`, and `NAMESPACE`.
+
+```bash snippet=deployment/snippet-01.sh
+docker info
+docker buildx version
+terraform version
+gcloud --version
+gke-gcloud-auth-plugin --version
+kubectl version --client
+
+gcloud auth login --update-adc
+gcloud config set project "$PROJECT_ID"
+gcloud auth configure-docker "${ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  --location "$GKE_LOCATION" \
+  --project "$PROJECT_ID"
+```
+
+Confirm that the customer-managed resources exist and that `kubectl` points to
+the intended cluster:
+
+```bash snippet=deployment/snippet-02.sh
+gcloud container clusters describe "$CLUSTER_NAME" \
+  --location "$GKE_LOCATION" \
+  --project "$PROJECT_ID"
+
+gcloud artifacts repositories describe "$ARTIFACT_REGISTRY_REPOSITORY" \
+  --location "$ARTIFACT_REGISTRY_LOCATION" \
+  --project "$PROJECT_ID"
+
+kubectl cluster-info
+kubectl get namespace "$NAMESPACE" || kubectl create namespace "$NAMESPACE"
+```
+
+`region` in `glean_deployment.yaml` is the GKE **location** accepted by
+`gcloud ... --location`; it may be a region such as `us-central1` or a zone such
+as `us-central1-a`.
+
+For a private-only cluster with a GKE DNS control-plane endpoint, set
+`cluster_endpoint` to its bare `*.gke.goog` hostname—no `https://`, port, path,
+or trailing slash. The generated Kubernetes provider uses system trust for an
+explicit DNS endpoint and the cluster CA for the auto-discovered IP endpoint.
+The machine running Terraform must still have network access to the selected
+endpoint.
+
+### AWS prerequisites
+
+AWS requires an existing EKS cluster, ECR repository, Kubernetes namespace, and
+IAM OIDC provider for IRSA. Authenticate the AWS CLI and Docker, then select the
+cluster explicitly:
+
+```bash
+aws sts get-caller-identity
+aws eks update-kubeconfig --name "$CLUSTER_NAME" --region "$AWS_REGION"
+kubectl cluster-info
+kubectl get namespace "$NAMESPACE" || kubectl create namespace "$NAMESPACE"
+
+aws ecr get-login-password --region "$AWS_REGION" |
+  docker login --username AWS --password-stdin \
+  "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+```
+
+## Generate and configure the deployment
+
+Run `init` from the connector project:
 
 ```bash snippet=overview/snippet-21.sh
 glean-idx deploy init --cloud gcp \
@@ -15,113 +125,169 @@ glean-idx deploy init --cloud gcp \
   --connector-factory create_connector
 ```
 
-:::danger
-**The generated infrastructure has not been validated end to end against a real
-cloud account.** Treat the output as a starting point to review, not as
-production-ready IaC. Have someone who owns the target account read the
-Terraform before applying it. Broader validation is tracked in
-[issue #104](https://github.com/gleanwork/glean-indexing-sdk/issues/104).
-:::
+`--connector-name` is a cloud resource slug. It may contain lowercase letters,
+digits, hyphens, and underscores. It is separate from
+`CustomDatasourceConfig.name`, which is the Glean datasource identifier and may
+contain only ASCII letters and digits. For example, deployment slug
+`company-wiki` can run datasource `companywiki`.
 
-## What gets generated
+### Generated files
 
 | File | Purpose |
 |---|---|
-| `glean_deployment.yaml` | Deployment configuration — you edit this. |
-| `Dockerfile` | Container image for the connector. |
-| `.dockerignore` | Build context exclusions. |
-| `run.py` | Entrypoint that imports and runs your connector. |
-| `main.tf`, `variables.tf` | Terraform for the CronJob, service account, and secrets. |
-| `.env.example` | Template for connector credentials. |
+| `glean_deployment.yaml` | Authoritative deployment configuration; edit this file before each operation. |
+| `Dockerfile` | Non-root connector image. |
+| `.dockerignore` | Excludes credentials, Terraform state, virtualenvs, tests, caches, coverage, and local build output. |
+| `run.py` | Cloud entrypoint that loads exact declared secrets and calls the connector factory. |
+| `terraform/main.tf` | CronJob, workload identity, exact secret access, logging, and metrics resources. |
+| `terraform/variables.tf` | Apply-time inputs populated from `glean_deployment.yaml`. |
+| `.env.example` | Template for Glean and source credentials. |
 
-Options for `init`:
+Generated Terraform is an artifact, not the configuration interface. Do not
+hand-edit it. Change `glean_deployment.yaml` instead; `deploy apply` passes every
+mutable setting at plan time.
 
-| Flag | Default | Purpose |
-|---|---|---|
-| `--cloud` | required | `gcp` or `aws`. |
-| `--connector-name` | current directory name | Used for resource naming. |
-| `--connector-class` | `MyConnector` | Class the entrypoint instantiates. |
-| `--connector-module` | `connector` | Module to import it from. |
-| `--connector-factory` | — | Optional zero-argument factory in the connector module. |
-| `--output-dir` | `.` | Where to write. |
-
-## Configuration
-
-`glean_deployment.yaml` drives generation. The placeholders written by `init`
-must be replaced before anything works.
+### Configuration reference
 
 | Key | Default | Notes |
 |---|---|---|
-| `connector_name` | — | Resource naming. |
-| `connector_class` / `connector_module` | — | What the entrypoint imports. |
-| `cloud` | — | `gcp` or `aws`. |
-| `region` | `us-central1` / `us-east-1` | Cloud region. |
-| `cluster_name` | placeholder | Target Kubernetes cluster. |
-| `namespace` | `default` | Kubernetes namespace. |
-| `cpu` | `500m` | Pod CPU request/limit. |
-| `memory` | — | Pod memory request/limit. |
-| `cron_schedule` | — | Standard cron expression. |
-| `indexing_mode` | — | `full` or `incremental`. |
-| `project_id`, `artifact_registry_repo`, `service_account_name` | — | GCP only. |
-| `account_id`, `ecr_repo`, `iam_role_name` | — | AWS only. |
+| `connector_name` | sanitized current directory name | Cloud resource name and secret prefix; not necessarily the Glean datasource name. |
+| `connector_class` / `connector_module` | `MyConnector` / `connector` | Connector import target. |
+| `connector_factory` | unset | Optional zero-argument factory; preferred when construction needs source credentials. |
+| `cloud` | required | `gcp` or `aws`; fixed when `deploy init` generates provider-specific Terraform. |
+| `region` | `us-central1` / `us-east-1` | GCP cluster location or AWS region. |
+| `cluster_name` | placeholder | Existing GKE or EKS cluster. |
+| `namespace` | `default` | Existing, customer-managed Kubernetes namespace. |
+| `image_tag` | `latest` | Image tag used by both `deploy build` and `deploy apply`. Use an immutable release identifier for controlled rollouts. |
+| `cpu` | `500m` | Pod CPU request and limit. |
+| `memory` | `512Mi` | Pod memory request and limit. |
+| `cron_schedule` | `0 2 * * *` | UTC cron expression. |
+| `indexing_mode` | `FULL` | `FULL` or `INCREMENTAL`. |
+| `project_id`, `artifact_registry_repo`, `service_account_name` | provider-specific | GCP project, repository URL, and optional workload service-account name. |
+| `cluster_endpoint` | unset | Optional bare GKE DNS endpoint for a private-only cluster. |
+| `account_id`, `ecr_repo`, `iam_role_name` | provider-specific | AWS account, ECR repository URI, and optional IRSA role name. |
 
-A common pattern is two CronJobs from one image: incremental on a short schedule,
-full nightly. See
-[Indexing modes](/libraries/indexing-sdk/concepts/indexing-modes).
+To change cloud providers, rerun `deploy init --cloud ...` into a reviewed
+output directory; editing `cloud` alone cannot convert the generated provider
+files.
 
-## Workflow
+A full and incremental schedule need separate deployment configurations because
+a Kubernetes CronJob has one schedule and indexing mode. They may point to the
+same immutable image. See [Indexing modes](/libraries/indexing-sdk/concepts/indexing-modes).
+
+## Deploy
+
+The canonical sequence is:
 
 <Stages stages={[
-  { title: <>Generate &mdash; <code>glean-idx deploy init</code></>, body: <>Writes the Dockerfile, entrypoint, Terraform, and config template.</> },
-  { title: <>Configure</>, body: <>Edit <code>glean_deployment.yaml</code> (cluster, region, registry, schedule), then <code>cp .env.example .env</code> and fill in credentials.</> },
-  { title: <>Build and push &mdash; <code>glean-idx deploy build --push</code></>, body: <>Builds the container image and pushes it to your registry.</> },
-  { title: <>Upload secrets &mdash; <code>glean-idx deploy secrets upload</code></>, body: <>Reads <code>.env</code>, writes each secret to the cloud provider, and atomically records the validated environment keys in local <code>.glean_secret_keys</code>.</> },
-  { title: <>Apply &mdash; <code>glean-idx deploy apply</code></>, body: <>Reads that manifest and passes its keys to Terraform at apply time so IAM and the CronJob name the exact runtime secrets.</> },
-  { title: <>Verify</>, body: <><code>glean-idx deploy status</code> and <code>glean-idx deploy logs --follow</code>, then confirm a document with <code>glean-idx document status --datasource NAME --document TYPE ID</code>. A CronJob that exits zero has not necessarily indexed anything.</> },
+  { title: <>Validate locally</>, body: <>Run the mock and integration phases before any cloud mutation.</> },
+  { title: <>Register the datasource</>, body: <><code>glean-idx datasource configure</code> validates the alphanumeric datasource name and submits its object definitions.</> },
+  { title: <>Build and push</>, body: <><code>glean-idx deploy build --push</code> delegates to Docker Buildx using the configured image tag.</> },
+  { title: <>Upload exact secrets</>, body: <><code>glean-idx deploy secrets upload</code> writes values to the provider and records only validated key names in <code>.glean_secret_keys</code>.</> },
+  { title: <>Plan and apply</>, body: <><code>glean-idx deploy apply</code> runs Terraform init, displays an exact saved plan, prompts, and applies that same plan.</> },
+  { title: <>Run and verify</>, body: <><code>glean-idx deploy run</code> creates one Job immediately; status, logs, and document polling verify the result.</> },
 ]} />
 
-Build and push the image **before** uploading secrets. The local manifest is
-created by `secrets upload`, excluded from the Docker build context, and consumed
-by `deploy apply`; it is not baked into the image. Uploading before build is
-neither required nor recommended.
+```bash snippet=deployment/snippet-03.sh
+glean-idx deploy init --cloud gcp \
+  --connector-name company-wiki \
+  --connector-class CompanyWikiConnector \
+  --connector-module connector \
+  --connector-factory create_connector
 
-:::warning
-`apply` prompts once before invoking `terraform apply -auto-approve`; `--yes`
-skips that prompt for unattended use. Run `terraform plan` in the generated
-`terraform/` directory and review it before applying.
-:::
+cp .env.example .env
+# Edit glean_deployment.yaml and fill in .env before continuing.
+
+glean-idx datasource configure --connector connector:CompanyWikiConnector
+glean-idx deploy build --push
+glean-idx deploy secrets upload
+glean-idx deploy apply
+```
+
+Build before uploading secrets. `.env` and `.glean_secret_keys` are excluded from
+the image. `deploy apply` reads the current YAML and current secret manifest;
+post-`init` edits to schedule, mode, resources, import metadata, namespace,
+identity names, endpoint, and image tag are reflected in the displayed plan.
+
+If datasource configuration loses its connection after sending the request, the
+SDK reads the configuration back without issuing a second write. Equivalent
+state counts as success. Divergent or unreadable state is reported as an
+ambiguous outcome; inspect it before retrying.
+
+## Run now and verify
+
+A newly applied CronJob may not be scheduled for hours. Start one Job immediately
+through the same deployment interface:
+
+```bash snippet=deployment/snippet-04.sh
+glean-idx deploy run
+glean-idx deploy status
+glean-idx deploy logs --follow
+glean-idx document status \
+  --datasource companywiki \
+  --document article page_123 \
+  --poll
+```
+
+`deploy run` delegates to `kubectl create job --from=cronjob/...`, derives the
+CronJob and namespace from the YAML, and returns the exact Job name. A completed
+Kubernetes Job proves only that the process exited successfully; document status
+proves that Glean uploaded and indexed the expected content.
 
 ## Secrets
 
-Credentials are read from the environment at runtime and injected from the cloud
-secret store. Never bake them into the image or commit `.env`.
+The generated workload can access only the secret names recorded by the latest
+successful `secrets upload`. GCP receives one secret-level IAM member per key;
+AWS resolves and grants the exact secret ARNs. The workload cannot enumerate
+secrets. Missing declared secrets fail startup.
 
-`secrets upload` validates environment-variable keys and writes their sorted
-names to `.glean_secret_keys`. At apply time, Terraform grants the workload
-access to each exact declared secret: one secret-level IAM member per key on
-GCP, or the exact resolved secret ARNs on AWS. The generated runtime receives
-the declared key list and fetches those values directly. It has no permission to
-enumerate secrets and does not discover them by connector-name prefix.
+`GLEAN_SERVER_URL` and `GLEAN_INDEXING_API_TOKEN` are always required. Add every
+source credential read by your factory—for example `WIKI_API_TOKEN`—to `.env` as
+well. Never commit `.env`, copy it into the image, put secret values in YAML, or
+pass them as Terraform variables.
 
-`glean-idx deploy secrets list` remains an operator command; the deployed
-connector does not use it. Startup fails if any declared secret cannot be
-loaded. A missing or empty manifest produces a secretless deployment.
+## Teardown and retained resources
 
-## Teardown
+Content and cloud infrastructure have separate lifecycles:
 
-```bash snippet=overview/snippet-22.sh
+```bash snippet=deployment/snippet-05.sh
+glean-idx datasource teardown --datasource companywiki
 glean-idx deploy destroy
 ```
 
-Requires two confirmations. `--keep-secrets` preserves stored secrets.
+- `datasource teardown` submits an empty full replacement. It removes indexed
+  documents after asynchronous processing but retains the datasource
+  registration and configuration.
+- `deploy destroy` removes Terraform-managed workload/IAM resources and, unless
+  `--keep-secrets` is used, exact manifest-owned secrets.
+- `deploy destroy` does **not** delete the container image, customer-owned
+  namespace, datasource registration, or local generated files. Its text and
+  JSON output list those retained artifacts.
+
+Remove retained resources only when they are dedicated to this connector:
+
+```bash
+# GCP: delete the configured image/tag or apply your registry lifecycle policy.
+gcloud artifacts docker images delete "$IMAGE_REFERENCE" --delete-tags
+
+# AWS: delete the dedicated tag or apply your ECR lifecycle policy.
+aws ecr batch-delete-image \
+  --repository-name "$ECR_REPOSITORY_NAME" \
+  --image-ids "imageTag=$IMAGE_TAG" \
+  --region "$AWS_REGION"
+
+# Customer-owned namespace: delete only when it contains no shared workloads.
+kubectl delete namespace "$NAMESPACE"
+```
+
+There is no Indexing API operation to delete a datasource registration. Use the
+Glean admin surface when complete registration removal is required.
 
 ## Running elsewhere
 
-Nothing about the SDK requires Kubernetes. A connector is a Python process that
-needs two environment variables, so it runs anywhere: a cron entry on a VM, a
-Lambda or Cloud Run job, an Airflow task, a GitHub Actions schedule.
-
-The generated Dockerfile is useful even if you discard the Terraform. What
-matters is that the job runs on a schedule, has credentials, exits non-zero on
-failure, and is monitored — see
-[Observability](/libraries/indexing-sdk/observability).
+The Python connector does not require Kubernetes. It can run as a VM cron job,
+Cloud Run or Lambda job, Airflow task, or scheduled CI workload. It needs Glean
+credentials **plus every source-specific runtime variable used by the connector**.
+The portable execution primitive is the connector factory invoked by
+`glean-idx run`; generated `run.py` files are provider-specific implementations
+for the GKE/EKS deployment path.

--- a/docs/libraries/indexing-sdk/observability.mdx
+++ b/docs/libraries/indexing-sdk/observability.mdx
@@ -38,7 +38,7 @@ success/failure.
 ```python snippet=observability/snippet-02.py
 from glean.indexing.observability import setup_connector_logging
 
-setup_connector_logging("company_wiki", log_level="INFO")
+setup_connector_logging("companywiki", log_level="INFO")
 ```
 
 Structured JSON logging is on by default, which is what makes logs queryable
@@ -68,8 +68,8 @@ to attach them elsewhere.
 from glean.indexing.observability import ConnectorObservability, InMemoryMetricsProvider
 
 observability = ConnectorObservability(
-    connector_name="company_wiki",
-    datasource="company_wiki",
+    connector_name="companywiki",
+    datasource="companywiki",
     crawl_mode="full",
     metrics_provider=InMemoryMetricsProvider(),
 )
@@ -101,20 +101,20 @@ from glean.indexing.observability.plugins.aws import (
 )
 
 setup_connector_logging(
-    "company_wiki",
+    "companywiki",
     logger_provider=CloudWatchLogsProvider(
         log_group="/glean/connectors",
-        log_stream="company_wiki",
+        log_stream="companywiki",
         region_name="us-east-1",
     ),
 )
 
 observability = ConnectorObservability(
-    connector_name="company_wiki",
+    connector_name="companywiki",
     metrics_provider=CloudWatchMetricsProvider(
         namespace="GleanConnectors",
         region_name="us-east-1",
-        dimensions={"connector": "company_wiki"},
+        dimensions={"connector": "companywiki"},
     ),
 )
 ```

--- a/docs/libraries/indexing-sdk/permissions.mdx
+++ b/docs/libraries/indexing-sdk/permissions.mdx
@@ -109,7 +109,7 @@ share an identity provider:
 
 ```python snippet=permissions/snippet-03.py
 configuration = CustomDatasourceConfig(
-    name="company_wiki",
+    name="companywiki",
     display_name="Company Wiki",
     is_user_referenced_by_email=True,
 )

--- a/docs/libraries/indexing-sdk/push/uploader.mdx
+++ b/docs/libraries/indexing-sdk/push/uploader.mdx
@@ -12,7 +12,7 @@ backfills, or targeted deletes.
 ```python snippet=uploader/snippet-01.py
 from glean.indexing.push import PushUploader
 
-uploader = PushUploader(datasource="company_wiki")
+uploader = PushUploader(datasource="companywiki")
 uploader.bulk_index_documents(documents)
 ```
 
@@ -134,7 +134,7 @@ always sequential** — the first opens the upload session, the last closes it a
 triggers stale deletion, so neither can race.
 
 ```python snippet=uploader/snippet-08.py
-uploader = PushUploader(datasource="company_wiki", upload_max_workers=10)
+uploader = PushUploader(datasource="companywiki", upload_max_workers=10)
 ```
 
 Raise it for many small batches over a high-latency link; lower it to `1` to

--- a/docs/libraries/indexing-sdk/quickstart.mdx
+++ b/docs/libraries/indexing-sdk/quickstart.mdx
@@ -105,7 +105,10 @@ class WikiDataClient(BaseDataClient[WikiPage]):
 ## Write a connector
 
 The connector declares its datasource configuration and maps source records to
-`DocumentDefinition` objects.
+`DocumentDefinition` objects. `CustomDatasourceConfig.name` may contain only
+ASCII letters and digits; Glean normalizes it internally. This API-facing name
+is separate from cloud deployment slugs, which may contain hyphens or
+underscores.
 
 ```python snippet=quickstart/snippet-06.py
 import os
@@ -123,7 +126,7 @@ from glean.indexing.models import (
 
 class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
     configuration = CustomDatasourceConfig(
-        name="company_wiki",
+        name="companywiki",
         display_name="Company Wiki",
         url_regex=r"https://wiki\.company\.com/.*",
         is_user_referenced_by_email=True,
@@ -149,7 +152,7 @@ class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
 def create_connector() -> CompanyWikiConnector:
     """Construct the connector from runtime configuration."""
     return CompanyWikiConnector(
-        name="company_wiki",
+        name="companywiki",
         data_client=WikiDataClient(
             base_url=os.environ["WIKI_BASE_URL"],
             api_token=os.environ["WIKI_API_TOKEN"],
@@ -176,7 +179,7 @@ network and needs no credentials:
 ```python snippet=quickstart/snippet-07.py
 from glean.indexing.testing import StaticDataClient, run_connector
 
-result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
+result = run_connector(CompanyWikiConnector("companywiki", StaticDataClient([
     {
         "id": "page_123",
         "title": "Engineering Onboarding Guide",
@@ -187,7 +190,7 @@ result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
     }
 ])))
 
-result.assert_documents_posted(count=1, datasource="company_wiki")
+result.assert_documents_posted(count=1, datasource="companywiki")
 ```
 
 Then move through the CLI phases one at a time. Both `mock` and `integration`
@@ -214,6 +217,12 @@ reconfigure it when its configuration changes.
 glean-idx datasource configure --connector connector:CompanyWikiConnector
 ```
 
+The CLI rejects invalid datasource names before making a request. If the write
+loses its connection after being sent, the SDK reads the configuration back
+without retrying the write. Equivalent state is reported as success; an
+unreadable or different result is reported as an ambiguous outcome that you
+must inspect before retrying.
+
 For the first live full crawl, use a disposable datasource and verify the target
 shown by the confirmation prompt. A full live test is a replacement and can
 stale-delete documents it does not produce, so the explicit acknowledgement is
@@ -238,7 +247,7 @@ Indexing is asynchronous — an accepted upload is not yet a searchable
 document. Check status from the CLI:
 
 ```bash snippet=quickstart/snippet-11.sh
-glean-idx document status --datasource company_wiki --document article page_123 --poll
+glean-idx document status --datasource companywiki --document article page_123 --poll
 ```
 
 Then search Glean for a phrase from the document body. If it isn't there, work

--- a/docs/libraries/indexing-sdk/status-and-debugging.mdx
+++ b/docs/libraries/indexing-sdk/status-and-debugging.mdx
@@ -28,7 +28,7 @@ Read-only wrappers over the debug endpoints:
 ```python
 from glean.indexing.push import StatusClient
 
-status = StatusClient(datasource="company_wiki")
+status = StatusClient(datasource="companywiki")
 
 status.get_datasource_status()      # counts and datasource state
 status.get_documents_status(...)    # per-document indexing status
@@ -46,7 +46,7 @@ anywhere — including with no install:
 
 ```bash snippet=status-and-debugging/snippet-02.sh
 glean-idx document status \
-  --datasource company_wiki \
+  --datasource companywiki \
   --document article page_123 \
   --document article page_124 \
   --poll
@@ -63,7 +63,7 @@ from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import check_documents_status, poll_documents_status
 
 snapshot = poll_documents_status(
-    "company_wiki",
+    "companywiki",
     [DebugDocumentRequest(object_type="article", doc_id="page_123")],
 )
 print(snapshot.result)
@@ -76,6 +76,7 @@ confirm it becomes searchable before declaring the rollout good.
 
 | Symptom | Likely cause |
 |---|---|
+| `datasource configure` reports an unknown outcome | The connection failed after the write may have committed and read-back could not prove equivalence. Inspect the current configuration with `glean-idx doctor --datasource NAME` before retrying. |
 | Document never appears | Never uploaded. Check `documents_posted` in a mocked run first. |
 | Appears, then disappears | A later **full** crawl didn't include it, so it was deleted as stale. |
 | Indexed but not findable by a user | ACL doesn't cover them, or the identity graph is incomplete. |
@@ -109,7 +110,7 @@ For per-document lifecycle events server-side:
 ```python
 from glean.indexing.push import PushUploader
 
-PushUploader(datasource="company_wiki").get_document_lifecycle_events(...)
+PushUploader(datasource="companywiki").get_document_lifecycle_events(...)
 ```
 
 ## Related

--- a/docs/libraries/indexing-sdk/testing/end-to-end.mdx
+++ b/docs/libraries/indexing-sdk/testing/end-to-end.mdx
@@ -86,7 +86,7 @@ from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import poll_documents_status
 
 snapshot = poll_documents_status(
-    "company_wiki",
+    "companywiki",
     [DebugDocumentRequest(object_type="article", doc_id="page_123")],
 )
 print(snapshot.result)
@@ -95,7 +95,7 @@ print(snapshot.result)
 `check_documents_status()` is the single-shot variant. Or from the shell:
 
 ```bash snippet=end-to-end/snippet-04.sh
-glean-idx document status --datasource company_wiki --document article page_123 --poll
+glean-idx document status --datasource companywiki --document article page_123 --poll
 ```
 
 See [Status and debugging](/libraries/indexing-sdk/status-and-debugging).
@@ -108,7 +108,7 @@ confirm they cannot see documents they shouldn't.
 ```python
 from glean.indexing.push import StatusClient
 
-status = StatusClient(datasource="company_wiki")
+status = StatusClient(datasource="companywiki")
 status.check_document_access(...)
 ```
 
@@ -124,7 +124,7 @@ created:
 ```python snippet=end-to-end/snippet-06.py
 from glean.indexing.push import PushUploader
 
-uploader = PushUploader(datasource="company_wiki")
+uploader = PushUploader(datasource="companywiki")
 for doc_id in created_ids:
     uploader.delete_document(object_type="article", document_id=doc_id)
 ```

--- a/docs/libraries/indexing-sdk/testing/unit.mdx
+++ b/docs/libraries/indexing-sdk/testing/unit.mdx
@@ -23,13 +23,13 @@ Pair `run_connector` with a static data client:
 from glean.indexing.testing import StaticDataClient, run_connector
 
 result = run_connector(
-    MyConnector("my_ds", StaticDataClient([
+    MyConnector("myds", StaticDataClient([
         {"id": "1", "title": "Doc 1", "url": "https://example.com/1"},
         {"id": "2", "title": "Doc 2", "url": "https://example.com/2"},
     ]))
 )
 
-result.assert_documents_posted(count=2, datasource="my_ds")
+result.assert_documents_posted(count=2, datasource="myds")
 ```
 
 It returns a `MockGleanClient` that recorded everything the connector sent.
@@ -45,12 +45,12 @@ Static clients exist for each connector shape:
 ## Assertions
 
 ```python snippet=unit/snippet-02.py
-result.assert_documents_posted(count=2, datasource="my_ds")
+result.assert_documents_posted(count=2, datasource="myds")
 result.assert_employees_posted(count=10)
 result.assert_users_posted(count=5)
 result.assert_groups_posted(count=2)
 result.assert_memberships_posted(count=8)
-result.assert_datasource_configured(name="my_ds")
+result.assert_datasource_configured(name="myds")
 ```
 
 Omit `count` to assert only that something was posted.
@@ -82,7 +82,7 @@ from glean.indexing.testing import StaticAsyncStreamingDataClient, run_connector
 @pytest.mark.asyncio
 async def test_async_connector():
     result = await run_connector_async(
-        MyAsyncConnector("my_ds", StaticAsyncStreamingDataClient(fixtures))
+        MyAsyncConnector("myds", StaticAsyncStreamingDataClient(fixtures))
     )
     result.assert_documents_posted(count=10)
 ```
@@ -116,7 +116,7 @@ with mock_glean_client() as client:
     connector.configure_datasource()
     connector.index_data(mode=IndexingMode.INCREMENTAL)
 
-    client.assert_datasource_configured(name="my_ds")
+    client.assert_datasource_configured(name="myds")
     client.assert_documents_posted(count=2)
 ```
 

--- a/snippets/cli/snippet-01.sh
+++ b/snippets/cli/snippet-01.sh
@@ -3,5 +3,5 @@ glean-idx validate ./my-connector   # is the plan complete, before writing code?
 glean-idx test --phase mock         # Glean mocked; connector source clients unchanged
 glean-idx test --phase integration  # real source, recorded/replayed; Glean mocked
 glean-idx run --mode incremental    # additive crawl for real
-glean-idx datasource status --datasource company_wiki
+glean-idx datasource status --datasource companywiki
 glean-idx deploy init --cloud gcp   # Docker and Terraform for a CronJob

--- a/snippets/cli/snippet-05.sh
+++ b/snippets/cli/snippet-05.sh
@@ -1,1 +1,1 @@
-glean-idx datasource status --datasource company_wiki --output json | jq .data.documents
+glean-idx datasource status --datasource companywiki --output json | jq .data.documents

--- a/snippets/deployment/snippet-01.sh
+++ b/snippets/deployment/snippet-01.sh
@@ -1,0 +1,13 @@
+docker info
+docker buildx version
+terraform version
+gcloud --version
+gke-gcloud-auth-plugin --version
+kubectl version --client
+
+gcloud auth login --update-adc
+gcloud config set project "$PROJECT_ID"
+gcloud auth configure-docker "${ARTIFACT_REGISTRY_LOCATION}-docker.pkg.dev"
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  --location "$GKE_LOCATION" \
+  --project "$PROJECT_ID"

--- a/snippets/deployment/snippet-02.sh
+++ b/snippets/deployment/snippet-02.sh
@@ -1,0 +1,10 @@
+gcloud container clusters describe "$CLUSTER_NAME" \
+  --location "$GKE_LOCATION" \
+  --project "$PROJECT_ID"
+
+gcloud artifacts repositories describe "$ARTIFACT_REGISTRY_REPOSITORY" \
+  --location "$ARTIFACT_REGISTRY_LOCATION" \
+  --project "$PROJECT_ID"
+
+kubectl cluster-info
+kubectl get namespace "$NAMESPACE" || kubectl create namespace "$NAMESPACE"

--- a/snippets/deployment/snippet-03.sh
+++ b/snippets/deployment/snippet-03.sh
@@ -1,0 +1,13 @@
+glean-idx deploy init --cloud gcp \
+  --connector-name company-wiki \
+  --connector-class CompanyWikiConnector \
+  --connector-module connector \
+  --connector-factory create_connector
+
+cp .env.example .env
+# Edit glean_deployment.yaml and fill in .env before continuing.
+
+glean-idx datasource configure --connector connector:CompanyWikiConnector
+glean-idx deploy build --push
+glean-idx deploy secrets upload
+glean-idx deploy apply

--- a/snippets/deployment/snippet-04.sh
+++ b/snippets/deployment/snippet-04.sh
@@ -1,5 +1,7 @@
+glean-idx deploy run
+glean-idx deploy status
+glean-idx deploy logs --follow
 glean-idx document status \
   --datasource companywiki \
   --document article page_123 \
-  --document article page_124 \
   --poll

--- a/snippets/deployment/snippet-05.sh
+++ b/snippets/deployment/snippet-05.sh
@@ -1,0 +1,2 @@
+glean-idx datasource teardown --datasource companywiki
+glean-idx deploy destroy

--- a/snippets/end-to-end/snippet-03.py
+++ b/snippets/end-to-end/snippet-03.py
@@ -2,7 +2,7 @@ from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import poll_documents_status
 
 snapshot = poll_documents_status(
-    "company_wiki",
+    "companywiki",
     [DebugDocumentRequest(object_type="article", doc_id="page_123")],
 )
 print(snapshot.result)

--- a/snippets/end-to-end/snippet-04.sh
+++ b/snippets/end-to-end/snippet-04.sh
@@ -1,1 +1,1 @@
-glean-idx document status --datasource company_wiki --document article page_123 --poll
+glean-idx document status --datasource companywiki --document article page_123 --poll

--- a/snippets/end-to-end/snippet-06.py
+++ b/snippets/end-to-end/snippet-06.py
@@ -1,5 +1,5 @@
 from glean.indexing.push import PushUploader
 
-uploader = PushUploader(datasource="company_wiki")
+uploader = PushUploader(datasource="companywiki")
 for doc_id in created_ids:
     uploader.delete_document(object_type="article", document_id=doc_id)

--- a/snippets/indexing-modes/snippet-03.py
+++ b/snippets/indexing-modes/snippet-03.py
@@ -1,9 +1,9 @@
 class WikiConnector(BaseDatasourceConnector[WikiPage]):
     def _get_last_crawl_timestamp(self):
         # your storage: file, S3, DynamoDB, database
-        return read_checkpoint("company_wiki")
+        return read_checkpoint("companywiki")
 
     def index_data(self, mode=IndexingMode.FULL, options=None):
         started_at = datetime.now(timezone.utc).isoformat()
         super().index_data(mode=mode, options=options)
-        write_checkpoint("company_wiki", started_at)  # only on success
+        write_checkpoint("companywiki", started_at)  # only on success

--- a/snippets/observability/snippet-02.py
+++ b/snippets/observability/snippet-02.py
@@ -1,3 +1,3 @@
 from glean.indexing.observability import setup_connector_logging
 
-setup_connector_logging("company_wiki", log_level="INFO")
+setup_connector_logging("companywiki", log_level="INFO")

--- a/snippets/observability/snippet-03.py
+++ b/snippets/observability/snippet-03.py
@@ -1,8 +1,8 @@
 from glean.indexing.observability import ConnectorObservability, InMemoryMetricsProvider
 
 observability = ConnectorObservability(
-    connector_name="company_wiki",
-    datasource="company_wiki",
+    connector_name="companywiki",
+    datasource="companywiki",
     crawl_mode="full",
     metrics_provider=InMemoryMetricsProvider(),
 )

--- a/snippets/observability/snippet-05.py
+++ b/snippets/observability/snippet-05.py
@@ -5,19 +5,19 @@ from glean.indexing.observability.plugins.aws import (
 )
 
 setup_connector_logging(
-    "company_wiki",
+    "companywiki",
     logger_provider=CloudWatchLogsProvider(
         log_group="/glean/connectors",
-        log_stream="company_wiki",
+        log_stream="companywiki",
         region_name="us-east-1",
     ),
 )
 
 observability = ConnectorObservability(
-    connector_name="company_wiki",
+    connector_name="companywiki",
     metrics_provider=CloudWatchMetricsProvider(
         namespace="GleanConnectors",
         region_name="us-east-1",
-        dimensions={"connector": "company_wiki"},
+        dimensions={"connector": "companywiki"},
     ),
 )

--- a/snippets/permissions/snippet-03.py
+++ b/snippets/permissions/snippet-03.py
@@ -1,5 +1,5 @@
 configuration = CustomDatasourceConfig(
-    name="company_wiki",
+    name="companywiki",
     display_name="Company Wiki",
     is_user_referenced_by_email=True,
 )

--- a/snippets/quickstart/snippet-06.py
+++ b/snippets/quickstart/snippet-06.py
@@ -13,7 +13,7 @@ from glean.indexing.models import (
 
 class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
     configuration = CustomDatasourceConfig(
-        name="company_wiki",
+        name="companywiki",
         display_name="Company Wiki",
         url_regex=r"https://wiki\.company\.com/.*",
         is_user_referenced_by_email=True,
@@ -39,7 +39,7 @@ class CompanyWikiConnector(BaseDatasourceConnector[WikiPage]):
 def create_connector() -> CompanyWikiConnector:
     """Construct the connector from runtime configuration."""
     return CompanyWikiConnector(
-        name="company_wiki",
+        name="companywiki",
         data_client=WikiDataClient(
             base_url=os.environ["WIKI_BASE_URL"],
             api_token=os.environ["WIKI_API_TOKEN"],

--- a/snippets/quickstart/snippet-07.py
+++ b/snippets/quickstart/snippet-07.py
@@ -1,6 +1,6 @@
 from glean.indexing.testing import StaticDataClient, run_connector
 
-result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
+result = run_connector(CompanyWikiConnector("companywiki", StaticDataClient([
     {
         "id": "page_123",
         "title": "Engineering Onboarding Guide",
@@ -11,4 +11,4 @@ result = run_connector(CompanyWikiConnector("company_wiki", StaticDataClient([
     }
 ])))
 
-result.assert_documents_posted(count=1, datasource="company_wiki")
+result.assert_documents_posted(count=1, datasource="companywiki")

--- a/snippets/quickstart/snippet-11.sh
+++ b/snippets/quickstart/snippet-11.sh
@@ -1,1 +1,1 @@
-glean-idx document status --datasource company_wiki --document article page_123 --poll
+glean-idx document status --datasource companywiki --document article page_123 --poll

--- a/snippets/status-and-debugging/snippet-03.py
+++ b/snippets/status-and-debugging/snippet-03.py
@@ -2,7 +2,7 @@ from glean.api_client.models import DebugDocumentRequest
 from glean.indexing.testing import check_documents_status, poll_documents_status
 
 snapshot = poll_documents_status(
-    "company_wiki",
+    "companywiki",
     [DebugDocumentRequest(object_type="article", doc_id="page_123")],
 )
 print(snapshot.result)

--- a/snippets/unit/snippet-01.py
+++ b/snippets/unit/snippet-01.py
@@ -1,10 +1,10 @@
 from glean.indexing.testing import StaticDataClient, run_connector
 
 result = run_connector(
-    MyConnector("my_ds", StaticDataClient([
+    MyConnector("myds", StaticDataClient([
         {"id": "1", "title": "Doc 1", "url": "https://example.com/1"},
         {"id": "2", "title": "Doc 2", "url": "https://example.com/2"},
     ]))
 )
 
-result.assert_documents_posted(count=2, datasource="my_ds")
+result.assert_documents_posted(count=2, datasource="myds")

--- a/snippets/unit/snippet-02.py
+++ b/snippets/unit/snippet-02.py
@@ -1,6 +1,6 @@
-result.assert_documents_posted(count=2, datasource="my_ds")
+result.assert_documents_posted(count=2, datasource="myds")
 result.assert_employees_posted(count=10)
 result.assert_users_posted(count=5)
 result.assert_groups_posted(count=2)
 result.assert_memberships_posted(count=8)
-result.assert_datasource_configured(name="my_ds")
+result.assert_datasource_configured(name="myds")

--- a/snippets/unit/snippet-04.py
+++ b/snippets/unit/snippet-04.py
@@ -6,6 +6,6 @@ from glean.indexing.testing import StaticAsyncStreamingDataClient, run_connector
 @pytest.mark.asyncio
 async def test_async_connector():
     result = await run_connector_async(
-        MyAsyncConnector("my_ds", StaticAsyncStreamingDataClient(fixtures))
+        MyAsyncConnector("myds", StaticAsyncStreamingDataClient(fixtures))
     )
     result.assert_documents_posted(count=10)

--- a/snippets/unit/snippet-06.py
+++ b/snippets/unit/snippet-06.py
@@ -4,5 +4,5 @@ with mock_glean_client() as client:
     connector.configure_datasource()
     connector.index_data(mode=IndexingMode.INCREMENTAL)
 
-    client.assert_datasource_configured(name="my_ds")
+    client.assert_datasource_configured(name="myds")
     client.assert_documents_posted(count=2)

--- a/snippets/uploader/snippet-01.py
+++ b/snippets/uploader/snippet-01.py
@@ -1,4 +1,4 @@
 from glean.indexing.push import PushUploader
 
-uploader = PushUploader(datasource="company_wiki")
+uploader = PushUploader(datasource="companywiki")
 uploader.bulk_index_documents(documents)

--- a/snippets/uploader/snippet-08.py
+++ b/snippets/uploader/snippet-08.py
@@ -1,1 +1,1 @@
-uploader = PushUploader(datasource="company_wiki", upload_max_workers=10)
+uploader = PushUploader(datasource="companywiki", upload_max_workers=10)


### PR DESCRIPTION
## Summary

- document prerequisites and the boundary between glean-idx and provider tooling
- cover AWS and GCP configuration, planning, apply, immediate runs, status, logs, and cleanup
- clarify customer-owned resources and settings fixed when deployment artifacts are generated
- correct and synchronize Indexing SDK quickstart, testing, uploader, permissions, and observability snippets

## Validation

- rebased onto current main
- markdown snippets are synchronized
- site and theme TypeScript checks pass
- repository-wide snippet TypeScript checks pass
- production Docusaurus build passes
- git diff --check passes

Depends on gleanwork/glean-indexing-sdk#201.